### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ ENV GSL_DL="http://ftp.wayne.edu/gnu/gsl/$GSL_TAR"
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-ENV GITUSER=GITUSERNAMEHERE
-ENV GITPASS=GITPASSWORDHERE
-
 WORKDIR /gnu
 
 RUN wget -q $GSL_DL \
@@ -24,7 +21,7 @@ RUN wget -q $GSL_DL \
     && make install
 
 RUN cd /home \
-    && git clone https://$GITUSER:$GITPASS@github.com/LSSTDESC/CCL.git \
+    && git clone https://github.com/LSSTDESC/CCL.git \
     && cd /home/CCL \
     && ./configure \
     && make \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,38 +3,36 @@ LABEL maintainer "asv13@pitt.edu"
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y git make g++ gcc wget swig libtool autoconf
-RUN pip install numpy ipython[all]
+RUN pip install numpy ipython[all] scipy matplotlib
 
 ENV GSL_TAR="gsl-2.3.tar.gz"
 ENV GSL_DL="http://ftp.wayne.edu/gnu/gsl/$GSL_TAR"
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-ENV GITUSER=YOURGITUSERNAME
-ENV GITPASS=YOURGITPASSWORD
+ENV GITUSER=GITUSERNAMEHERE
+ENV GITPASS=GITPASSWORDHERE
 
 WORKDIR /gnu
 
 RUN wget -q $GSL_DL \
     && tar zxvf $GSL_TAR \
-    && rm -f $GSL_TAR
-
-WORKDIR /gnu/gsl-2.3
-
-RUN ./configure \
+    && rm -f $GSL_TAR \
+    && cd /gnu/gsl-2.3 \
+    && ./configure \
     && make -j 4 \
     && make install
 
-WORKDIR /home
-RUN git clone https://$GITUSER:$GITPASS@github.com/LSSTDESC/CCL.git
-
-WORKDIR /home/CCL
-
-RUN ./configure \ 
+RUN cd /home \
+    && git clone https://$GITUSER:$GITPASS@github.com/LSSTDESC/CCL.git \
+    && cd /home/CCL \
+    && ./configure \
     && make \
     && make install \
     && autoreconf -i \
     && python setup.py install \
     && python setup.py install
+
+WORKDIR /home/CCL
 
 CMD jupyter notebook --no-browser --allow-root --port=8888 --ip=0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ENV GSL_DL="http://ftp.wayne.edu/gnu/gsl/$GSL_TAR"
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
+ENV GITUSER=YOURGITUSERNAME
+ENV GITPASS=YOURGITPASSWORD
+
 WORKDIR /gnu
 
 RUN wget -q $GSL_DL \
@@ -22,7 +25,7 @@ RUN ./configure \
     && make install
 
 WORKDIR /home
-RUN git clone https://<GITUSERHERE>:<GITPASSHERE>@github.com/LSSTDESC/CCL.git
+RUN git clone https://$GITUSER:$GITPASS@github.com/LSSTDESC/CCL.git
 
 WORKDIR /home/CCL
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM ubuntu:14.04
+FROM continuumio/anaconda
 LABEL maintainer "asv13@pitt.edu"
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y git make g++ gcc python2.7-dev wget python-pip swig libtool autoconf
-RUN pip install numpy
+RUN apt-get install -y git make g++ gcc wget swig libtool autoconf
 
 ENV GSL_TAR="gsl-2.3.tar.gz"
 ENV GSL_DL="http://ftp.wayne.edu/gnu/gsl/$GSL_TAR"
+
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
 WORKDIR /gnu
@@ -30,6 +30,7 @@ RUN ./configure \
     && make \
     && make install \
     && autoreconf -i \
+    && python setup.py install \
     && python setup.py install
 
-CMD echo Welcome to CCL-Docker. Please enter this container using a command such as: 'docker run -it ccl bash'! This image is not secure and should not be shared under any circumstances.
+CMD jupyter notebook --no-browser --port=8888 --ip=0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM continuumio/anaconda
+FROM python:2.7
 LABEL maintainer "asv13@pitt.edu"
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y git make g++ gcc wget swig libtool autoconf
+RUN pip install numpy ipython[all]
 
 ENV GSL_TAR="gsl-2.3.tar.gz"
 ENV GSL_DL="http://ftp.wayne.edu/gnu/gsl/$GSL_TAR"
