### PR TITLE
Trivial doc change to test readthedocs

### DIFF
--- a/include/ccl_lsst_specs.h
+++ b/include/ccl_lsst_specs.h
@@ -22,7 +22,7 @@ typedef struct {
 
 /**
  * Compute b(a), the bias of the clustering sample of a cosmology at a given scale factor
- * This is input from LSS group.
+ * This is input from the LSS group.
  * @param cosmo Cosmological parameters
  * @param a scale factor, normalized to a=1 today.
  * @param status Status flag. 0 if there are no errors, nonzero otherwise.


### PR DESCRIPTION
This is a one-line change in the docs of ccl_lsst_specs.h. It is a trivial commit to be merged to master so we can check whether readthedocs integration has been successful.