### PR TITLE
This fixes a minor warning in ccl_example_run

### DIFF
--- a/tests/ccl_sample_run.c
+++ b/tests/ccl_sample_run.c
@@ -149,3 +149,4 @@ int main(int argc,char **argv){
 
 	return 0;
 }
+


### PR DESCRIPTION
This is an absurdly small fix that adds an empty line to the example file so that it gives no warnings upon compilation.