### PR TITLE
Add a simple Python script to run timing benchmarks

### DIFF
--- a/tests/ccl_timing_benchmarks.py
+++ b/tests/ccl_timing_benchmarks.py
@@ -9,8 +9,8 @@ def run_distance():
     """
     Run an example luminosity distance calculation.
     """
-    cosmo = ccl.Cosmology(Omega_c=0.26, Omega_b=0.048, h=0.67, n_s=0.96, 
-                          sigma8=0.834)
+    cosmo = ccl.Cosmology(Omega_c=0.25, Omega_b=0.05, h=0.7, n_s=0.96, 
+                          sigma8=0.8) #CCL1
     a = np.linspace(0.1, 1., 200)
     dl = ccl.luminosity_distance(cosmo, a)
     return dl
@@ -20,10 +20,76 @@ def run_matter_power(mode='linear', transfer_fn='boltzmann', mpk_fn='halofit'):
     """
     Run an example matter power spectrum calculation.
     """
-    cosmo = ccl.Cosmology(Omega_c=0.26, Omega_b=0.048, h=0.67, n_s=0.96, 
-                          sigma8=0.834, Neff=3.04,
+    cosmo = ccl.Cosmology(Omega_c=0.25, Omega_b=0.05, h=0.7, n_s=0.96, 
+                          sigma8=0.8,
                           transfer_function=transfer_fn,
-                          matter_power_spectrum=mpk_fn)
+                          matter_power_spectrum=mpk_fn) #CCL1
+    k = np.logspace(-4., 0., 200)
+    
+    if mode == 'linear':
+        pk = ccl.linear_matter_power(cosmo, k, a=1.)
+    else:
+        pk = ccl.nonlin_matter_power(cosmo, k, a=1.)
+    return pk
+
+def run_matter_power_emu(mode='nonlin', transfer_fn='emulator', mpk_fn='emu'):
+    """
+    Run an example matter power spectrum calculation.
+    """
+    cosmo = ccl.Cosmology(Omega_c=3.2759e-01, Omega_b=5.9450e-02, h=6.1670e-01,
+                          sigma8=8.7780e-01,n_s=9.6110e-01,w0=-7.0000e-01,wa=6.7220e-01, Neff=3.04,
+                          transfer_function=transfer_fn,
+                          matter_power_spectrum=mpk_fn)#M1
+    k = np.logspace(-4., 0., 200)
+    
+    if mode == 'linear':
+        pk = ccl.linear_matter_power(cosmo, k, a=1.)
+    else:
+        pk = ccl.nonlin_matter_power(cosmo, k, a=1.)
+    return pk
+
+
+def run_matter_power_nu_eq(mode='linear', transfer_fn='boltzmann', mpk_fn='halofit'):
+    """
+    Run an example matter power spectrum calculation.
+    """
+    cosmo = ccl.Cosmology(Omega_c=0.25, Omega_b=0.05, h=0.7,sigma8=0.8, n_s=0.96,m_nu=np.array([0.04,0.0,0.0]),
+                          transfer_function=transfer_fn,
+                          matter_power_spectrum=mpk_fn) #CCL7
+    k = np.logspace(-4., 0., 200)
+    
+    if mode == 'linear':
+        pk = ccl.linear_matter_power(cosmo, k, a=1.)
+    else:
+        pk = ccl.nonlin_matter_power(cosmo, k, a=1.)
+    return pk
+
+
+def run_matter_power_nu_uneq(mode='linear', transfer_fn='boltzmann', mpk_fn='halofit'):
+    """
+    Run an example matter power spectrum calculation.
+    """
+    cosmo = ccl.Cosmology(Omega_c=0.25, Omega_b=0.05, h=0.7,sigma8=0.8, n_s=0.96,w0=-0.9,
+                         wa=0.1,m_nu=np.array([0.03,0.02,0.04]),
+                        transfer_function=transfer_fn,
+                          matter_power_spectrum=mpk_fn) #CCL9
+    k = np.logspace(-4., 0., 200)
+    
+    if mode == 'linear':
+        pk = ccl.linear_matter_power(cosmo, k, a=1.)
+    else:
+        pk = ccl.nonlin_matter_power(cosmo, k, a=1.)
+    return pk
+
+def run_matter_power_emu_nu(mode='nonlin', transfer_fn='emulator', mpk_fn='emu'):
+    """
+    Run an example matter power spectrum calculation.
+    """
+    Mnu_out = ccl.nu_masses(2.0317e-02*(5.9020e-01)**2, 'equal');
+    cosmo = ccl.Cosmology(Omega_c=3.5595e-01, Omega_b=6.5074e-02, h= 5.9020e-01, n_s=9.5623e-01, 
+                          sigma8=7.3252e-01, w0=-8.0194e-01, wa=3.6280e-01, Neff=3.04,m_nu=Mnu_out,
+                          transfer_function=transfer_fn,
+                          matter_power_spectrum=mpk_fn) #M38
     k = np.logspace(-4., 0., 200)
     
     if mode == 'linear':
