### PR TITLE
fix consistency with default mass function prescription

### DIFF
--- a/pyccl/cls.py
+++ b/pyccl/cls.py
@@ -258,6 +258,7 @@ def angular_cl(cosmo, cltracer1, cltracer2, ell):
 
     """
     # Access ccl_cosmology object
+    cosmo_in = cosmo
     cosmo = _cosmology_obj(cosmo)
 
     # Access CCL_ClTracer objects
@@ -275,5 +276,5 @@ def angular_cl(cosmo, cltracer1, cltracer2, ell):
     else:
         # Use vectorised function
         cl, status = lib.angular_cl_vec(cosmo, clt1, clt2, ell, len(ell), status)
-    check(status)
+    check(status, cosmo_in)
     return cl

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -214,7 +214,7 @@ class Cosmology(object):
                  z_mg=None, df_mg=None, 
                  transfer_function='boltzmann_class',
                  matter_power_spectrum='halofit',
-                 mass_function='tinker'):
+                 mass_function='tinker10'):
         """Creates a wrapper for ccl_cosmology.
 
         TODO: enumerate transfer_function and 

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -147,7 +147,7 @@ class Parameters(object):
                 = lib.parameters_create_vec( Omega_c, Omega_b, Omega_k, N_nu_rel, 
                                              N_nu_mass, m_nu, w0, wa, h, norm_pk, 
                                              n_s, z_mg, df_mg, status )
-        check(status)    
+        check(status)   
     
     def __getitem__(self, key):
         """Access parameter values by name.
@@ -365,7 +365,7 @@ class Cosmology(object):
         """
         status = 0
         status = lib.cosmology_compute_distances(self.cosmo, status)
-        check(status)
+        check(status, self.cosmo)
     
     def compute_growth(self):
         """Interfaces with src/ccl_background.c: ccl_cosmology_compute_growth().
@@ -374,7 +374,7 @@ class Cosmology(object):
         """
         status = 0
         status = lib.cosmology_compute_growth(self.cosmo, status)
-        check(status)
+        check(status, self.cosmo)
     
     def compute_power(self):
         """Interfaces with src/ccl_power.c: ccl_cosmology_compute_power().
@@ -383,7 +383,7 @@ class Cosmology(object):
         """
         status = 0
         status = lib.cosmology_compute_power(self.cosmo, status)
-        check(status)
+        check(status, self.cosmo)
     
     def has_distances(self):
         """Checks if the distances have been precomputed.

--- a/pyccl/correlation.py
+++ b/pyccl/correlation.py
@@ -30,7 +30,7 @@ def correlation(cosmo, ell, C_ell, theta, corr_type='gg', method='fftlog'):
     Returns:
         Value(s) of the correlation function at the input angular separation(s).
     """
-
+    cosmo_in = cosmo
     cosmo = _cosmology_obj(cosmo)
     status = 0
 
@@ -55,6 +55,6 @@ def correlation(cosmo, ell, C_ell, theta, corr_type='gg', method='fftlog'):
                                       correlation_types[corr_type],
                                       correlation_methods[method],
                                       len(theta), status)
-    check(status)
+    check(status, cosmo_in)
     if scalar: return wth[0]
     return wth

--- a/pyccl/pyutils.py
+++ b/pyccl/pyutils.py
@@ -3,7 +3,7 @@ from pyccl import ccllib as lib
 import numpy as np
 import pyccl.core
 
-def check(status):
+def check(status, cosmo=None):
     """Check the status returned by a ccllib function.
 
     Args:
@@ -12,15 +12,20 @@ def check(status):
     """
     # Check for normal status (no action required)
     if status == 0: return
+    
+    # Get status message from Cosmology object, if there is one
+    if cosmo is not None:
+        msg = _cosmology_obj(cosmo).status_message
+    else:
+        msg = ""
 
     # Check for known error status
     if status in pyccl.core.error_types.keys():
