### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -30,6 +30,7 @@ void ccl_cosmology_read_config(){
   FILE *fconfig;
   char buf[CONFIG_LINE_BUFFER_SIZE];
   char var_name[MAX_CONFIG_VAR_LEN];
+  char* rtn;
   double var_dbl;
   
   ccl_splines = malloc(sizeof(ccl_spline_params));
@@ -50,7 +51,7 @@ void ccl_cosmology_read_config(){
   } 
 
   while(! feof(fconfig)) {
-  fgets(buf, CONFIG_LINE_BUFFER_SIZE, fconfig);
+  rtn = fgets(buf, CONFIG_LINE_BUFFER_SIZE, fconfig);
   if (buf[0]==';' || buf[0]=='[' || buf[0]=='\n') {
     continue;
   } else {

--- a/tests/ccl_test_bbks.c
+++ b/tests/ccl_test_bbks.c
@@ -57,6 +57,7 @@ static void compare_bbks(int i_model,struct bbks_data * data)
 {
   int nk,i,j;
   char fname[256],str[1024];
+  char* rtn;
   FILE *f;
   ccl_configuration config = default_config;
   config.transfer_function_method = ccl_bbks;
@@ -77,7 +78,7 @@ static void compare_bbks(int i_model,struct bbks_data * data)
   }
   nk=linecount(f)-1; rewind(f);
   
-  fgets(str, 1024, f);
+  rtn = fgets(str, 1024, f);
   for(i=0;i<nk;i++) {
     double k_h,k;
     int stat;

--- a/tests/ccl_test_cls.c
+++ b/tests/ccl_test_cls.c
@@ -78,6 +78,8 @@ static void compare_cls(char *compare_type,struct cls_data * data)
   }
   else {
     char str[1024];
+    char* rtn;
+    int stat;
     FILE *fnz1=fopen("./tests/benchmark/codecomp_step2_outputs/bin1_histo.txt","r");
     ASSERT_NOT_NULL(fnz1);
     FILE *fnz2=fopen("./tests/benchmark/codecomp_step2_outputs/bin2_histo.txt","r");
@@ -88,12 +90,12 @@ static void compare_cls(char *compare_type,struct cls_data * data)
     zarr_2=malloc(nz*sizeof(double));
     pzarr_2=malloc(nz*sizeof(double));
     bzarr=malloc(nz*sizeof(double));
-    fgets(str,1024,fnz1);
-    fgets(str,1024,fnz2);
+    rtn = fgets(str,1024,fnz1);
+    rtn = fgets(str,1024,fnz2);
     for(int ii=0;ii<nz;ii++) {
       double z1,z2,nz1,nz2;
-      fscanf(fnz1,"%lf %lf",&z1,&nz1);
-      fscanf(fnz2,"%lf %lf",&z2,&nz2);
+      stat = fscanf(fnz1,"%lf %lf",&z1,&nz1);
+      stat = fscanf(fnz2,"%lf %lf",&z2,&nz2);
       zarr_1[ii]=z1; zarr_2[ii]=z2;
       pzarr_1[ii]=nz1; pzarr_2[ii]=nz2;
       bzarr[ii]=1.;
@@ -123,17 +125,18 @@ static void compare_cls(char *compare_type,struct cls_data * data)
   fi_ll_22=fopen(fname,"r"); ASSERT_NOT_NULL(fi_ll_22);
   double fraction_failed=0;
   for(int ii=0;ii<3001;ii++) {
-    int l;
+    int l, rtn;
     double cl_dd_11,cl_dd_12,cl_dd_22;
     double cl_ll_11,cl_ll_12,cl_ll_22;
     double cl_dd_11_h,cl_dd_12_h,cl_dd_22_h;
     double cl_ll_11_h,cl_ll_12_h,cl_ll_22_h;
-    fscanf(fi_dd_11,"%d %lf",&l,&cl_dd_11);
-    fscanf(fi_dd_12,"%d %lf",&l,&cl_dd_12);
-    fscanf(fi_dd_22,"%d %lf",&l,&cl_dd_22);
-    fscanf(fi_ll_11,"%d %lf",&l,&cl_ll_11);
-    fscanf(fi_ll_12,"%d %lf",&l,&cl_ll_12);
-    fscanf(fi_ll_22,"%d %lf",&l,&cl_ll_22);
+    
+    rtn = fscanf(fi_dd_11,"%d %lf",&l,&cl_dd_11);
+    rtn = fscanf(fi_dd_12,"%d %lf",&l,&cl_dd_12);
+    rtn = fscanf(fi_dd_22,"%d %lf",&l,&cl_dd_22);
+    rtn = fscanf(fi_ll_11,"%d %lf",&l,&cl_ll_11);
+    rtn = fscanf(fi_ll_12,"%d %lf",&l,&cl_ll_12);
+    rtn = fscanf(fi_ll_22,"%d %lf",&l,&cl_ll_22);
     cl_dd_11_h=ccl_angular_cl(cosmo,l,tr_nc_1,tr_nc_1,&status);
     if (status) printf("%s\n",cosmo->status_message);
     cl_dd_12_h=ccl_angular_cl(cosmo,l,tr_nc_1,tr_nc_2,&status);

--- a/tests/ccl_test_eh.c
+++ b/tests/ccl_test_eh.c
@@ -56,6 +56,7 @@ static void compare_eh(int i_model,struct eh_data * data)
 {
   int nk,i,j;
   char fname[256],str[1024];
+  char* rtn;
   FILE *f;
   ccl_configuration config = default_config;
   config.transfer_function_method = ccl_eisenstein_hu;
@@ -77,7 +78,7 @@ static void compare_eh(int i_model,struct eh_data * data)
   }
   nk=linecount(f)-1; rewind(f);
   
-  fgets(str, 1024, f);
+  rtn = fgets(str, 1024, f);
   for(i=0;i<nk;i++) {
     double k_h,k;
     int stat;

--- a/tests/ccl_test_growth.c
+++ b/tests/ccl_test_growth.c
@@ -32,7 +32,8 @@ static void read_growth_test_file(double z[6], double gf[5][6])
   
   // Ignore header line
   char str[1024];
-  fgets(str, 1024, f);
+  char* rtn;
+  rtn = fgets(str, 1024, f);
   
     // File is fixed format - five rows and six columns
   for (int i=0; i<6; i++){

--- a/tests/ccl_test_massfunc.c
+++ b/tests/ccl_test_massfunc.c
@@ -36,7 +36,8 @@ static void read_massfunc_test_file(double mass[13], double massfunc[3][13])
 
    // Ignore header line
    char str[1024];
-   fgets(str, 1024, f);
+   char* rtn;
+   rtn = fgets(str, 1024, f);
 
    // file is in fixed format - logmass, sigma, invsigma, and hmf, w/ 13 rows
    for (int i=0; i<13; i++){

--- a/tests/ccl_test_sigmaM.c
+++ b/tests/ccl_test_sigmaM.c
@@ -56,6 +56,7 @@ static void compare_sigmam(int i_model,struct sigmam_data * data)
 {
   int nm,i;
   char fname[256],str[1024];
+  char* rtn;
   FILE *f;
   int status=0;
   ccl_configuration config = default_config;
@@ -76,7 +77,7 @@ static void compare_sigmam(int i_model,struct sigmam_data * data)
   }
   nm=linecount(f)-1; rewind(f);
   
-  fgets(str, 1024, f);
+  rtn = fgets(str, 1024, f);
   for(i=0;i<nm;i++) {
     double m,m_h,sm_bench,sm_h,err;
     int stat;


### PR DESCRIPTION
There are several compile-time warnings caused by unused return values from `stdio` functions like `fgets`. These warnings could be removed by setting a compiler flag, but we probably want to leave that enabled in case it helps to catch more serious issues.

This PR fixes the warnings by collecting the return values into dummy variables. It's very minor.