### PR TITLE
Bring back missing tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,15 @@ project(ccl VERSION 0.2.1)
 
     # Defines list of CCL tests src files
     # ! Add new tests to this list
-    set(TEST_SRC tests/ccl_test.c tests/ccl_test_utils.c tests/ccl_test_params.c tests/ccl_test_cosmology.c
-                 tests/ccl_test_distances.c tests/ccl_test_distances_hiz.c tests/ccl_test_growth.c
-                 tests/ccl_test_growth_hiz.c tests/ccl_test_bbks.c tests/ccl_test_eh.c tests/ccl_test_cls.c
-                 tests/ccl_test_cmblens.c tests/ccl_test_sigmaM.c tests/ccl_test_massfunc.c tests/ccl_test_correlation.c
-                 tests/ccl_test_bcm.c tests/ccl_test_emu.c tests/ccl_test_emu_nu.c tests/ccl_test_angpow.c)
+    set(TEST_SRC tests/ccl_test.c tests/ccl_test_utils.c tests/ccl_test_params.c tests/ccl_test_params_mnu.c
+    		 tests/ccl_test_cosmology.c tests/ccl_test_distances.c tests/ccl_test_distances_hiz.c
+		 tests/ccl_test_growth.c tests/ccl_test_growth_hiz.c tests/ccl_test_bbks.c tests/ccl_test_eh.c
+		 tests/ccl_test_cls.c tests/ccl_test_cmblens.c tests/ccl_test_sigmaM.c
+		 tests/ccl_test_massfunc.c tests/ccl_test_correlation.c tests/ccl_test_correlation_3d.c
+		 tests/ccl_test_bcm.c tests/ccl_test_emu.c tests/ccl_test_emu_nu.c
+		 tests/ccl_test_distances_mnu.c tests/ccl_test_distances_hiz_mnu.c
+		 tests/ccl_test_power_nu.c tests/ccl_test_nonlimber.c tests/ccl_test_angpow.c)
+
 
     # Defines list of extra distribution files to be installed on the system
     set(EXTRA_DIST include/ccl_params.ini README.md LICENSE LICENSE_COSMICEMU)

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -7,4 +7,4 @@ To add a new set of tests to the system:
  - Create a new file tests/your_tests.c
  - Add your tests to that file.  You do not need a "main" function. See the examples in tests/ccl_test_params.c for how to write tests, which should use the ctest assertions to check they are working (see the sparse documentation at https://github.com/bvdberg/ctest).
  - In the CMakeLists.txt add tests/your_tests.c to the "TEST_SRC" list towards the top of  the  file
- - Run "make check" to run all your tests
+ - Run "check_ccl" to run all your tests


### PR DESCRIPTION
This PR fixes the CMakeLists file to incorporate some tests that were missing. This brings the lists of tests back to 62 (from 40 in current master).