### PR TITLE
Fix Python Parameters() constructor to handle new norm_pk variable

### DIFF
--- a/pyccl/ccl_core.i
+++ b/pyccl/ccl_core.i
@@ -13,3 +13,24 @@
 
 %include "../include/ccl_core.h"
 
+// Enable vectorised arguments for arrays
+%apply (double* IN_ARRAY1, int DIM1) {
+            (double* zarr, int nz),
+            (double* dfarr, int nf)
+};
+
+%inline %{
+ccl_parameters parameters_create_vec(
+                        double Omega_c, double Omega_b, double Omega_k, 
+                        double Omega_n, double w0, double wa, double h, 
+                        double norm_pk, double n_s, 
+                        double* zarr, int nz,
+                        double* dfarr, int nf)
+{
+    assert(nz == nf);
+    if (nz == 0){ nz = -1; }
+    return ccl_parameters_create(Omega_c, Omega_b, Omega_k, Omega_n, 
+                                 w0, wa, h, norm_pk, n_s, 
+                                 nz, zarr, dfarr);
+}
+%}

--- a/pyccl/power.py
+++ b/pyccl/power.py
@@ -4,11 +4,11 @@ from pyutils import _vectorize_fn, _vectorize_fn2
 
 def linear_matter_power(cosmo, a, k):
     return _vectorize_fn2(lib.linear_matter_power, 
-                          lib.linear_matter_power_vec, cosmo, a, k)
+                          lib.linear_matter_power_vec, cosmo, k, a)
 
 def nonlin_matter_power(cosmo, a, k):
     return _vectorize_fn2(lib.nonlin_matter_power, 
-                          lib.nonlin_matter_power_vec, cosmo, a, k)
+                          lib.nonlin_matter_power_vec, cosmo, k, a)
 
 def sigmaR(cosmo, R):
     return _vectorize_fn(lib.sigmaR, 


### PR DESCRIPTION
 * Update Parameters() constructor to handle changes in C API
 * Sanity checks on whether A_s or sigma8 was specified in constructor
 * Fix bug when MG growth arrays are specified
 * Fix transposition bug in Python power spectrum fns