### PR TITLE
Fix issue with `pip` always trying to reinstall `mkauthlist` dependencies

### DIFF
--- a/doc/0000-ccl_note/Makefile
+++ b/doc/0000-ccl_note/Makefile
@@ -78,10 +78,15 @@ tar : main
 	cd ${tardir} && tar -czf ../${outname}.tar.gz . && cd ..
 	rm -rf ${tardir}
 
-authlist :
-	pip install --upgrade mkauthlist
+authlist : mkauthlist-exists
+	#pip install --upgrade mkauthlist
+ifdef MKAUTHLIST
+	$(MKAUTHLIST) -j ${style} -f -c "LSST Dark Energy Science Collaboration" \
+		--cntrb contributions.tex authors.csv authors.tex
+else
 	mkauthlist -j ${style} -f -c "LSST Dark Energy Science Collaboration" \
 		--cntrb contributions.tex authors.csv authors.tex
+endif
 
 # http://stackoverflow.com/q/8028314/
 TARGETS=apj apjl prd prl mnras tex aastex61 emulateapj
@@ -95,6 +100,12 @@ $(TARGETS):
 # with no target compiles PDF out of main.tex using lsstdescnote.cls
 # (which is to say, by default we assume you are writing an LSST
 # DESC Note in latex format).
+
+# Check if mkauthlist exists. Can be overridden with environment variable.
+mkauthlist-exists : 
+ifndef MKAUTHLIST
+	$(if $(shell which mkauthlist),,$(error "mkauthlist not found. Install using 'pip install mkauthlist'"))
+endif
 
 tidy:
 	rm -f *.log *.aux *.out *.dvi *.synctex.gz *.fdb_latexmk *.fls


### PR DESCRIPTION
Myself and other people have been having problems with `mkauthlist` always trying to change the `numpy` version through pip and other annoyances.

This PR:
- Adds test in Makefile to see if `mkauthlist` command exists, instead of just trying to `pip upgrade` it every time we run `make`.
- Allows the user to manually specify the path to the `mkauthlist` command themselves, by setting the `MKAUTHLIST` environment variable.

Example usage:
```sh
$ make
Makefile:107: *** "mkauthlist not found. Install using 'pip install mkauthlist'". Stop.
```

```sh
$ MKAUTHLIST=/home/mariecurie/.local/bin/mkauthlist make
<makefile runs>
```