### PR TITLE
Solves problem with pip install breaking CLASS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,12 @@ install:
 - cmake --version
 - python --version
 script:
-- python setup.py build
-- nosetests tests/run_tests.py --all --debug --detailed-errors --verbose --process-restartworker --with-coverage --cover-package=pyccl
+- make -Cbuild
 - sudo make -Cbuild install
 - check_ccl
+- python setup.py build
+- nosetests tests/run_tests.py --all --debug --detailed-errors --verbose --process-restartworker --with-coverage --cover-package=pyccl
+
 after_success:
 - coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,9 @@ install:
 - cmake --version
 - python --version
 script:
-- mkdir build && sudo make -Cbuild install
 - python setup.py build
-- rm -rf build
 - nosetests tests/run_tests.py --all --debug --detailed-errors --verbose --process-restartworker --with-coverage --cover-package=pyccl
+- sudo make -Cbuild install
 - check_ccl
 after_success:
 - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,10 @@ install:
 - cmake --version
 - python --version
 script:
-- python setup.py build
-- nosetests tests/run_tests.py --all --debug --detailed-errors --verbose --process-restartworker --with-coverage --cover-package=pyccl
 - sudo make -Cbuild install
+- python setup.py build
+- rm -rf build
+- nosetests tests/run_tests.py --all --debug --detailed-errors --verbose --process-restartworker --with-coverage --cover-package=pyccl
 - check_ccl
 after_success:
 - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,10 @@ install:
 - cmake --version
 - python --version
 script:
-- make -Cbuild
-- sudo make -Cbuild install
-- check_ccl
 - python setup.py build
 - nosetests tests/run_tests.py --all --debug --detailed-errors --verbose --process-restartworker --with-coverage --cover-package=pyccl
-
+- make -Cbuild && sudo make -Cbuild install
+- check_ccl
 after_success:
 - coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ install:
 - cmake --version
 - python --version
 script:
-- sudo make -Cbuild install
 - python setup.py build
+- sudo make -Cbuild install
 - rm -rf build
 - nosetests tests/run_tests.py --all --debug --detailed-errors --verbose --process-restartworker --with-coverage --cover-package=pyccl
 - check_ccl

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ install:
 - cmake --version
 - python --version
 script:
+- mkdir build && sudo make -Cbuild install
 - python setup.py build
-- sudo make -Cbuild install
 - rm -rf build
 - nosetests tests/run_tests.py --all --debug --detailed-errors --verbose --process-restartworker --with-coverage --cover-package=pyccl
 - check_ccl

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -37,4 +37,5 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 else
     # Install some custom requirements on Linux
     echo "No specific requirements on linux"
+    pip install nose coverage coveralls
 fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,9 @@ project(ccl VERSION 0.2.1)
 		 tests/ccl_test_power_nu.c tests/ccl_test_nonlimber.c tests/ccl_test_angpow.c)
 
 
-    # Defines list of extra distribution files to be installed on the system
+    # Defines list of extra distribution files and directories to be installed on the system
     set(EXTRA_DIST include/ccl_params.ini README.md LICENSE LICENSE_COSMICEMU)
+    set(EXTRA_DIST_DIRS)
 
     # Uses system libraries or downloads and build if necessary
     include(BuildFFTW)
@@ -111,8 +112,9 @@ project(ccl VERSION 0.2.1)
     install(DIRECTORY include/ DESTINATION include
             FILES_MATCHING PATTERN "*.h")
     install(FILES ${EXTRA_DIST} DESTINATION share/ccl)
