### PR TITLE
Fix to travis yml to avoid OSX clash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,11 @@ matrix:
     python: 3.6
     env: TOXENV=py36
   - os: osx
+    osx_image: xcode8.3
     language: generic
     env: TOXENV=py27
   - os: osx
+    osx_image: xcode8.3
     language: generic
     env: TOXENV=py36
 install:


### PR DESCRIPTION
This PR is a small change to the travis yml to check that reverting to the old previous OSX results in travis passing our checks for the master branch. The fix is currently in the `halo_model` branch but we need it up an running asap. See #434 for further reference.