### PR TITLE
Fix bug in example Python code in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,12 +430,9 @@ Below is a simple example Python script that creates a new **Cosmology** object,
 import pyccl as ccl
 import numpy as np
 
-# Create new Parameters object, containing cosmo parameter values
-p = ccl.Parameters(Omega_c=0.27, Omega_b=0.045, h=0.67, A_s=1e-10, n_s=0.96)
-
-# Create new Cosmology object with these parameters. This keeps track of
-# previously-computed cosmological functions
-cosmo = ccl.Cosmology(p)
+# Create new Cosmology object with a given set of parameters. This keeps track 
+# of previously-computed cosmological functions
+cosmo = ccl.Cosmology(Omega_c=0.27, Omega_b=0.045, h=0.67, A_s=1e-10, n_s=0.96)
 
 # Define a simple binned galaxy number density curve as a function of redshift
 z_n = np.linspace(0., 1., 200)
@@ -443,8 +440,8 @@ n = np.ones(z_n.shape)
 
 # Create objects to represent tracers of the weak lensing signal with this
 # number density (with has_intrinsic_alignment=False)
-lens1 = ccl.ClTracerLensing(cosmo, False, z_n, n)
-lens2 = ccl.ClTracerLensing(cosmo, False, z_n, n)
+lens1 = ccl.ClTracerLensing(cosmo, False, n=(z_n, n))
+lens2 = ccl.ClTracerLensing(cosmo, False, n=(z_n, n))
 
 # Calculate the angular cross-spectrum of the two tracers as a function of ell
 ell = np.arange(2, 10)


### PR DESCRIPTION
The example code in the README file assumes an older version of the Python wrapper, and fails with the current version. This PR fixes the issue.