+    install(DIRECTORY ${EXTRA_DIST_DIRS} DESTINATION share/ccl)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ccl.pc DESTINATION lib/pkgconfig)
-
+    
     # Adds uninstall target
     if(NOT TARGET uninstall)
       configure_file(

--- a/cmake/Modules/BuildCLASS.cmake
+++ b/cmake/Modules/BuildCLASS.cmake
@@ -10,6 +10,8 @@ else()
   set(CLASS_OMPFLAG "OMPFLAG   = -fopenmp")
 endif()
 
+# Define class install path and sscape the slashes for the Perl command
+STRING(REPLACE "/" "\\/" CLASS_INSTALL_DIR "__CLASSDIR__='\"${CMAKE_INSTALL_PREFIX}/share/ccl\"'")
 
 # Downloads and compiles CLASS
 ExternalProject_Add(CLASS
@@ -17,15 +19,26 @@ ExternalProject_Add(CLASS
         GIT_REPOSITORY https://github.com/lesgourg/class_public.git
         GIT_TAG ${CLASSTag}
         DOWNLOAD_NO_PROGRESS 1
+        PATCH_COMMAND patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/cmake/class-2.6.3.patch
         # In the configuration step, we comment out the default compiler and
         # provide an appropriate omp flag
         CONFIGURE_COMMAND     perl -pi -e "s/^CC /# CC /" Makefile &&
-                              perl -pi -e "s/^OMPFLAG .*/${CLASS_OMPFLAG}/" Makefile
+                              perl -pi -e "s/^OMPFLAG .*/${CLASS_OMPFLAG}/" Makefile &&
+                              perl -pi -e "s/__CLASSDIR__.*/${CLASS_INSTALL_DIR}/" Makefile
         BUILD_COMMAND         make CC=${CMAKE_C_COMPILER} libclass.a
         INSTALL_COMMAND       mkdir -p ${CMAKE_BINARY_DIR}/extern/lib &&
                               cp libclass.a ${CMAKE_BINARY_DIR}/extern/lib &&
-                              cp -r include ${CMAKE_BINARY_DIR}/extern
+                              cp -r include ${CMAKE_BINARY_DIR}/extern &&
+                              mkdir -p ${CMAKE_BINARY_DIR}/extern/share/class/hyrec &&
+                              cp hyrec/Alpha_inf.dat ${CMAKE_BINARY_DIR}/extern/share/class/hyrec &&
+                              cp hyrec/R_inf.dat ${CMAKE_BINARY_DIR}/extern/share/class/hyrec &&
+                              cp hyrec/two_photon_tables.dat ${CMAKE_BINARY_DIR}/extern/share/class/hyrec &&
+                              mkdir -p ${CMAKE_BINARY_DIR}/extern/share/class/bbn &&
+                              cp bbn/sBBN_2017.dat ${CMAKE_BINARY_DIR}/extern/share/class/bbn
         BUILD_IN_SOURCE 1)
 set(CLASS_LIBRARY_DIRS ${CMAKE_BINARY_DIR}/extern/lib/ )
 set(CLASS_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/extern/include/)
 set(CLASS_LIBRARIES -lclass)
+
+# We also need to make sure the CLASS parameter files are added to the install
+set(EXTRA_DIST_DIRS ${EXTRA_DIST_DIRS} ${CMAKE_BINARY_DIR}/extern/share/class/)

--- a/cmake/class-2.6.3.patch
+++ b/cmake/class-2.6.3.patch
@@ -1,0 +1,44 @@
+diff --git a/source/input.c b/source/input.c
+index 43a2fdd..f4a9367 100755
+--- a/source/input.c
++++ b/source/input.c
+@@ -3167,6 +3167,15 @@ int input_default_params(
+
+ int input_default_precision ( struct precision * ppr ) {
+
++  /** Resolve path to parameter files
++   */
++  FileName param_dir;
++  const char* param_dir_env = getenv("CLASS_PARAM_DIR");
++  if (param_dir_env != NULL)
++    sprintf(param_dir,  param_dir_env);
++  else
++    sprintf(param_dir, __CLASSDIR__);
++
+   /** Initialize presicion parameters for different structures:
+    * - parameters related to the background
+    */
+@@ -3188,7 +3197,7 @@ int input_default_precision ( struct precision * ppr ) {
+    */
+
+   /* for bbn */
+-  sprintf(ppr->sBBN_file,__CLASSDIR__);
++  sprintf(ppr->sBBN_file, param_dir);
+   strcat(ppr->sBBN_file,"/bbn/sBBN_2017.dat");
+
+   /* for recombination */
+@@ -3226,11 +3235,11 @@ int input_default_precision ( struct precision * ppr ) {
+
+   ppr->recfast_H_frac=1.e-3;               /* from recfast 1.4 */
+
+-  sprintf(ppr->hyrec_Alpha_inf_file,__CLASSDIR__);
++  sprintf(ppr->hyrec_Alpha_inf_file, param_dir);
+   strcat(ppr->hyrec_Alpha_inf_file,"/hyrec/Alpha_inf.dat");
+-  sprintf(ppr->hyrec_R_inf_file,__CLASSDIR__);
++  sprintf(ppr->hyrec_R_inf_file, param_dir);
+   strcat(ppr->hyrec_R_inf_file,"/hyrec/R_inf.dat");
+-  sprintf(ppr->hyrec_two_photon_tables_file,__CLASSDIR__);
++  sprintf(ppr->hyrec_two_photon_tables_file, param_dir);
+   strcat(ppr->hyrec_two_photon_tables_file,"/hyrec/two_photon_tables.dat");
+
+   /* for reionization */

--- a/pyccl/__init__.py
+++ b/pyccl/__init__.py
@@ -5,6 +5,8 @@
 from os import environ, path
 if environ.get("CCL_PARAM_FILE") is None:
     environ["CCL_PARAM_FILE"] = path.dirname(path.abspath(__file__)) + '/ccl_params.ini'
+if environ.get("CLASS_PARAM_DIR") is None:
+    environ["CLASS_PARAM_DIR"] = path.dirname(path.abspath(__file__))
 
 from pyccl import ccllib as lib
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,13 @@ class build(_build):
         if call(["cp", "build/pyccl/ccllib.py", "pyccl/"]) != 0:
             raise Exception("Could not find python module, SWIG must have failed.")
         call(["cp", "include/ccl_params.ini", "pyccl/"])
+
+        # Copy files required by CLASS
+        if call(["cp","-r", "build/extern/share/class/bbn", "pyccl/"]) != 0:
+            raise Exception("Could not copy the CLASS BBN fikes, CLASS compilation must have failed.")
+        if call(["cp","-r", "build/extern/share/class/hyrec", "pyccl/"]) != 0:
+            raise Exception("Could not copy the CLASS BBN fikes, CLASS compilation must have failed.")
+
         _build.run(self)
 
 # read the contents of the README file
@@ -38,7 +45,7 @@ setup(name="pyccl",
     url="https://github.com/LSSTDESC/CCL",
     packages=['pyccl'],
     provides=['pyccl'],
-    package_data={'pyccl': ['_ccllib.so', 'ccl_params.ini']},
+    package_data={'pyccl': ['_ccllib.so', 'ccl_params.ini', 'bbn', 'hyrec']},
     include_package_data = True,
     install_requires=['numpy'],
     test_suite='nose.collector',


### PR DESCRIPTION
As documented in #411 there were some unforeseen consequences to the pip install process (entirely my fault btw). Contrary to CCL, CLASS is not a proper package in the sense that it is not meant to be compiled then installed in a different directory, it relies on hard coded file path pointing to the compile directory. 
Problem is that pip build the package in a temporary directory, then install the package in a different location and removes the temporary, so class can't find data files needed by the big bang nucleosynthesis  and recombination modules.

So, here is my proposal to solve this problem.

The C library needs to be movable for pip, there is no way around that, so I adopt the same strategy than in CCL to provide the file paths, which is to first check an environment variable, then look at a hard coded location. This means unfortunately patching CLASS. We could open a PR and ask Julien to merge our changes, but in the meantime, I created a `patch` file against v2.6.3 we are currently using  (this is likely to break if/when we move to another version of CLASS, but ¯\_(ツ)_/¯ )

With the patch in place, I specify `{isntall_dir}/share/ccl` as the path to find the `bbn` and `hyrec` files, and move these files to this location during install. This will work seamlessly for the C module with our automated compilation of CLASS, no need to specify an environment variable. If people use their own CLASS, it should work as well since they presumably don't move their CLASS folder around (standalone class would stop working for them anyway if they do).

For the python module, I add 2 lines in the __init__.py to define the necessary environment variable pointing to the pyccl folder. I also make sure to copy the required data files in the pyccl folder, so that the module is completely movable. (We were doing the same thing for the `ccl_params.ini`)