@@ -34,7 +100,7 @@ def run_matter_power(mode='linear', transfer_fn='boltzmann', mpk_fn='halofit'):
 
 
 if __name__ == '__main__':
-    
+
     # Luminosity distance
     print("Timing luminosity distance...")
     t = timeit.repeat("""dl = run_distance()""", 
@@ -68,10 +134,34 @@ if __name__ == '__main__':
     
     # Nonlinear matter power (CosmicEmu)
     print("Timing matter power (cosmicemu)...")
-    t = timeit.repeat("""pk = run_matter_power(mode='nonlin', 
+    t = timeit.repeat("""pk = run_matter_power_emu(mode='nonlin', 
                                                transfer_fn='emulator',
                                                mpk_fn='emu')""", 
-                      setup="from __main__ import run_matter_power",
+                      setup="from __main__ import run_matter_power_emu",
                       number=1, repeat=20)
     print("\tRuntime: %3.3f +/- %3.3f sec" % (np.median(t), np.std(t)))
     
+    # Nonlinear matter power (CosmicEmu with neutrinos)
+    print("Timing matter power (cosmicemu with neutrinos)...")
+    t = timeit.repeat("""pk = run_matter_power_emu_nu(mode='nonlin', 
+                                               transfer_fn='emulator',
+                                               mpk_fn='emu')""", 
+                      setup="from __main__ import run_matter_power_emu_nu",
+                      number=1, repeat=20)
+    print("\tRuntime: %3.3f +/- %3.3f sec" % (np.median(t), np.std(t)))
+    
+    # Nonlinear matter power (CLASS + Halofit with neutrinos - CCL7)
+    print("Timing matter power (Boltzmann + Halofit with neutrinos CCL7)...")
+    t = timeit.repeat("""pk = run_matter_power_nu_eq(mode='nonlin', 
+                                                  transfer_fn='boltzmann')""", 
+                      setup="from __main__ import run_matter_power_nu_eq",
+                      number=1, repeat=20)
+    print("\tRuntime: %3.3f +/- %3.3f sec" % (np.median(t), np.std(t)))
+    
+    # Nonlinear matter power (CLASS + Halofit with neutrinos - CCL9)
+    print("Timing matter power (Boltzmann + Halofit with neutrinos CCL9)...")
+    t = timeit.repeat("""pk = run_matter_power_nu_uneq(mode='nonlin', 
+                                                  transfer_fn='boltzmann')""", 
+                      setup="from __main__ import run_matter_power_nu_uneq",
+                      number=1, repeat=20)
+    print("\tRuntime: %3.3f +/- %3.3f sec" % (np.median(t), np.std(t)))

--- a/tests/ccl_timing_benchmarks.py
+++ b/tests/ccl_timing_benchmarks.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python
-"""
-Run timing benchmarks on key CCL functions.
-"""
 import numpy as np
 import pyccl as ccl
 import timeit
 
+##### 
+# This script tests the speed of CCL on key CCL functions.
 
 def run_distance():
     """

--- a/tests/ccl_timing_benchmarks.py
+++ b/tests/ccl_timing_benchmarks.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""
+Run timing benchmarks on key CCL functions.
+"""
+import numpy as np
+import pyccl as ccl
+import timeit
+
+
+def run_distance():
+    """
+    Run an example luminosity distance calculation.
+    """
+    cosmo = ccl.Cosmology(Omega_c=0.26, Omega_b=0.048, h=0.67, n_s=0.96, 
+                          sigma8=0.834)
+    a = np.linspace(0.1, 1., 200)
+    dl = ccl.luminosity_distance(cosmo, a)
+    return dl
+
+
+def run_matter_power(mode='linear', transfer_fn='boltzmann', mpk_fn='halofit'):
+    """
+    Run an example matter power spectrum calculation.
+    """
+    cosmo = ccl.Cosmology(Omega_c=0.26, Omega_b=0.048, h=0.67, n_s=0.96, 
+                          sigma8=0.834, Neff=3.04,
+                          transfer_function=transfer_fn,
+                          matter_power_spectrum=mpk_fn)
+    k = np.logspace(-4., 0., 200)
+    
+    if mode == 'linear':
+        pk = ccl.linear_matter_power(cosmo, k, a=1.)
+    else:
+        pk = ccl.nonlin_matter_power(cosmo, k, a=1.)
+    return pk
+
+
+if __name__ == '__main__':
+    
+    # Luminosity distance
+    print("Timing luminosity distance...")
+    t = timeit.repeat("""dl = run_distance()""", 
+                      setup="from __main__ import run_distance",
+                      number=1, repeat=20)
+    print("\tRuntime: %3.3f +/- %3.3f sec" % (np.median(t), np.std(t)))
+    
+    # Linear matter power (Eisenstein + Hu)
+    print("Timing matter power (Eisenstein + Hu)...")
+    t = timeit.repeat("""pk = run_matter_power(mode='linear', 
+                                               transfer_fn='eisenstein_hu')""", 
+                      setup="from __main__ import run_matter_power",
+                      number=1, repeat=20)
+    print("\tRuntime: %3.3f +/- %3.3f sec" % (np.median(t), np.std(t)))
+    
+    # Linear matter power (CLASS)
+    print("Timing matter power (Boltzmann)...")
+    t = timeit.repeat("""pk = run_matter_power(mode='linear', 
+                                               transfer_fn='boltzmann')""", 
+                      setup="from __main__ import run_matter_power",
+                      number=1, repeat=20)
+    print("\tRuntime: %3.3f +/- %3.3f sec" % (np.median(t), np.std(t)))
+    
+    # Nonlinear matter power (CLASS + Halofit)
+    print("Timing matter power (Boltzmann + Halofit)...")
+    t = timeit.repeat("""pk = run_matter_power(mode='nonlin', 
+                                               transfer_fn='boltzmann')""", 
+                      setup="from __main__ import run_matter_power",
+                      number=1, repeat=20)
+    print("\tRuntime: %3.3f +/- %3.3f sec" % (np.median(t), np.std(t)))
+    
+    # Nonlinear matter power (CosmicEmu)
+    print("Timing matter power (cosmicemu)...")
+    t = timeit.repeat("""pk = run_matter_power(mode='nonlin', 
+                                               transfer_fn='emulator',
+                                               mpk_fn='emu')""", 
+                      setup="from __main__ import run_matter_power",
+                      number=1, repeat=20)
+    print("\tRuntime: %3.3f +/- %3.3f sec" % (np.median(t), np.std(t)))
+    

--- a/tests/ccl_timing_benchmarks2.py
+++ b/tests/ccl_timing_benchmarks2.py
@@ -1,0 +1,153 @@
+import numpy as np
+import pyccl as ccl
+import time
+
+##### 
+# This script tests the speed of CCL in a typical likelihood evaluation.
+
+#####
+# Tune the parameters below to explore different scenarios
+#  a) Number of redshift bins (for both sources and lenses)
+nbins=10
+#  b) Type of cosmological model (1-> simple LCDM, 2-> LCDM with massive neutrinos, 3-> Use emulator to obtain P(k))
+which_cosmo=1
+#  c) Do sources have intrinsic alignments?
+has_ia = True
+#  d) Do lenses have redshift-space distortions?
+has_rsd = True
+#  e) Do lenses have magnification bias?
+has_mag = True
+
+logyn=['no','yes']
+print("Run parameters: ")
+if which_cosmo==1 :
+       print(" Vanilla LCDM")
+elif which_cosmo==2 :
+       print(" LCDM + m_nu")
+elif which_cosmo==3 :
+       print(" CosmicEmu")
+else :
+       raise ValueError("Please choose which_cosmo=1, 2 or 3")
+print(" %d tomographic bins"%nbins)
+print(" RSD  : "+logyn[int(has_rsd)])
+print(" IAs  : "+logyn[int(has_ia)])
+print(" Magnification : "+logyn[int(has_mag)])
+print("")
+
+def report_time(msg,tm) :
+       print(msg+": %.5lf s"%tm)
+
+#####
+# A) The first step is to define the N(z)s of both lenses and sources.
+#    For this particular example we use CCL's internal functions, but these are only useful for forecasting.
+z = np.linspace(0.,2.0, 200)
+pz_gaussian = ccl.PhotoZGaussian(0.05)
+dNdz_lens_list=[]
+dNdz_source_list=[]
+for i in range(0,nbins):
+       dNdz_source_list.append(ccl.dNdz_tomog(z, 'wl_fid', i*0.15, (i+1)*0.15, pz_gaussian))
+       dNdz_lens_list.append(ccl.dNdz_tomog(z, 'nc', i*0.15, (i+1)*0.15, pz_gaussian))
+
+#####
+# B) Start the timer
+t1=time.time()
+
+#####
+# C) Initialize the cosmological model
+if which_cosmo==1 :
+       cosmo = ccl.Cosmology(Omega_c=0.27, Omega_b=0.045, h=0.67, A_s=2.1e-9, n_s=0.96)
+elif which_cosmo==2 :
+       cosmo = ccl.Cosmology(Omega_c=0.27, Omega_b=0.045, h=0.67, A_s=2.1e-9, n_s=0.96,m_nu=0.06)
+elif which_cosmo==3 :
+       cosmo = ccl.Cosmology(Omega_c=0.27, Omega_b=0.045, h=0.7, sigma8=0.8, w0=-1., wa=0., n_s=0.96,Neff=3.04, transfer_function='emulator',matter_power_spectrum='emu')
+t2=time.time()
+report_time('Cosmology creation',t2-t1)
+
+#####
+# D) We first test how long it takes to compute the matter power spectrum from the chosen method.
+s8=ccl.sigma8(cosmo)
+t3=time.time()
+report_time('P(k) call',t3-t2)
+
+#####
+# E) Now we will initialize one ClTracer object for each redshift bin of either lenses or sources.
+#    First let us define some bias functions (galaxy bias, IA amplitudes, magnification bias)
+bias_ia = np.ones(z.size) # Intrinsic alignment bias factor
+f_red = 0.5 * np.ones(z.size) # Fraction of aligned galaxies
+bias = np.ones(z.size) # Galaxy bias
+mag_bias = np.ones(z.size) # Magnification bias
+#    Now we actually generate the tracers
+lenses=[]
+sources=[]
+for i in range(0,nbins):
+       lenses.append(ccl.ClTracerLensing(cosmo, has_intrinsic_alignment=has_ia, z=z, n=dNdz_source_list[i], bias_ia=bias_ia, f_red=f_red))
+       sources.append(ccl.ClTracerNumberCounts(cosmo, has_rsd=has_rsd, has_magnification=has_mag,n=dNdz_lens_list[i], bias=bias, mag_bias=mag_bias, z=z))
+t4=time.time()
+report_time('Tracer creation',t4-t3)
+
+#####
+# F) Now compute all possible cross-power spectra
+#    ell-range chosen to give good coverage to compute correlation function later on
+ell = np.arange(1,10000)
+nell=len(ell)
+#    Galaxy-galaxy power spectra
+cl_gg=np.zeros([nbins,nbins,nell])
+for i in range(0,nbins) :
+       for j in range(i,nbins) :
+              cl_gg[i,j,:]=ccl.angular_cl(cosmo,sources[i],sources[j],ell,l_linstep=10000,l_logstep=1.1)
+              if j!=i :
+                     cl_gg[j,i,:]=cl_gg[i,j,:]
+#    Galaxy-lensing power spectra
+cl_gl=np.zeros([nbins,nbins,nell])
+for i in range(0,nbins) :
+       for j in range(0,nbins) :
+              cl_gl[i,j,:]=ccl.angular_cl(cosmo,sources[i],lenses[j],ell,l_linstep=10000,l_logstep=1.1)
+#    Lensing-lensing power spectra
+cl_ll=np.zeros([nbins,nbins,nell])
+for i in range(0,nbins) :
+       for j in range(i,nbins) :
+              cl_ll[i,j,:]=ccl.angular_cl(cosmo,lenses[i],lenses[j],ell,l_linstep=10000,l_logstep=1.1)
+              if j!=i :
+                     cl_ll[j,i,:]=cl_ll[i,j,:]
+#    Total number of power spectra computed
+total_pspec=nbins*(nbins+1)+nbins**2
+t5=time.time()
+report_time('%d Cls'%total_pspec,t5-t4)
+
+#####
+# G) Finally, we compute the angular correlation functions
+#    Generic angular range (in degrees)
+theta_deg = np.logspace(-1, np.log10(5.), 20)
+nth=len(theta_deg)
+corrmethod='FFTLog'
+#    Galaxy-galaxy (w)
+xi_gg=np.zeros([nbins,nbins,nth])
+for i in range(0,nbins) :
+       for j in range(i,nbins) :
+              xi_gg[i,j,:]=ccl.correlation(cosmo,ell,cl_gg[i,j],theta_deg,corr_type='GG',method=corrmethod)
+              if j!=i :
+                     xi_gg[j,i,:]=xi_gg[i,j,:]
+#    Galaxy-lensing (gamma_T)
+xi_gl=np.zeros([nbins,nbins,nth])
+for i in range(0,nbins) :
+       for j in range(0,nbins) :
+              xi_gl[i,j,:]=ccl.correlation(cosmo,ell,cl_gl[i,j],theta_deg,corr_type='GL',method=corrmethod)
+              if j!=i :
+                     xi_gl[j,i,:]=xi_gl[i,j,:]
+#    Lensing-lensing (xi_+, xi_-)
+xi_p=np.zeros([nbins,nbins,nth])
+xi_m=np.zeros([nbins,nbins,nth])
+for i in range(0,nbins) :
+       for j in range(i,nbins) :
+              xi_p[i,j,:]=ccl.correlation(cosmo,ell,cl_ll[i,j],theta_deg,corr_type='L+',method=corrmethod)
+              xi_m[i,j,:]=ccl.correlation(cosmo,ell,cl_ll[i,j],theta_deg,corr_type='L-',method=corrmethod)
+              if j!=i :
+                     xi_p[j,i,:]=xi_p[i,j,:]
+                     xi_m[j,i,:]=xi_m[i,j,:]
+#    Total number of correlation functions computed
+total_corrs=3*((nbins*(nbins+1))/2)+nbins**2
+t6=time.time()
+report_time('%d correlation functions'%total_corrs,t6-t5)
+
+#Final reckoning
+report_time("Total time ellapsed",t6-t1)

--- a/tests/ccl_timing_benchmarks2.py
+++ b/tests/ccl_timing_benchmarks2.py
@@ -14,6 +14,7 @@ which_cosmo=1
 #  c) Do sources have intrinsic alignments?
 has_ia = True
 #  d) Do lenses have redshift-space distortions?
+#     This must be set to False for cosmologies with massive neutrinos
 has_rsd = True
 #  e) Do lenses have magnification bias?
 has_mag = True

--- a/tests/ccl_timing_benchmarks2.py
+++ b/tests/ccl_timing_benchmarks2.py
@@ -9,13 +9,13 @@ import time
 # Tune the parameters below to explore different scenarios
 #  a) Number of redshift bins (for both sources and lenses)
 nbins=10
-#  b) Type of cosmological model (1-> simple LCDM, 2-> LCDM with massive neutrinos, 3-> Use emulator to obtain P(k))
-which_cosmo=1
+#  b) Type of cosmological model (1-> simple LCDM, 2-> LCDM with single massive neutrino, 3-> Use emulator to obtain P(k, 4-> LCDM with three massive neutrinos, 5-> Use emulator with massive neutrinos ))
+which_cosmo=5
 #  c) Do sources have intrinsic alignments?
 has_ia = True
 #  d) Do lenses have redshift-space distortions?
 #     This must be set to False for cosmologies with massive neutrinos
-has_rsd = True
+has_rsd = False
 #  e) Do lenses have magnification bias?
 has_mag = True
 
@@ -24,9 +24,13 @@ print("Run parameters: ")
 if which_cosmo==1 :
        print(" Vanilla LCDM")
 elif which_cosmo==2 :
-       print(" LCDM + m_nu")
+       print(" LCDM + m_nu CCL7")
 elif which_cosmo==3 :
-       print(" CosmicEmu")
+       print(" CosmicEmu M1")
+elif which_cosmo==4 :
+       print(" LCDM + m_nu CCL 9")
+elif which_cosmo==5 :
+       print(" CosmicEmu M38")
 else :
        raise ValueError("Please choose which_cosmo=1, 2 or 3")
 print(" %d tomographic bins"%nbins)
@@ -55,12 +59,19 @@ t1=time.time()
 
 #####
 # C) Initialize the cosmological model
-if which_cosmo==1 :
-       cosmo = ccl.Cosmology(Omega_c=0.27, Omega_b=0.045, h=0.67, A_s=2.1e-9, n_s=0.96)
-elif which_cosmo==2 :
-       cosmo = ccl.Cosmology(Omega_c=0.27, Omega_b=0.045, h=0.67, A_s=2.1e-9, n_s=0.96,m_nu=0.06)
-elif which_cosmo==3 :
-       cosmo = ccl.Cosmology(Omega_c=0.27, Omega_b=0.045, h=0.7, sigma8=0.8, w0=-1., wa=0., n_s=0.96,Neff=3.04, transfer_function='emulator',matter_power_spectrum='emu')
+if which_cosmo==1 : #CCL1
+       cosmo = ccl.Cosmology(Omega_c=0.25, Omega_b=0.05, h=0.7,sigma8=0.8, n_s=0.96)
+elif which_cosmo==2 : #CCL7
+       cosmo = ccl.Cosmology(Omega_c=0.25, Omega_b=0.05, h=0.7,sigma8=0.8, n_s=0.96,m_nu=np.array([0.04,0.0,0.0]))
+elif which_cosmo==3 : #M1
+       cosmo = ccl.Cosmology(Omega_c=3.2759e-01, Omega_b=5.9450e-02, h=6.1670e-01, sigma8=8.7780e-01,n_s=9.6110e-01,w0=-7.0000e-01,wa=6.7220e-01, Neff=3.04, transfer_function='emulator',matter_power_spectrum='emu')
+elif which_cosmo==4 : #CCL9
+       cosmo = ccl.Cosmology(Omega_c=0.25, Omega_b=0.05, h=0.7,sigma8=0.8, n_s=0.96,w0=-0.9,wa=0.1,m_nu=np.array([0.03,0.02,0.04]))
+elif which_cosmo==5 : #M38
+       Mnu_out = ccl.nu_masses(2.0317e-02*(5.9020e-01)**2, 'equal');
+       cosmo = ccl.Cosmology(Omega_c=3.5595e-01, Omega_b=6.5074e-02, h= 5.9020e-01, n_s=9.5623e-01, 
+                             sigma8=7.3252e-01, w0=-8.0194e-01, wa=3.6280e-01, Neff=3.04,m_nu=Mnu_out,
+                             transfer_function='emulator',matter_power_spectrum='emu')
 t2=time.time()
 report_time('Cosmology creation',t2-t1)
 

--- a/tests/ccl_timing_benchmarks2.py
+++ b/tests/ccl_timing_benchmarks2.py
@@ -10,12 +10,12 @@ import time
 #  a) Number of redshift bins (for both sources and lenses)
 nbins=10
 #  b) Type of cosmological model (1-> simple LCDM, 2-> LCDM with single massive neutrino, 3-> Use emulator to obtain P(k, 4-> LCDM with three massive neutrinos, 5-> Use emulator with massive neutrinos ))
-which_cosmo=5
+which_cosmo=1
 #  c) Do sources have intrinsic alignments?
 has_ia = True
 #  d) Do lenses have redshift-space distortions?
 #     This must be set to False for cosmologies with massive neutrinos
-has_rsd = False
+has_rsd = True
 #  e) Do lenses have magnification bias?
 has_mag = True
 


### PR DESCRIPTION
This PR implements a simple script to run a few timing benchmarks. Only a single distance function and several matter power spectrum functions are timed at the moment. The results on my machine (4yo Dell XPS 13, Intel i7) are:

```
Timing luminosity distance...
	Runtime: 0.124 +/- 0.003 sec
Timing matter power (Eisenstein + Hu)...
	Runtime: 0.066 +/- 0.003 sec
Timing matter power (Boltzmann)...
	Runtime: 5.195 +/- 0.029 sec
Timing matter power (Boltzmann + Halofit)...
	Runtime: 5.193 +/- 0.271 sec
Timing matter power (cosmicemu)...
	Runtime: 4.916 +/- 0.689 sec
```