@@ -36,4 +37,4 @@ RUN ./configure \
     && python setup.py install \
     && python setup.py install
 
-CMD jupyter notebook --no-browser --port=8888 --ip=0.0.0.0
+CMD jupyter notebook --no-browser --allow-root --port=8888 --ip=0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN pip install numpy ipython[all] scipy matplotlib
 
 ENV GSL_TAR="gsl-2.3.tar.gz"
 ENV GSL_DL="http://ftp.wayne.edu/gnu/gsl/$GSL_TAR"
+ENV FFTW_TAR="fftw-3.3.6-pl2.tar.gz"
+ENV FFTW_DL="http://www.fftw.org/$FFTW_TAR"
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
@@ -20,6 +22,16 @@ RUN wget -q $GSL_DL \
     && make -j 4 \
     && make install
 
+WORKDIR /fftw
+
+RUN wget -q $FFTW_DL \
+    && tar zxvf $FFTW_TAR \
+    && rm -f $FFTW_TAR \
+    && cd /fftw/fftw-3.3.6-pl2 \
+    && ./configure --enable-shared \
+    && make \
+    && make install
+
 RUN cd /home \
     && git clone https://github.com/LSSTDESC/CCL.git \
     && cd /home/CCL \
@@ -27,8 +39,7 @@ RUN cd /home \
     && make \
     && make install \
     && autoreconf -i \
