### PR TITLE
Change error handling behaviour to protect Python wrapper from fatal errors

### DIFF
--- a/include/ccl_core.h
+++ b/include/ccl_core.h
@@ -10,6 +10,11 @@
 #define EXPAND_STR(s) STRING(s)
 #define STRING(s) #s
 
+// Global error state (not thread safe) and switch for whether errors are fatal
+extern int global_error_state;
+extern int global_error_continue;
+extern char global_error_message[512];
+
 typedef struct ccl_parameters {
   // Densities: CDM, baryons, total matter, neutrinos, curvature
   double Omega_c;

--- a/include/ccl_error.h
+++ b/include/ccl_error.h
@@ -13,4 +13,13 @@
 #define CCL_ERROR_MF 10
 #define CCL_ERROR_HMF_INTERP 11
 #define CCL_ERROR_PARAMETERS 12
+#define CCL_ERROR_UNKNOWN 99
+
 void ccl_check_status(ccl_cosmology *cosmo, int* status);
+
+int check_exception(void);
+void clear_exception(void);
+void throw_exception(int err, char* msg);
+
+char* get_error_message(void);
+void set_continue_on_error(void);

--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -11,6 +11,12 @@
 #include "ccl_params.h"
 #include <stdlib.h>
 
+// Initialise flag containing global error state, and switch for whether errors 
+// are fatal (needed for Python exception handling)
+int global_error_state = 0;
+int global_error_continue = 0;
+char global_error_message[512];
+
 const ccl_configuration default_config = {ccl_boltzmann_class, ccl_halofit, ccl_tinker10};
 
 /* ------- ROUTINE: ccl_cosmology_read_config ------
@@ -46,7 +52,7 @@ void ccl_cosmology_read_config(){
   
   if ((fconfig=fopen(param_file, "r")) == NULL) {
     fprintf(stderr, "ccl_core.c: Failed to open config file %s\n", param_file);
-    exit(EXIT_FAILURE);
+    throw_exception(EXIT_FAILURE, "ccl_core.c: Failed to open config file");
   } 
 
   while(! feof(fconfig)) {

--- a/src/ccl_error.c
+++ b/src/ccl_error.c
@@ -3,29 +3,61 @@
 #include "math.h"
 #include "stdio.h"
 #include "stdlib.h"
+#include "string.h"
 
-// RH 
+
+void clear_exception(){
+    // Clear the global error state
+	global_error_state = 0;
+}
+
+void throw_exception(int err, char* msg){
+    // Set global error state to the errorcode of this exception
+    global_error_state = err;
+    
+    // Copy error message
+    strncpy(global_error_message, msg, 512);
+    
+    // Exit if fatal errors are enabled
+    if ((!global_error_continue) && (err)){
+        fprintf(stderr, "%s\n", global_error_message);
+        exit(err);
+    }
+}
+
+int check_exception(){
+    // Check the global error state for an error code
+	return global_error_state;
+}
+
+char* get_error_message(void){
+    // Return the global error message
+    return &global_error_message;
+}
+
+void set_continue_on_error(){
+    // Set global error continue flag
+    global_error_continue = 1;
+}
+
+
 void ccl_check_status(ccl_cosmology *cosmo, int * status){
 	switch (*status){
 		case 0: //all good, nothing to do
 			return;
-		case CCL_ERROR_LINSPACE:	// spacing allocation error, always terminate		
-			fprintf(stderr,"%s",cosmo->status_message);
-			exit(1);	
+		/*
+		case CCL_ERROR_LINSPACE:// spacing allocation error, always terminate		
+			throw_exception(CCL_ERROR_LINSPACE, cosmo->status_message);
 		case CCL_ERROR_SPLINE:	// spline allocation error, always terminate	
-			fprintf(stderr,"%s",cosmo->status_message);
-			exit(1);
-		case CCL_ERROR_COMPUTECHI:	// compute_chi error //RH
-			fprintf(stderr,"%s",cosmo->status_message);
-			exit(1);
-                case CCL_ERROR_HMF_INTERP: // terminate if hmf definition not supported
-                        fprintf(stderr,"%s",cosmo->status_message);
-                        exit(1);
-
+			throw_exception(CCL_ERROR_SPLINE, cosmo->status_message);
+		case CCL_ERROR_COMPUTECHI:	// compute_chi error
+			throw_exception(CCL_ERROR_COMPUTECHI, cosmo->status_message);
+        case CCL_ERROR_HMF_INTERP: // terminate if hmf definition not supported
+            throw_exception(CCL_ERROR_HMF_INTERP, cosmo->status_message);
+        */
 		// implement softer error handling, e.g. for integral convergence here
 			
-		default:		
-			fprintf(stderr,"%s",cosmo->status_message);
-			exit(1);
+		default:
+			throw_exception(*status, cosmo->status_message);
 	}
 }

--- a/src/ccl_massfunc.c
+++ b/src/ccl_massfunc.c
@@ -195,12 +195,14 @@ static double massfunc_f(ccl_cosmology *cosmo, double halomass, double a, double
 
     if (odelta < 200){
       *status = CCL_ERROR_HMF_INTERP;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_massfunc_f(): Tinker 2008 only supported in range of Delta = 200 to Delta = 3200.\n");
+      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_massfunc_f(): Tinker 2008 only supported in range of Delta = 200 to Delta = 3200.");
+      throw_exception(CCL_ERROR_HMF_INTERP, cosmo->status_message);
       return 0;
     }
     if (odelta > 3200){
-      * status = CCL_ERROR_HMF_INTERP;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_massfunc_f(): Tinker 2008 only supported in range of Delta = 200 to Delta = 3200.\n");
+      *status = CCL_ERROR_HMF_INTERP;
+      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_massfunc_f(): Tinker 2008 only supported in range of Delta = 200 to Delta = 3200.");
+      throw_exception(CCL_ERROR_HMF_INTERP, cosmo->status_message);
       return 0;
     }
 


### PR DESCRIPTION
The Python interpreter should not be made to quit under any circumstances.

 * Implement basic C "exception handling" pattern using global variables (may
   be an issue for thread safety)
 * Add new exception handling functions in ccl_error.c
 * Add exception handling logic to SWIG wrapper (ccl.i)
 * Add switch to turn exit() calls off when run through Python (see ccl.i)
 * Use new throw_exception() function instead of exit()