### PR TITLE
Incorporate configurable constants to pyccl

### DIFF
--- a/pyccl/__init__.py
+++ b/pyccl/__init__.py
@@ -26,3 +26,5 @@ from lsst_specs import bias_clustering, sigmaz_clustering, sigmaz_sources, \
 # Useful constants and unit conversions
 from constants import CLIGHT_HMPC, MPC_TO_METER, PC_TO_METER, \
                       GNEWT, RHO_CRITICAL, SOLAR_MASS
+
+

--- a/pyccl/ccl.i
+++ b/pyccl/ccl.i
@@ -36,6 +36,7 @@
 %include "ccl_massfunc.i"
 %include "ccl_cls.i"
 %include "ccl_constants.i"
+%include "ccl_params.i"
 %include "ccl_lsst_specs.i"
 
 %include "../include/ccl_config.h"

--- a/pyccl/ccl_params.i
+++ b/pyccl/ccl_params.i
@@ -1,0 +1,17 @@
+%module ccl_params
+
+%{
+
+#define SWIG_FILE_WITH_INIT
+#include "../include/ccl_params.h"
+
+%}
+
+// Automatically document arguments and output types of all functions
+%feature("autodoc", "1");
+
+// Strip the ccl_ prefix from function names
+//%rename("%(strip:[ccl_])s") "";
+
+%include "../include/ccl_params.h"
+


### PR DESCRIPTION
This fixes issue #173. Python tests run and I am able to call CCL from python. 