### PR TITLE
Struct and helper functions to track multiple parameter structures

### DIFF
--- a/include/ccl_core.h
+++ b/include/ccl_core.h
@@ -122,7 +122,7 @@ typedef struct ccl_data{
 } ccl_data;
 
 /**
- * Sturct containing references to instances of the above structs, and boolean flags of precomputed values.
+ * Struct containing references to instances of the above structs, and boolean flags of precomputed values.
  */
 typedef struct ccl_cosmology
 {

--- a/include/ccl_paramset.h
+++ b/include/ccl_paramset.h
@@ -1,0 +1,31 @@
+/** @file */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#pragma once
+// Max. no. of paramsets allowed in the list
+#define CCL_PARAMSET_LIST_SIZE 30
+
+// Status variables
+#define CCL_PARAMSET_NOT_FOUND 1
+#define CCL_PARAMSET_ALREADY_EXISTS 2
+
+typedef struct ccl_paramset_list {
+    void* paramset[CCL_PARAMSET_LIST_SIZE];
+    int num_sets;
+    char name[CCL_PARAMSET_LIST_SIZE][128];
+} ccl_paramset_list;
+
+
+int ccl_paramset_list_init(ccl_paramset_list* pslist);
+int ccl_has_paramset(ccl_paramset_list* pslist, char* name);
+void* ccl_get_paramset(ccl_paramset_list* pslist, char* name);
+void ccl_add_paramset(ccl_paramset_list* pslist, char* name, void* params, 
+                      int* status);
+void ccl_remove_paramset(ccl_paramset_list* pslist, char* name, int* status);
+void ccl_list_paramsets(ccl_paramset_list* pslist);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ccl_paramset.c
+++ b/src/ccl_paramset.c
@@ -1,0 +1,131 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include "ccl_paramset.h"
+
+
+/* ------- ROUTINE: ccl_paramset_list_init ------
+   INPUTS: ccl_paramset_list pslist
+   TASK: Initialize a ccl_paramset_list.   
+*/
+int ccl_paramset_list_init(ccl_paramset_list* pslist){
+    // Create a new paramset_list
+    pslist->num_sets = 0;
+}
+
+
+/* ------- ROUTINE: ccl_has_paramset ------
+   INPUTS: ccl_paramset_list pslist
+           char* name
+   OUTPUT: bool has_paramset
+   TASK:   Return true if the paramset_list contains a paramset with this name
+*/
+int ccl_has_paramset(ccl_paramset_list* pslist, char* name){
+    // Check if the parameter dictionary contains a given parameter set
+    for(int i=0; i < pslist->num_sets; i++){
+        if(strcmp(pslist->name[i], name) == 0) return true; // found
+    }
+    return false;
+}
+
+
+/* ------- ROUTINE: ccl_get_paramset ------
+   INPUTS: ccl_paramset_list pslist
+           char* name
+   OUTPUT: void* (pointer to user-defined parameters struct)
+   TASK:   Return a pointer to a user-defined parameters structure, specified 
+           by 'name'. This is returned as a void pointer, which must be cast to 
+           the correct type. If the paramset is not found, NULL is returned.
+*/
+void* ccl_get_paramset(ccl_paramset_list* pslist, char* name){
+    // Get a paramset by name (if it exists)
+    
+    // Loop over available paramsets to find the requested one
+    for(int i=0; i < pslist->num_sets; i++){
+        if(strcmp(pslist->name[i], name) == 0) return pslist->paramset[i];
+    }
+    
+    // paramset doesn't exist, return NULL
+    return NULL;
+}
+
+
+/* ------- ROUTINE: ccl_add_paramset ------
+   INPUTS: ccl_paramset_list pslist
+           char* name
+           void* params
+           int* status
+   TASK:   Add a pointer to a user-defined parameter structure to the 
+           paramset_list. If a paramset with this name already exists, status 
+           is returned with value CCL_PARAMSET_ALREADY_EXISTS.
+*/
+void ccl_add_paramset(ccl_paramset_list* pslist, char* name, void* params, 
+                      int* status)
+{
+    // Add a parameter struct to the paramset_list
+    
+    // Check to see if paramset with this name already exists
+    if (has_paramset(pslist, name)){
+        *status = CCL_PARAMSET_ALREADY_EXISTS;
+        return;
+    }
+    
+    // Add new paramset
+    int idx = pslist->num_sets;
+    strcpy(pslist->name[idx], name); // Name of paramset_list
+    pslist->paramset[idx] = params; // Assign pointer to params struct
+    pslist->num_sets = idx + 1;
+    
+    *status = 0;
+    return;
+}
+
+
+/* ------- ROUTINE: ccl_remove_paramset ------
+   INPUTS: ccl_paramset_list pslist
+           char* name
+           int* status
+   TASK:   Remove a paramset from the list. The paramset is not deallocated by 
+           this function; the reference to it is simply removed from the list. 
+           If a paramset with this name does not exist, status is returned with 
+           value CCL_PARAMSET_NOT_FOUND.
+*/
+void ccl_remove_paramset(ccl_paramset_list* pslist, char* name, int* status){
+    // Remove a named paramset, if it exists
+    
+    // Find the index of the paramset to be removed
+    int idx = -1;
+    for(int i=0; i < pslist->num_sets; i++){
+        if(strcmp(pslist->name[i], name) == 0){
+            idx = i;
+            break;
+        }
+    }
+    
+    // Return errorcode if no paramset was found
+    if(idx == -1){
+        *status = CCL_PARAMSET_NOT_FOUND;
+        return;
+    }
+    
+    // Shuffle paramsets up in the list, replacing the paramset to be removed
+    for(int i=idx+1; i < pslist->num_sets; i++){
+        strcpy(pslist->name[i-1], pslist->name[i]);
+        pslist->paramset[i-1] = pslist->paramset[i];
+    }
+    pslist->num_sets--; // Decrement paramset count
+    *status = 0;
+    return;
+}
+
+
+/* ------- ROUTINE: ccl_list_paramsets ------
+   INPUTS: ccl_paramset_list pslist
+   TASK:   Print a list of all paramsets stored in the list.
+*/
+void ccl_list_paramsets(ccl_paramset_list* pslist){
+    // Check if the parameter dictionary contains a given parameter set
+    for(int i=0; i < pslist->num_sets; i++)
+        printf("%3d: %s\n", i, pslist->name[i]);
+}
+


### PR DESCRIPTION
(In progress)
To support extensions to CCL, we need some way of handling new, non-standard sets of parameters. This PR proposes a way of handling extended parameter sets.

In addition to the core `ccl_parameters` object, each extension can define its own custom parameters struct, containing any new parameters that it needs. The extension should define functions to create and initialize these structs, similar to the functions that do this for `ccl_parameters` in `ccl_core.c`.

When an extension is enabled, the user can add the corresponding parameter struct to a `ccl_paramset_list`, using the `ccl_add_paramset()` function. (The standard `ccl_parameters` struct is also kept in this list). If multiple extensions are enabled, multiple structs can be added to the list. The list is then attached to a `ccl_cosmology` object. For example:
```
ccl_paramset_list pslist;
modgrav_params mg_params;
ccl_add_paramset(&pslist, "modgrav", &mg_params);
```

Each extension module can retrieve its own parameters struct from the list by using the `ccl_get_paramset()` function. This retrieves the paramset by name. The function returns a void pointer, which the extension module must cast to the correct type, e.g.
```
modgrav_params* mg_params;
mg_params = (modgrav_params*) ccl_get_paramset(&pslist, "modgrav", &status);
printf("MG parameter mu: %3.3f\n", mg_params->mu);
```
Functions are also provided to check if a paramset exists in the list, remove a paramset from the list, and print the names of all paramsets in the list.

At the moment, this PR only provides the new `ccl_paramset_list` struct and helper functions. Assuming that people are happy with this way of doing things, this PR should be further developed to plumb them in to CCL.