-        raise RuntimeError("Error %d: %s" % (status, pyccl.core.error_types[status]))
+        raise RuntimeError("Error %s: %s" % (pyccl.core.error_types[status], msg))
 
     # Check for unknown error
     if status != 0:
-        raise RuntimeError("Error %d: Unnamed error returned by CCL C library." \
-                           % status)
+        raise RuntimeError("Error %d: %s" % (status, msg))
 
 
 def _cosmology_obj(cosmo):
@@ -87,6 +92,7 @@ def _vectorize_fn(fn, fn_vec, cosmo, x, returns_status=True):
 
     """
     # Access ccl_cosmology object
+    cosmo_in = cosmo
     cosmo = _cosmology_obj(cosmo)
     status = 0
 
@@ -110,7 +116,7 @@ def _vectorize_fn(fn, fn_vec, cosmo, x, returns_status=True):
             f = fn_vec(cosmo, x, len(x))
 
     # Check result and return
-    check(status)
+    check(status, cosmo_in)
     return f
 
 
@@ -129,6 +135,7 @@ def _vectorize_fn2(fn, fn_vec, cosmo, x, z, returns_status=True):
 
     """
     # Access ccl_cosmology object
+    cosmo_in = cosmo
     cosmo = _cosmology_obj(cosmo)
     status = 0
     scalar = False
@@ -152,7 +159,7 @@ def _vectorize_fn2(fn, fn_vec, cosmo, x, z, returns_status=True):
             f = fn_vec(cosmo, z, x, len(x))
 
     # Check result and return
-    check(status)
+    check(status, cosmo_in)
     if scalar:
         return f[0]
     else:
@@ -171,7 +178,8 @@ def _vectorize_fn3(fn, fn_vec, cosmo, x, n, returns_status=True):
         returns_stats (bool): Indicates whether fn returns a status.
 
     """
-   # Access ccl_cosmology object
+    # Access ccl_cosmology object
+    cosmo_in = cosmo
     cosmo = _cosmology_obj(cosmo)
     status = 0
     scalar = False
@@ -194,7 +202,7 @@ def _vectorize_fn3(fn, fn_vec, cosmo, x, n, returns_status=True):
             f = fn_vec(cosmo, n, x, len(x))
 
     # Check result and return
-    check(status)
+    check(status, cosmo_in)
     if scalar:
         return f[0]
     else:
@@ -214,7 +222,8 @@ def _vectorize_fn4(fn, fn_vec, cosmo, x, a, d, returns_status=True):
         returns_stats (bool): Indicates whether fn returns a status.
 
     """
-   # Access ccl_cosmology object
+    # Access ccl_cosmology object
+    cosmo_in = cosmo
     cosmo = _cosmology_obj(cosmo)
     status = 0
     scalar = False
@@ -237,7 +246,7 @@ def _vectorize_fn4(fn, fn_vec, cosmo, x, a, d, returns_status=True):
             f = fn_vec(cosmo, a, d, x, len(x))
 
     # Check result and return
-    check(status)
+    check(status, cosmo_in)
     if scalar:
         return f[0]
     else:

--- a/src/ccl_massfunc.c
+++ b/src/ccl_massfunc.c
@@ -323,7 +323,6 @@ static double ccl_halo_b1(ccl_cosmology *cosmo, double halomass, double a, doubl
     
   default:
     *status = CCL_ERROR_MF;
-    cosmo->status = 11;
     sprintf(cosmo->status_message ,
 	    "ccl_massfunc.c: ccl_halo_b1(): No b(M) fitting function implemented for mass_function_method: %d \n",
       cosmo->config.mass_function_method);


### PR DESCRIPTION
Fixes issue #262 - the default mass function prescription is Tinker2008, but the halo bias is only defined for Tinker2010. The error function in this case is not helpful at all, so it'd be nice to change the current error handling system to output the actual error message raised at the C library level (probably in a different PR to avoid mission creep)