### PR TITLE
Fix ccl_sample_run to call linear PS if desired

### DIFF
--- a/src/ccl_power.c
+++ b/src/ccl_power.c
@@ -672,7 +672,7 @@ TASK: compute the nonlinear power spectrum at a given redshift
 double ccl_nonlin_matter_power(ccl_cosmology * cosmo, double a, double k){
 
   //If the matter PS specified was linear, then do the linear compuation
-  if(cosmo->config.matter_power_spectrum_method==0){
+  if(cosmo->config.matter_power_spectrum_method==ccl_linear){
     
     return ccl_linear_matter_power(cosmo,a,k);
   


### PR DESCRIPTION
We have fixed the ccl_sample_run file which was segfaulting for the linear PS case. The fix involves changes in ccl_power that have to do with:
1) not allocating/calculating the nonlinear power if it isn't needed - which also saves time,
2) using the linear PS for the Cls if specified, even if they call the ccl_nonlin_matter_power routine.