### PR TITLE
Fix power spectrum units in power.py

### DIFF
--- a/pyccl/power.py
+++ b/pyccl/power.py
@@ -3,7 +3,7 @@ import ccllib as lib
 from pyutils import _vectorize_fn, _vectorize_fn2
 
 def linear_matter_power(cosmo, k, a):
-    """The linear matter power spectrum; Mpc^-3.
+    """The linear matter power spectrum; Mpc^3.
 
     Args:
         cosmo (:obj:`ccl.cosmology`): Cosmological parameters.
@@ -11,14 +11,14 @@ def linear_matter_power(cosmo, k, a):
         a (float): Scale factor.
 
     Returns:
-        linear_matter_power (float or array_like): Linear matter power spectrum; Mpc^-3.
+        linear_matter_power (float or array_like): Linear matter power spectrum; Mpc^3.
 
     """
     return _vectorize_fn2(lib.linear_matter_power, 
                           lib.linear_matter_power_vec, cosmo, k, a)
 
 def nonlin_matter_power(cosmo, k, a):
-    """The nonlinear matter power spectrum; Mpc^-3.
+    """The nonlinear matter power spectrum; Mpc^3.
 
     Args:
         cosmo (:obj:`ccl.cosmology`): Cosmological parameters.
@@ -26,7 +26,7 @@ def nonlin_matter_power(cosmo, k, a):
         a (float): Scale factor.
 
     Returns:
-        nonlin_matter_power (float or array_like): Nonlinear matter power spectrum; Mpc^-3.
+        nonlin_matter_power (float or array_like): Nonlinear matter power spectrum; Mpc^3.
 
     """
     return _vectorize_fn2(lib.nonlin_matter_power, 


### PR DESCRIPTION
Change from Mpc^{-3} to Mpc^3. This relates to issue #245. 