### PR TITLE
Changed all default Neff values to 3.046 in c library

### DIFF
--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -338,7 +338,7 @@ ccl_parameters ccl_parameters_create_flat_lcdm(double Omega_c, double Omega_b, d
 {
   double Omega_k = 0.0;
   double N_nu_mass = 0.0;
-  double N_nu_rel = 0.0;
+  double N_nu_rel = 3.046;
   double mnu = 0.0;
   double w0 = -1.0;
   double wa = 0.0;
@@ -372,7 +372,7 @@ TASK: call ccl_parameters_create for this specific model
 ccl_parameters ccl_parameters_create_lcdm(double Omega_c, double Omega_b, double Omega_k, double h, double norm_pk, double n_s, int *status)
 {
   double N_nu_mass = 0.0;
-  double N_nu_rel = 0.0;
+  double N_nu_rel = 3.046;
   double mnu = 0.0;
   double w0 = -1.0;
   double wa = 0.0;
@@ -409,7 +409,7 @@ ccl_parameters ccl_parameters_create_flat_wcdm(double Omega_c, double Omega_b, d
 
   double Omega_k = 0.0;
   double N_nu_mass = 0.0;
-  double N_nu_rel = 0.0;
+  double N_nu_rel = 3.046;
   double mnu = 0.0;
   double wa = 0.0;
   ccl_parameters params = ccl_parameters_create(Omega_c, Omega_b, Omega_k, N_nu_rel, N_nu_mass, mnu, w0, wa, h, norm_pk, n_s,-1,NULL,NULL, status);
@@ -442,7 +442,7 @@ ccl_parameters ccl_parameters_create_flat_wacdm(double Omega_c, double Omega_b, 
 
   double Omega_k = 0.0;
   double N_nu_mass = 0.0;
-  double N_nu_rel = 0.0;
+  double N_nu_rel = 3.046;
   double mnu = 0.0;
   ccl_parameters params = ccl_parameters_create(Omega_c, Omega_b, Omega_k,N_nu_rel, N_nu_mass, mnu, w0, wa, h, norm_pk, n_s,-1,NULL,NULL, status);
   return params;

--- a/tests/ccl_sample_power.c
+++ b/tests/ccl_sample_power.c
@@ -13,8 +13,8 @@ int main(int argc, char * argv[])
   double n_s = 0.96;
 
   ccl_configuration config = default_config;
-  config.transfer_function_method = ccl_bbks;
-  //config.matter_power_spectrum_method=ccl_linear;
+  //config.transfer_function_method = ccl_bbks;
+  config.matter_power_spectrum_method=ccl_linear;
 
   ccl_parameters params = ccl_parameters_create_flat_lcdm(Omega_c, Omega_b, h, normp, n_s, &status);
   ccl_cosmology * cosmo = ccl_cosmology_create(params, config);


### PR DESCRIPTION
This branch addresses issue #193 . The problem was that ccl_sample_power was crashing in master when CLASS was used to compute the matter power spectrum. The reason was that default values of N_eff (N_nu_rel in the code) were set to 0 for some of the parameter constructors (those which were left over from prior to neutrino support). I set these defaults to 3.046 as they are set in the python library anyway. 

Note that if we merge this we will need to make some small changes to the note because I think at the moment the note says that you'll have a default of no massless neturinos (no neutrinos at all) if you use these old parameter constructors.