### PR TITLE
Changed the Stefan-Boltzmann constant to be a derived parameter.

### DIFF
--- a/include/ccl_constants.h
+++ b/include/ccl_constants.h
@@ -69,7 +69,8 @@ extern "C" {
 /**
  * Stefan-Boltzmann constant in units of kg/s^3 / K^4
  */
-#define STBOLTZ GSL_CONST_MKSA_STEFAN_BOLTZMANN_CONSTANT
+//#define STBOLTZ GSL_CONST_MKSA_STEFAN_BOLTZMANN_CONSTANT
+#define STBOLTZ (2*M_PI*M_PI*M_PI*M_PI*M_PI*KBOLTZ*KBOLTZ*KBOLTZ*KBOLTZ)/(15*HPLANCK*HPLANCK*HPLANCK*CLIGHT*CLIGHT)
 
 /**
  * Planck's constant in units kg m^2 / s


### PR DESCRIPTION
As I was writing I noticed that the Stefan-Boltzmann constant was hard-coded into ccl_constants.h.

I turned it into a derived parameter. The relative difference is 3e-12 of its previous value.

I was able to get SWIG running (unlike last time) by adding in `-I/path/to/GSL` and it runs with no errors. However, even after doing this, the C test that tests for updated swig files fails. All other tests pass. I had this issue in the past and @damonge fixed it somehow.