### PR TITLE
Makes setup.py fail if Python 3.x is being used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,12 @@
 from distutils.core import *
 from distutils import sysconfig
 import os.path
+import sys
+
+# Throw error if Python 3.x is being used
+if sys.version_info.major == 3:
+    print("Python 3.x is not currently supported. Please use Python 2.")
+    sys.exit(1)
 
 # Get numpy include directory (works across versions)
 import numpy


### PR DESCRIPTION
Python 3 is currently not supported by CCL, so the `setup.py` script should fail right away if the user is using 3.x. Otherwise, they will get quite far with the installation before seeing an error message. This PR implements a version check at the start of the `setup.py` script.