### PR TITLE
Fix issue 315

### DIFF
--- a/tests/ccl_sample_run.c
+++ b/tests/ccl_sample_run.c
@@ -111,9 +111,9 @@ int main(int argc,char **argv)
   CCL_ClTracer *ct_wl=ccl_cl_tracer_lensing_simple_new(cosmo,NZ,z_arr_sh,nz_arr_sh, &status);
   printf("ell C_ell(c,c) C_ell(c,g) C_ell(c,s) C_ell(g,g) C_ell(g,s) C_ell(s,s) | r(g,s)\n");
   for(int l=2;l<=NL;l*=2) {
-    double cl_cc=ccl_angular_cl(cosmo,l,ct_wl,ct_wl, &status); //CMBLensing-CMBLensing
-    double cl_cg=ccl_angular_cl(cosmo,l,ct_wl,ct_wl, &status); //CMBLensing-CMBLensing
-    double cl_cs=ccl_angular_cl(cosmo,l,ct_wl,ct_wl, &status); //CMBLensing-CMBLensing
+    double cl_cc=ccl_angular_cl(cosmo,l,ct_cl,ct_cl, &status); //CMBLensing-CMBLensing
+    double cl_cg=ccl_angular_cl(cosmo,l,ct_cl,ct_gc, &status); //CMBLensing-Clustering
+    double cl_cs=ccl_angular_cl(cosmo,l,ct_wl,ct_cl, &status); //CMBLensing-Galaxy lensing
     double cl_gg=ccl_angular_cl(cosmo,l,ct_gc,ct_gc, &status); //Galaxy-galaxy
     double cl_gs=ccl_angular_cl(cosmo,l,ct_gc,ct_wl, &status); //Galaxy-lensing
     double cl_ss=ccl_angular_cl(cosmo,l,ct_wl,ct_wl, &status); //Lensing-lensing


### PR DESCRIPTION
This is a small fix to ccl_sample_run.c that solves a bug where we were calling the galaxy lensing tracer instead of the CMB lensing tracer. This refers to issue #315.