-    && python setup.py install \
-    && python setup.py install
+    && python setup.py install 
 
 WORKDIR /home/CCL
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:14.04
+LABEL maintainer "asv13@pitt.edu"
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y git make g++ gcc python2.7-dev wget python-pip swig libtool autoconf
+RUN pip install numpy
+
+ENV GSL_TAR="gsl-2.3.tar.gz"
+ENV GSL_DL="http://ftp.wayne.edu/gnu/gsl/$GSL_TAR"
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+WORKDIR /gnu
+
+RUN wget -q $GSL_DL \
+    && tar zxvf $GSL_TAR \
+    && rm -f $GSL_TAR
+
+WORKDIR /gnu/gsl-2.3
+
+RUN ./configure \
+    && make -j 4 \
+    && make install
+
+WORKDIR /home
+RUN git clone https://<GITUSERHERE>:<GITPASSHERE>@github.com/LSSTDESC/CCL.git
+
+WORKDIR /home/CCL
+
+RUN ./configure \ 
+    && make \
+    && make install \
+    && autoreconf -i \
+    && python setup.py install
+
+CMD echo Welcome to CCL-Docker. Please enter this container using a command such as: 'docker run -it ccl bash'! This image is not secure and should not be shared under any circumstances.

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ You can quickly check whether *pyccl* has been installed correctly by running `p
 The Dockerfile to generate a Docker image is included in the CCL repository as Dockerfile. This can be used to create an image that Docker can spool up as a virtual machine, allowing you to utilize CCL on any infrastructure with minimal hassle. The details of Docker and the installation process can be found at [https://www.docker.com/](https://www.docker.com/). Once Docker is installed, it is a simple process to create an image!
 1. Enter the Dockerfile with the editor of your choice. Replace <GITUSERHERE> and <GITPASSHERE> with your Git information. This is a temporary measure that will be removed upon public release of the repository. **DO NOT SHARE THE RESULTING IMAGE WITH ANYONE.**
 2. In a terminal of your choosing (with Docker running), type the command `docker build -t ccl .` in the CCL directory.
-3. To spool up a docker container, we recommend entering in interactive mode with bash. This can be done with `docker run -rm -it ccl bash`. This command will remove the container once it is closed and enter this Docker container in bash.
 
-This Dockerfile currently contains all installed C libraries and the Python wrapper. It currently uses Python2.7-dev and does not yet support ipython or Jupyter notebooks. This all runs on a virtual Ubuntu machine and should exhibit minimal slowdown.
+The resulting Docker image has two primary functionalities. The first is a CMD that will open Jupyter notebook tied to a port on your local machine. This can be used with the following run command: `docker run -p 8888:8888 ccl`. You can then access the notebook in the browser of your choice at `localhost:8888`. The second is to access the bash itself, which can be done using `docker run -it ccl bash.`
+
+This Dockerfile currently contains all installed C libraries and the Python wrapper. It currently uses continuumio/anaconda as the base image and supports ipython and Jupyter notebook. There should be minimal slowdown due to the virtualization.
 
 **AGAIN DO NOT SHARE THIS IMAGE UNDER ANY CIRCUMSTANCES.** Images will be safe upon public release.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ and then run one of the `setup.py install` commands listed above. (Note: As an a
 You can quickly check whether *pyccl* has been installed correctly by running `python -c "import pyccl"` and checking that no errors are returned. For a more in-depth test to make sure everything is working, change to the `tests/` sub-directory and run `python run_tests.py`. These tests will take a few minutes.
 
 
+## Docker image installation
+**NOTE THAT AT THIS TIME DOCKER IMAGES ARE NOT SECURE AND SHOULD NOT BE SHARED UNDER ANY CIRCUMSTANCES. EACH INDIVIDUAL SHOULD GENERATE THEIR OWN DOCKER IMAGES AND NEVER SHARE THEM.** This will be changed at Public Release.
+
+The Dockerfile to generate a Docker image is included in the CCL repository as Dockerfile. This can be used to create an image that Docker can spool up as a virtual machine, allowing you to utilize CCL on any infrastructure with minimal hassle. The details of Docker and the installation process can be found at [https://www.docker.com/](https://www.docker.com/). Once Docker is installed, it is a simple process to create an image!
+1. Enter the Dockerfile with the editor of your choice. Replace <GITUSERHERE> and <GITPASSHERE> with your Git information. This is a temporary measure that will be removed upon public release of the repository. **DO NOT SHARE THE RESULTING IMAGE WITH ANYONE.**
+2. In a terminal of your choosing (with Docker running), type the command `docker build -t ccl .` in the CCL directory.
+3. To spool up a docker container, we recommend entering in interactive mode with bash. This can be done with `docker run -rm -it ccl bash`. This command will remove the container once it is closed and enter this Docker container in bash.
+
+This Dockerfile currently contains all installed C libraries and the Python wrapper. It currently uses Python2.7-dev and does not yet support ipython or Jupyter notebooks. This all runs on a virtual Ubuntu machine and should exhibit minimal slowdown.
+
+**AGAIN DO NOT SHARE THIS IMAGE UNDER ANY CIRCUMSTANCES.** Images will be safe upon public release.
+
 # Documentation
 
 This document contains basic information about used structures and functions. At the end of document is provided code which implements these basic functions (also in *tests/ccl_sample_run.c*). More information about CCL functions and implementation can be found in *doc/0000-ccl_note/0000-ccl_note.pdf*.

--- a/README.md
+++ b/README.md
@@ -73,17 +73,13 @@ You can quickly check whether *pyccl* has been installed correctly by running `p
 
 
 ## Docker image installation
-**NOTE THAT AT THIS TIME DOCKER IMAGES ARE NOT SECURE AND SHOULD NOT BE SHARED UNDER ANY CIRCUMSTANCES. EACH INDIVIDUAL SHOULD GENERATE THEIR OWN DOCKER IMAGES AND NEVER SHARE THEM.** This will be changed at Public Release.
 
