### PR TITLE
Add python 3 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
 
 # Travis uses Ubuntu 12.04 and 14.04. None of them have GSL2x in apt-get
 # We have to install it from source (this will make the tests slower)

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ script:
 language: python
 python:
   - "2.7"
-# Take out python3.x until python3 branch is merged
-#  - "3.5"
+  - "3.5"
+
 # Travis uses Ubuntu 12.04 and 14.04. None of them have GSL2x in apt-get
 # We have to install it from source (this will make the tests slower)
 before_install:
@@ -11,7 +11,7 @@ before_install:
   - sudo apt-get install fftw3 fftw3-dev pkg-config
 #  - sudo apt-get install latexmk
   - pip install numpy
-  - ./install-gsl.sh 
+  - ./install-gsl.sh
 #addons:
 #    apt:
 #        packages:
@@ -22,11 +22,11 @@ before_install:
 #            - dvipng
 install: python setup.py install
 script:
-    - python tests/run_tests.py --debug --detailed-errors --verbose --process-restartworker 
+    - python tests/run_tests.py --debug --detailed-errors --verbose --process-restartworker
 
 # Check why the note creation process crashes
 #    - make -C doc/0000-ccl_note
-#after_success: 
+#after_success:
 #    if [[ -n "$GITHUB_API_KEY" ]; then
 #        git checkout --orphan pdf
 #        git rm -rf .


### PR DESCRIPTION
I just noted that travis only covered 2.7, so I quickly added 3.5 and 3.6. Checks out [just fine](https://travis-ci.org/DanielLenz/CCL), no issues.