### PR TITLE
Add License Terms

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -27,5 +27,51 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-Contact GitHub API Training Shop Blog About
-© 2017 GitHub, Inc. Terms Privacy Security Status Help
+
+
+
+GPLv3 Disclaimer
+As CCL uses GSL and FFTW internally, CCL is dually licensed under GPLv3. You
+can find the GPL one the GNU web site (https://www.gnu.org/licenses/gpl-3.0.html)
+
+Any derivative work which is redistributed that includes GSL and/or FFTW must also 
+be redistributed under the terms of GPLv3. Derivative work which does not
+include those libraries listed under the GPL licenses sections are not subject to
+the terms of GPLv3.
+
+
+
+============================================================================
+   CCL Subcomponents:
+
+   The CCL project contains subcomponents with separate copyright notices 
+   and license terms. Your use of the source code for the these
+   subcomponents is subject to the terms and conditions of the following
+   licenses.
+
+
+========================================================================
+GPL licenses
+========================================================================
+
+The following components are provided under the MIT License. See project 
+link for details. 
+
+    (GPLv3 License) GSL (https://www.gnu.org/software/gsl/)
+    (GPLv2 License) FFTW (http://www.fftw.org/)
+
+License information:
+
+    GPLv2: https://www.gnu.org/licenses/gpl-2.0.html
+    GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
+
+
+========================================================================
+CC licenses
+========================================================================
+
+    (CC0 1.0 License) FFTLog (http://casa.colorado.edu/~ajsh/FFTLog/)
+
+License information:
+
+    CC0: https://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
Add license terms of libraries used by CCL, including GSL, FFTW, and FFTLog. Include a note which disclaims that CCL code is licensed as BSD, but de-facto dually-licensed as GPLv3 due to inclusion of GSL and FFTW.