-The Dockerfile to generate a Docker image is included in the CCL repository as Dockerfile. This can be used to create an image that Docker can spool up as a virtual machine, allowing you to utilize CCL on any infrastructure with minimal hassle. The details of Docker and the installation process can be found at [https://www.docker.com/](https://www.docker.com/). Once Docker is installed, it is a simple process to create an image!
-1. Enter the Dockerfile with the editor of your choice. Replace YOURGITUSERNAME and YOURGITPASSWORD with your Git information. This is a temporary measure that will be removed upon public release of the repository. **DO NOT SHARE THE RESULTING IMAGE WITH ANYONE.**
-2. In a terminal of your choosing (with Docker running), type the command `docker build -t ccl .` in the CCL directory.
+The Dockerfile to generate a Docker image is included in the CCL repository as Dockerfile. This can be used to create an image that Docker can spool up as a virtual machine, allowing you to utilize CCL on any infrastructure with minimal hassle. The details of Docker and the installation process can be found at [https://www.docker.com/](https://www.docker.com/). Once Docker is installed, it is a simple process to create an image! In a terminal of your choosing (with Docker running), type the command `docker build -t ccl .` in the CCL directory.
 
 The resulting Docker image has two primary functionalities. The first is a CMD that will open Jupyter notebook tied to a port on your local machine. This can be used with the following run command: `docker run -p 8888:8888 ccl`. You can then access the notebook in the browser of your choice at `localhost:8888`. The second is to access the bash itself, which can be done using `docker run -it ccl bash`.
 
 This Dockerfile currently contains all installed C libraries and the Python wrapper. It currently uses continuumio/anaconda as the base image and supports ipython and Jupyter notebook. There should be minimal slowdown due to the virtualization.
 
-**AGAIN DO NOT SHARE THIS IMAGE UNDER ANY CIRCUMSTANCES.** Images will be safe upon public release.
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ You can quickly check whether *pyccl* has been installed correctly by running `p
 **NOTE THAT AT THIS TIME DOCKER IMAGES ARE NOT SECURE AND SHOULD NOT BE SHARED UNDER ANY CIRCUMSTANCES. EACH INDIVIDUAL SHOULD GENERATE THEIR OWN DOCKER IMAGES AND NEVER SHARE THEM.** This will be changed at Public Release.
 
 The Dockerfile to generate a Docker image is included in the CCL repository as Dockerfile. This can be used to create an image that Docker can spool up as a virtual machine, allowing you to utilize CCL on any infrastructure with minimal hassle. The details of Docker and the installation process can be found at [https://www.docker.com/](https://www.docker.com/). Once Docker is installed, it is a simple process to create an image!
-1. Enter the Dockerfile with the editor of your choice. Replace <GITUSERHERE> and <GITPASSHERE> with your Git information. This is a temporary measure that will be removed upon public release of the repository. **DO NOT SHARE THE RESULTING IMAGE WITH ANYONE.**
+1. Enter the Dockerfile with the editor of your choice. Replace YOURGITUSERNAME and YOURGITPASSWORD with your Git information. This is a temporary measure that will be removed upon public release of the repository. **DO NOT SHARE THE RESULTING IMAGE WITH ANYONE.**
 2. In a terminal of your choosing (with Docker running), type the command `docker build -t ccl .` in the CCL directory.
 
-The resulting Docker image has two primary functionalities. The first is a CMD that will open Jupyter notebook tied to a port on your local machine. This can be used with the following run command: `docker run -p 8888:8888 ccl`. You can then access the notebook in the browser of your choice at `localhost:8888`. The second is to access the bash itself, which can be done using `docker run -it ccl bash.`
+The resulting Docker image has two primary functionalities. The first is a CMD that will open Jupyter notebook tied to a port on your local machine. This can be used with the following run command: `docker run -p 8888:8888 ccl`. You can then access the notebook in the browser of your choice at `localhost:8888`. The second is to access the bash itself, which can be done using `docker run -it ccl bash`.
 
 This Dockerfile currently contains all installed C libraries and the Python wrapper. It currently uses continuumio/anaconda as the base image and supports ipython and Jupyter notebook. There should be minimal slowdown due to the virtualization.
 


### PR DESCRIPTION
This PR adds a Dockerfile to CCL and gives instructions on how to utilize it to generate an image. This will require an update at public release to make the image more secure and potentially able to be automatically updated with a repository like Docker Hub.

For now, there is just copious warnings about not sharing the resulting images, but this should still allow people to run CCL on any infrastructure imaginable. I just ran CCL on my Windows box!