### PR TITLE
Fix missing call to error.h in ccl_core

### DIFF
--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -12,6 +12,7 @@
 #include "gsl/gsl_integration.h"
 #include "ccl_params.h"
 #include <stdlib.h>
+#include "ccl_error.h"
 
 const ccl_configuration default_config = {ccl_boltzmann_class, ccl_halofit, ccl_tinker10};
 


### PR DESCRIPTION
ccl_error.h was missing from ccl_core.c, preventing the "error_nocosmo" function from being called and generating a warning upon compilation.