### PR TITLE
Update use of class to calculate linear power

### DIFF
--- a/src/ccl_power.c
+++ b/src/ccl_power.c
@@ -393,11 +393,12 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
     double Z, ic;
     int s;
     for (int i=0; i<nk; i++){
-      s =spectra_pk_at_k_and_z(&ba, &pm, &sp,x[i],0.0, &Z,&ic);
-      y[i] = log(Z);
+      //s =spectra_pk_at_k_and_z(&ba, &pm, &sp,x[i],0.0, &Z,&ic);
+      //y[i] = log(Z);
       x[i] = log(x[i]);
     }
 
+    /***
     gsl_spline * log_power_lin = gsl_spline_alloc(K_SPLINE_TYPE, nk);
     int classstatus = gsl_spline_init(log_power_lin, x, y, nk);
     if (classstatus){
@@ -409,6 +410,7 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
     }
     //else
       //cosmo->data.p_lin = log_power_lin;
+    **/
 
     if(cosmo->config.matter_power_spectrum_method==ccl_halofit){
       double * y2d = malloc(nk * na * sizeof(double));


### PR DESCRIPTION
This is work in progress on #125 and #79, starting from PR #124 (so merge that first).

The main change is to replace calls to `spectra_pk_at_k_and_z()` for each k with a single call to `spectra_pk_at_z()`.  The original code was not a bottleneck (with our current hardcoded `K_MAX_SPLINE=500/Mpc`), so this change is mostly aesthetic to clean up the code but should also help with #79.

This is not ready to merge, but feel free to comment or ask questions about the changes so far.