### PR TITLE
Fixes the dependencies in SWIG build

### DIFF
--- a/pyccl/CMakeLists.txt
+++ b/pyccl/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
 # Builds the python module
 #
-
 include(BuildSWIG)
 include(UseSWIG)
+set (UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
 
 find_package(PythonLibsNew)
 find_package(NumPy)
@@ -14,6 +14,13 @@ add_library(ccl_static STATIC $<TARGET_OBJECTS:objlib>)
 target_link_libraries(ccl_static ${GSL_LIBRARIES} ${CLASS_LIBRARIES} ${ANGPOW_LIBRARIES} ${FFTW_LIBRARIES} m)
 add_dependencies(ccl_static ccl)
 
+# Adds these extra depencies before building SWIG interface, to ensure that SWIG
+# will be built first if need, same goes for GSL (through ccl_static)
+set(SWIG_MODULE_ccllib_EXTRA_DEPS ccl_static)
+if(NOT SWIG_FOUND)
+  set(SWIG_MODULE_ccllib_EXTRA_DEPS ${SWIG_MODULE_ccllib_EXTRA_DEPS} SWIG)
+endif()
+
 # Builds swig python module in place
 if(${CMAKE_VERSION} VERSION_LESS "3.8.0")
   swig_add_module(ccllib python ccl.i)
@@ -21,6 +28,7 @@ else()
   swig_add_library(ccllib TYPE SHARED LANGUAGE python SOURCES ccl.i)
 endif()
 swig_link_libraries(ccllib ccl_static)
+
 if(APPLE)
     # Unpleasant subtelty for linking on osx
     set_target_properties(${SWIG_MODULE_ccllib_REAL_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
@@ -28,8 +36,3 @@ else(APPLE)
     swig_link_libraries(ccllib ${PYTHON_LIBRARIES})
 endif()
 set_target_properties(${SWIG_MODULE_ccllib_REAL_NAME} PROPERTIES SUFFIX .so)
-
-# Forces build of swig executable if not found
-if(NOT SWIG_FOUND)
-  add_dependencies(${SWIG_MODULE_ccllib_REAL_NAME} SWIG)
-endif()


### PR DESCRIPTION
This PR fixes #434 by updating the way the dependencies are specified for the SWIG targets. Long story short, the python wrapper target generated by swig is not covered by `add_dependencies(${SWIG_MODULE_ccllib_REAL_NAME} SWIG)`.
