### PR TITLE
A few cleanups

### DIFF
--- a/include/ccl_core.h
+++ b/include/ccl_core.h
@@ -152,6 +152,9 @@ typedef enum ccl_mnu_convention {
 void ccl_cosmology_read_config(void);
 ccl_cosmology * ccl_cosmology_create(ccl_parameters params, ccl_configuration config);
 
+/* Internal function to set the status message safely. */
+void ccl_cosmology_set_status_message(ccl_cosmology * cosmo, const char * status_message);
+
 
 // Helper functions to create ccl_cosmology structs directly given a set of params
 ccl_cosmology * ccl_cosmology_create_with_params(double Omega_c, double Omega_b, double Omega_k,

--- a/include/ccl_core.h
+++ b/include/ccl_core.h
@@ -153,7 +153,7 @@ void ccl_cosmology_read_config(void);
 ccl_cosmology * ccl_cosmology_create(ccl_parameters params, ccl_configuration config);
 
 /* Internal function to set the status message safely. */
-void ccl_cosmology_set_status_message(ccl_cosmology * cosmo, const char * status_message);
+void ccl_cosmology_set_status_message(ccl_cosmology * cosmo, const char * status_message, ...);
 
 
 // Helper functions to create ccl_cosmology structs directly given a set of params

--- a/include/ccl_core.h
+++ b/include/ccl_core.h
@@ -11,10 +11,6 @@ extern "C" {
 #include "ccl_constants.h"
 #include <stdbool.h>
 
-// Macros for replacing relative paths
-#define EXPAND_STR(s) STRING(s)
-#define STRING(s) #s
-
 /**
  * Struct containing the parameters defining a cosmology
  */

--- a/src/ccl_background.c
+++ b/src/ccl_background.c
@@ -87,7 +87,7 @@ double ccl_rho_x(ccl_cosmology * cosmo, double a, ccl_species_x_label label, int
 
   default:
     *status = CCL_ERROR_PARAMETERS;
-    sprintf(cosmo->status_message,"ccl_background.c: ccl_rho_x(): Species %d not supported\n",label);
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_rho_x(): Species %d not supported\n",label);
     return 0.;
   }
 }
@@ -137,7 +137,7 @@ double ccl_omega_x(ccl_cosmology * cosmo, double a, ccl_species_x_label label, i
     
   default:
     *status = CCL_ERROR_PARAMETERS;
-    sprintf(cosmo->status_message,"ccl_background.c: ccl_omega_x(): Species %d not supported\n",label);
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_omega_x(): Species %d not supported\n",label);
     return 0.;
   }
 }
@@ -357,7 +357,7 @@ void ccl_cosmology_compute_distances(ccl_cosmology * cosmo, int *status)
 
   if(ccl_splines->A_SPLINE_MAX>1.) {
     *status = CCL_ERROR_COMPUTECHI; 
-    strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
     return;
   }
 
@@ -371,7 +371,7 @@ void ccl_cosmology_compute_distances(ccl_cosmology * cosmo, int *status)
       (a[na-1]>1.0)) {
       // old:    cosmo->status = CCL_ERROR_LINSPACE;
       *status = CCL_ERROR_LINSPACE; 
-      strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_distances(): Error creating first logarithmic and then linear spacing in a\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_distances(): Error creating first logarithmic and then linear spacing in a\n");
       return;
   }
 
@@ -382,7 +382,7 @@ void ccl_cosmology_compute_distances(ccl_cosmology * cosmo, int *status)
     free(a);
     // old:    cosmo->status=CCL_ERROR_MEMORY;
     *status=CCL_ERROR_MEMORY; 
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_distances(): ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_distances(): ran out of memory\n");
     return;
   }
   
@@ -401,7 +401,7 @@ void ccl_cosmology_compute_distances(ccl_cosmology * cosmo, int *status)
     gsl_spline_free(E);
     *status = CCL_ERROR_SPLINE; 
     //    cosmo->status = CCL_ERROR_SPLINE; 
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_distances(): Error creating  E(a) spline\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_distances(): Error creating  E(a) spline\n");
     return;
   }
 
@@ -414,7 +414,7 @@ void ccl_cosmology_compute_distances(ccl_cosmology * cosmo, int *status)
     free(y);
     gsl_spline_free(E);        
     *status = CCL_ERROR_INTEG; 
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_distances(): chi(a) integration error \n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_distances(): chi(a) integration error \n");
     return;
   }
 
@@ -427,7 +427,7 @@ void ccl_cosmology_compute_distances(ccl_cosmology * cosmo, int *status)
     gsl_spline_free(E);
     gsl_spline_free(chi);
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_distances(): Error creating  chi(a) spline\n"); 
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_distances(): Error creating  chi(a) spline\n"); 
     return;
   }
 
@@ -442,7 +442,7 @@ void ccl_cosmology_compute_distances(ccl_cosmology * cosmo, int *status)
     gsl_spline_free(E);
     gsl_spline_free(chi);
     *status = CCL_ERROR_LINSPACE; 
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_distances(): Error creating linear spacing in chi\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_distances(): Error creating linear spacing in chi\n");
     return;
   }
 
@@ -452,7 +452,7 @@ void ccl_cosmology_compute_distances(ccl_cosmology * cosmo, int *status)
     gsl_spline_free(E);
     gsl_spline_free(chi);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_distances(): ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_distances(): ran out of memory\n");
     return; 
   }
 
@@ -471,7 +471,7 @@ void ccl_cosmology_compute_distances(ccl_cosmology * cosmo, int *status)
     gsl_spline_free(E);
     gsl_spline_free(chi);
     *status = CCL_ERROR_ROOT; 
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_distances(): a(chi) root-finding error \n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_distances(): a(chi) root-finding error \n");
     return;
   }
 
@@ -485,7 +485,7 @@ void ccl_cosmology_compute_distances(ccl_cosmology * cosmo, int *status)
     gsl_spline_free(chi);
     gsl_spline_free(achi);
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_distances(): Error creating  a(chi) spline\n"); 
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_distances(): Error creating  a(chi) spline\n"); 
     return;
   }
 
@@ -514,7 +514,7 @@ void ccl_cosmology_compute_growth(ccl_cosmology * cosmo, int * status)
   // This is not valid for massive neutrinos; if we have massive neutrinos, exit.
   if (cosmo->params.N_nu_mass>0){
 	  *status = CCL_ERROR_NOT_IMPLEMENTED;
-	  strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_growth(): Support for the growth rate in cosmologies with massive neutrinos is not yet implemented.\n");
+	  ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_growth(): Support for the growth rate in cosmologies with massive neutrinos is not yet implemented.\n");
 	  return; 
   }
 	
@@ -530,7 +530,7 @@ void ccl_cosmology_compute_growth(ccl_cosmology * cosmo, int * status)
       (a[na-1]>1.0)
       ) {
     *status = CCL_ERROR_LINSPACE;
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_growth(): Error creating logarithmically and then linear spacing in a\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_growth(): Error creating logarithmically and then linear spacing in a\n");
     return;
   }
 
@@ -542,7 +542,7 @@ void ccl_cosmology_compute_growth(ccl_cosmology * cosmo, int * status)
     if(df_arr==NULL) {
       free(a);
       *status=CCL_ERROR_MEMORY;
-      strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_distances(): ran out of memory\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_distances(): ran out of memory\n");
       return;
     }
     //Generate spline for Delta f(z) that we will then interpolate into an array of a
@@ -555,7 +555,7 @@ void ccl_cosmology_compute_growth(ccl_cosmology * cosmo, int * status)
       free(df_arr);
       gsl_spline_free(df_z_spline);
       *status = CCL_ERROR_SPLINE;
-      strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_growth(): Error creating Delta f(z) spline\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_growth(): Error creating Delta f(z) spline\n");
       return;
     }
     for (int i=0; i<na; i++) {
@@ -576,7 +576,7 @@ void ccl_cosmology_compute_growth(ccl_cosmology * cosmo, int * status)
       free(df_arr);
       gsl_spline_free(df_z_spline);
       *status = CCL_ERROR_SPLINE;
-      strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_growth(): Error evaluating Delta f(z) spline\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_growth(): Error evaluating Delta f(z) spline\n");
       return;
     }
     gsl_spline_free(df_z_spline);
@@ -589,7 +589,7 @@ void ccl_cosmology_compute_growth(ccl_cosmology * cosmo, int * status)
       free(a);
       gsl_spline_free(df_a_spline);
       *status = CCL_ERROR_SPLINE;
-      strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_growth(): Error creating Delta f(a) spline\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_growth(): Error creating Delta f(a) spline\n");
       return;
     }
     
@@ -606,7 +606,7 @@ void ccl_cosmology_compute_growth(ccl_cosmology * cosmo, int * status)
   if(y==NULL) {
     free(a);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_distances(): ran out of memory\n"); 
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_distances(): ran out of memory\n"); 
     return;
   }
   double *y2 = malloc(sizeof(double)*na);
@@ -614,7 +614,7 @@ void ccl_cosmology_compute_growth(ccl_cosmology * cosmo, int * status)
     free(a);
     free(y);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_distances(): ran out of memory\n"); 
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_distances(): ran out of memory\n"); 
     return;
   }
   
@@ -652,11 +652,11 @@ void ccl_cosmology_compute_growth(ccl_cosmology * cosmo, int * status)
       gsl_integration_cquad_workspace_free(workspace);
     if (chistatus) {
       *status = CCL_ERROR_INTEG;
-      strcpy(cosmo->status_message ,"ccl_background.c: ccl_cosmology_compute_growth(): integral for linear growth factor didn't converge\n");
+      ccl_cosmology_set_status_message(cosmo ,"ccl_background.c: ccl_cosmology_compute_growth(): integral for linear growth factor didn't converge\n");
     }
     if(status_mg) {
       *status = CCL_ERROR_INTEG;
-      strcpy(cosmo->status_message ,"ccl_background.c: ccl_cosmology_compute_growth(): integral for MG growth factor didn't converge\n");
+      ccl_cosmology_set_status_message(cosmo ,"ccl_background.c: ccl_cosmology_compute_growth(): integral for MG growth factor didn't converge\n");
     }
     return;
   }
@@ -674,7 +674,7 @@ void ccl_cosmology_compute_growth(ccl_cosmology * cosmo, int * status)
     free(y2);
     gsl_spline_free(growth);
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_growth(): Error creating D(a) spline\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_growth(): Error creating D(a) spline\n");
     return;
   }
 
@@ -687,7 +687,7 @@ void ccl_cosmology_compute_growth(ccl_cosmology * cosmo, int * status)
     gsl_spline_free(growth);
     gsl_spline_free(fgrowth);
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_growth(): Error creating f(a) spline\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_cosmology_compute_growth(): Error creating f(a) spline\n");
     return;
   }
 
@@ -722,7 +722,7 @@ double ccl_h_over_h0(ccl_cosmology * cosmo, double a, int* status)
   if(gslstatus != GSL_SUCCESS) {
     ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_h_over_h0():");
     *status = gslstatus;
-    strcpy(cosmo->status_message, "ccl_background.c: ccl_h_over_h0(): Scale factor outside interpolation range.\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_h_over_h0(): Scale factor outside interpolation range.\n");
     return NAN;    
   }
   
@@ -742,7 +742,7 @@ void ccl_h_over_h0s(ccl_cosmology * cosmo, int na, double a[], double output[], 
     if(gslstatus != GSL_SUCCESS) {
       ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_h_over_h0s():");
       *status |= gslstatus;
-      strcpy(cosmo->status_message, "ccl_background.c: ccl_h_over_h0s(): Scale factor outside interpolation range.\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_h_over_h0s(): Scale factor outside interpolation range.\n");
       output[i]= NAN;    
     }
   }
@@ -756,7 +756,7 @@ double ccl_comoving_radial_distance(ccl_cosmology * cosmo, double a, int * statu
   }
   else if(a>1.) {
     *status = CCL_ERROR_COMPUTECHI; 
-    strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
     ccl_check_status(cosmo,status);
     return 0.;
   }
@@ -771,7 +771,7 @@ double ccl_comoving_radial_distance(ccl_cosmology * cosmo, double a, int * statu
     if(gslstatus != GSL_SUCCESS) {
       ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_comoving_radial_distance():");
       *status = gslstatus;
-      strcpy(cosmo->status_message, "ccl_background.c: ccl_comoving_radial_distance(): Scale factor outside interpolation range.\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_comoving_radial_distance(): Scale factor outside interpolation range.\n");
       return NAN;
     }
     return crd;
@@ -790,7 +790,7 @@ void ccl_comoving_radial_distances(ccl_cosmology * cosmo, int na, double a[], do
       output[i]=0.;
     else if(a[i]>1.) {
       *status = CCL_ERROR_COMPUTECHI; 
-      strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
       ccl_check_status(cosmo,status);
     }
     else {
@@ -798,7 +798,7 @@ void ccl_comoving_radial_distances(ccl_cosmology * cosmo, int na, double a[], do
       if(gslstatus != GSL_SUCCESS) {
         ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_comoving_radial_distances():");
         *status |= gslstatus;
-        strcpy(cosmo->status_message, "ccl_background.c: ccl_comoving_radial_distances(): Scale factor outside interpolation range.\n");
+        ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_comoving_radial_distances(): Scale factor outside interpolation range.\n");
         output[i] = NAN;
       }
     }
@@ -820,7 +820,7 @@ double ccl_sinn(ccl_cosmology *cosmo, double chi, int *status)
     return chi;
   default:
     *status = CCL_ERROR_PARAMETERS;
-    sprintf(cosmo->status_message,"ccl_background.c: ccl_sinn: ill-defined cosmo->params.k_sign = %d",
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_sinn: ill-defined cosmo->params.k_sign = %d",
 	    cosmo->params.k_sign);
     return NAN;
   }
@@ -833,7 +833,7 @@ double ccl_comoving_angular_distance(ccl_cosmology * cosmo, double a, int* statu
   }
   else if(a>1.) {
     *status = CCL_ERROR_COMPUTECHI;
-    strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
     ccl_check_status(cosmo,status);
     return 0.;
   }
@@ -849,7 +849,7 @@ double ccl_comoving_angular_distance(ccl_cosmology * cosmo, double a, int* statu
     if(gslstatus != GSL_SUCCESS) {
       ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_comoving_angular_distance():");
       *status |= gslstatus;
-      strcpy(cosmo->status_message, "ccl_background.c: ccl_comoving_angular_distance(): Scale factor outside interpolation range.\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_comoving_angular_distance(): Scale factor outside interpolation range.\n");
       return NAN;      
     }
     return ccl_sinn(cosmo,chi,status);
@@ -870,7 +870,7 @@ void ccl_comoving_angular_distances(ccl_cosmology * cosmo, int na, double a[],
       output[i]=0.;
     else if(a[i]>1.) {
       *status = CCL_ERROR_COMPUTECHI;
-      strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
       ccl_check_status(cosmo,status);
     }
     else {
@@ -879,7 +879,7 @@ void ccl_comoving_angular_distances(ccl_cosmology * cosmo, int na, double a[],
       if(gslstatus != GSL_SUCCESS) {
         ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_comoving_angular_distances():");
         *status |= gslstatus;
-        strcpy(cosmo->status_message, "ccl_background.c: ccl_comoving_angular_distances(): Scale factor outside interpolation range.\n");
+        ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_comoving_angular_distances(): Scale factor outside interpolation range.\n");
         output[i] =  NAN;      
       }
     }
@@ -893,7 +893,7 @@ double ccl_luminosity_distance(ccl_cosmology * cosmo, double a, int* status)
   }
   else if(a>1.) {
     *status = CCL_ERROR_COMPUTECHI;
-    strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
     ccl_check_status(cosmo,status);
     return 0.;
   }
@@ -917,7 +917,7 @@ void ccl_luminosity_distances(ccl_cosmology * cosmo, int na, double a[], double 
       output[i] = 0.;
     else if (a[i] > 1.) {
       *status = CCL_ERROR_COMPUTECHI;
-      strcpy(cosmo->status_message, "ccl_background.c: scale factor cannot be larger than 1.\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_background.c: scale factor cannot be larger than 1.\n");
       ccl_check_status(cosmo, status);
     }
     else
@@ -929,12 +929,12 @@ double ccl_distance_modulus(ccl_cosmology * cosmo, double a, int* status)
   
   if((a > (1.0 - 1.e-8)) && (a<=1.0)) {
     *status = CCL_ERROR_COMPUTECHI;
-    strcpy(cosmo->status_message,"ccl_background.c: distance_modulus undefined for a=1.\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: distance_modulus undefined for a=1.\n");
     ccl_check_status(cosmo,status);
     return NAN;
   } else if(a>1.) {
     *status = CCL_ERROR_COMPUTECHI;
-    strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
     ccl_check_status(cosmo,status);
     return NAN;
   } else {
@@ -956,12 +956,12 @@ void ccl_distance_moduli(ccl_cosmology * cosmo, int na, double a[], double outpu
   for (int i=0; i<na; i++) {
     if((a[i] > (1. - 1.e-8)) && (a[i]<=1.)) {
       *status = CCL_ERROR_COMPUTECHI;
-      strcpy(cosmo->status_message,"ccl_background.c: distance_modulus undefined for a=1.\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: distance_modulus undefined for a=1.\n");
       ccl_check_status(cosmo,status);
     }
     else if(a[i]>1.) {
       *status = CCL_ERROR_COMPUTECHI;
-      strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
       ccl_check_status(cosmo,status);
     }
     else output[i]=5*log10(ccl_luminosity_distance(cosmo, a[i], status))+25;
@@ -976,7 +976,7 @@ double ccl_scale_factor_of_chi(ccl_cosmology * cosmo, double chi, int * status)
   }
   else if(chi<0.) {
     *status = CCL_ERROR_COMPUTECHI;
-    strcpy(cosmo->status_message,"ccl_background.c: distance cannot be smaller than 0.\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: distance cannot be smaller than 0.\n");
     ccl_check_status(cosmo,status);
     return 0.;
   }
@@ -1008,7 +1008,7 @@ void ccl_scale_factor_of_chis(ccl_cosmology * cosmo, int nchi, double chi[], dou
       output[i]=1.;
     else if(chi[i]<0.) {
       *status = CCL_ERROR_COMPUTECHI;
-      strcpy(cosmo->status_message,"ccl_background.c: distance cannot be less than 0.\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: distance cannot be less than 0.\n");
       ccl_check_status(cosmo,status);
     }
     else
@@ -1027,7 +1027,7 @@ double ccl_growth_factor(ccl_cosmology * cosmo, double a, int * status)
   }
   else if(a>1.) {
     *status = CCL_ERROR_COMPUTECHI;
-    strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
     ccl_check_status(cosmo,status);
     return 0.;
   }
@@ -1042,7 +1042,7 @@ double ccl_growth_factor(ccl_cosmology * cosmo, double a, int * status)
       if(gslstatus != GSL_SUCCESS) {
         ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_growth_factor():");
         *status |= gslstatus;
-        strcpy(cosmo->status_message, "ccl_background.c: ccl_growth_factor(): Scale factor outside interpolation range.\n");
+        ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_growth_factor(): Scale factor outside interpolation range.\n");
         return NAN;      
       }
       return D;
@@ -1064,7 +1064,7 @@ void ccl_growth_factors(ccl_cosmology * cosmo, int na, double a[], double output
   for (int i=0; i<na; i++) {
     if(a[i]>1.) {
       *status = CCL_ERROR_COMPUTECHI;
-      strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
       ccl_check_status(cosmo,status);
     }
     else {
@@ -1073,7 +1073,7 @@ void ccl_growth_factors(ccl_cosmology * cosmo, int na, double a[], double output
         if(gslstatus != GSL_SUCCESS) {
           ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_growth_factors():");
           *status |= gslstatus;
-          strcpy(cosmo->status_message, "ccl_background.c: ccl_growth_factors(): Scale factor outside interpolation range.\n");
+          ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_growth_factors(): Scale factor outside interpolation range.\n");
           output[i] = NAN;        
         }
       } 
@@ -1088,7 +1088,7 @@ double ccl_growth_factor_unnorm(ccl_cosmology * cosmo, double a, int * status)
 {	
   if(a>1.) {
     *status = CCL_ERROR_COMPUTECHI;
-    strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
     ccl_check_status(cosmo,status);
     return 0.; 
   }
@@ -1106,7 +1106,7 @@ double ccl_growth_factor_unnorm(ccl_cosmology * cosmo, double a, int * status)
       if(gslstatus != GSL_SUCCESS) {
         ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_growth_factor_unnorm():");
         *status |= gslstatus;
-        strcpy(cosmo->status_message, "ccl_background.c: ccl_growth_factor_unnorm(): Scale factor outside interpolation range.\n");
+        ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_growth_factor_unnorm(): Scale factor outside interpolation range.\n");
         return NAN;      
       }
       return cosmo->data.growth0*D;
@@ -1128,7 +1128,7 @@ void ccl_growth_factors_unnorm(ccl_cosmology * cosmo, int na, double a[], double
   for (int i=0; i<na; i++) {
     if(a[i]>1.) {
       *status = CCL_ERROR_COMPUTECHI;
-      strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
       ccl_check_status(cosmo,status);
     }
     else {
@@ -1138,7 +1138,7 @@ void ccl_growth_factors_unnorm(ccl_cosmology * cosmo, int na, double a[], double
         if(gslstatus != GSL_SUCCESS) {
           ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_growth_factors_unnorm():");
           *status |= gslstatus;
-          strcpy(cosmo->status_message, "ccl_background.c: ccl_growth_factors_unnorm(): Scale factor outside interpolation range.\n");
+          ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_growth_factors_unnorm(): Scale factor outside interpolation range.\n");
           output[i] = NAN;        
         }
       } 
@@ -1153,7 +1153,7 @@ double ccl_growth_rate(ccl_cosmology * cosmo, double a, int * status)
 {
   if(a>1.) {
     *status = CCL_ERROR_COMPUTECHI;
-    strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
     ccl_check_status(cosmo,status);
     return 0.;
   }
@@ -1169,7 +1169,7 @@ double ccl_growth_rate(ccl_cosmology * cosmo, double a, int * status)
       if(gslstatus != GSL_SUCCESS) {
         ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_growth_rate():");
         *status |= gslstatus;
-        strcpy(cosmo->status_message, "ccl_background.c: ccl_growth_rate(): Scale factor outside interpolation range.\n");
+        ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_growth_rate(): Scale factor outside interpolation range.\n");
         return NAN;      
       }
       return g;
@@ -1190,7 +1190,7 @@ void ccl_growth_rates(ccl_cosmology * cosmo, int na, double a[], double output[]
   for (int i=0; i<na; i++) {
     if(a[i]>1.) {
       *status = CCL_ERROR_COMPUTECHI;
-      strcpy(cosmo->status_message,"ccl_background.c: scale factor cannot be larger than 1.\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_background.c: scale factor cannot be larger than 1.\n");
       ccl_check_status(cosmo,status);
     }
     else {

--- a/src/ccl_cls.c
+++ b/src/ccl_cls.c
@@ -73,7 +73,7 @@ CCL_ClWorkspace *ccl_cl_workspace_default(int lmax,int l_limber,int non_limber_m
   if(w==NULL) {
     *status=CCL_ERROR_MEMORY;
     //Can't access cosmology object
-    //    strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_workspace_default(); memory allocation\n");
+    //    ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_workspace_default(); memory allocation\n");
     return NULL;
   }
 
@@ -91,7 +91,7 @@ CCL_ClWorkspace *ccl_cl_workspace_default(int lmax,int l_limber,int non_limber_m
     free(w);
     *status=CCL_ERROR_INCONSISTENT;
     //Can't access cosmology object
-    //    strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_workspace_default(); unknown non-limber method\n");
+    //    ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_workspace_default(); unknown non-limber method\n");
     return NULL;
   }
   w->nlimb_method=non_limber_method;
@@ -120,7 +120,7 @@ CCL_ClWorkspace *ccl_cl_workspace_default(int lmax,int l_limber,int non_limber_m
     free(w);
     *status=CCL_ERROR_MEMORY;
     //Can't access cosmology object
-    //    strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_workspace_default(); memory allocation\n");
+    //    ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_workspace_default(); memory allocation\n");
     return NULL;
   }
 
@@ -302,14 +302,14 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
   if(clt==NULL) {
 
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_tracer(): memory allocation\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_tracer(): memory allocation\n");
     return NULL;
   }
 
   if ( ((cosmo->params.N_nu_mass)>0) && tracer_type==CL_TRACER_NC && has_rsd){
 	  free(clt);
 	  *status=CCL_ERROR_NOT_IMPLEMENTED;
-	  strcpy(cosmo->status_message, "ccl_cls.c: ccl_cl_tracer_new(): Number counts tracers with rsd not yet implemented in cosmologies with massive neutrinos.");
+	  ccl_cosmology_set_status_message(cosmo, "ccl_cls.c: ccl_cl_tracer_new(): Number counts tracers with rsd not yet implemented in cosmologies with massive neutrinos.");
 	  return NULL;
   }
 
@@ -327,7 +327,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
     if(clt->spl_nz==NULL) {
       free(clt);
       *status=CCL_ERROR_SPLINE;
-      strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_tracer(): error initializing spline for N(z)\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_tracer(): error initializing spline for N(z)\n");
       return NULL;
     }
 
@@ -339,7 +339,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
       ccl_spline_free(clt->spl_nz);
       free(clt);
       *status=CCL_ERROR_MEMORY;
-      strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_tracer(): memory allocation\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_tracer(): memory allocation\n");
       return NULL;
     }
 
@@ -356,7 +356,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
       ccl_spline_free(clt->spl_nz);
       free(clt);
       *status=CCL_ERROR_INTEG;
-      strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_tracer(): integration error when normalizing N(z)\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_tracer(): integration error when normalizing N(z)\n");
       return NULL;
     }
     for(int ii=0;ii<nz_n;ii++)
@@ -367,7 +367,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
     if(clt->spl_nz==NULL) {
       free(clt);
       *status=CCL_ERROR_SPLINE;
-      strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_tracer(): error initializing normalized spline for N(z)\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_tracer(): error initializing normalized spline for N(z)\n");
       return NULL;
     }
 
@@ -378,7 +378,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
 	ccl_spline_free(clt->spl_nz);
 	free(clt);
 	*status=CCL_ERROR_SPLINE;
-	strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_tracer(): error initializing spline for b(z)\n");
+	ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_tracer(): error initializing spline for b(z)\n");
 	return NULL;
       }
       clt->has_rsd=has_rsd;
@@ -401,7 +401,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
 	  ccl_spline_free(clt->spl_bz);
 	  free(clt);
 	  *status=CCL_ERROR_SPLINE;
-	  strcpy(cosmo->status_message,
+	  ccl_cosmology_set_status_message(cosmo,
 		 "ccl_cls.c: ccl_cl_tracer(): error initializing spline for s(z)\n");
 	  return NULL;
 	}
@@ -415,7 +415,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
 	  ccl_spline_free(clt->spl_sz);
 	  free(clt);
 	  *status=CCL_ERROR_LINSPACE;
-	  strcpy(cosmo->status_message,
+	  ccl_cosmology_set_status_message(cosmo,
 		 "ccl_cls.c: ccl_cl_tracer(): Error creating linear spacing in chi\n");
 	  return NULL;
 	}
@@ -427,7 +427,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
 	  ccl_spline_free(clt->spl_sz);
 	  free(clt);
 	  *status=CCL_ERROR_MEMORY;
-	  strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_tracer(): memory allocation\n");
+	  ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_tracer(): memory allocation\n");
 	  return NULL;
 	}
 
@@ -441,7 +441,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
 	  ccl_spline_free(clt->spl_sz);
 	  free(clt);
 	  *status=CCL_ERROR_INTEG;
-	  strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_tracer(): error computing lensing window\n");
+	  ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_tracer(): error computing lensing window\n");
 	  return NULL;
 	}
 
@@ -454,7 +454,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
 	  ccl_spline_free(clt->spl_sz);
 	  free(clt);
 	  *status=CCL_ERROR_SPLINE;
-	  strcpy(cosmo->status_message,
+	  ccl_cosmology_set_status_message(cosmo,
 		 "ccl_cls.c: ccl_cl_tracer(): error initializing spline for lensing window\n");
 	  return NULL;
 	}
@@ -480,7 +480,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
 	ccl_spline_free(clt->spl_nz);
 	free(clt);
 	*status=CCL_ERROR_LINSPACE;
-	strcpy(cosmo->status_message,
+	ccl_cosmology_set_status_message(cosmo,
 	       "ccl_cls.c: ccl_cl_tracer(): Error creating linear spacing in chi\n");
 	return NULL;
       }
@@ -490,7 +490,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
 	ccl_spline_free(clt->spl_nz);
 	free(clt);
 	*status=CCL_ERROR_MEMORY;
-	strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_tracer(): memory allocation\n");
+	ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_tracer(): memory allocation\n");
 	return NULL;
       }
 
@@ -502,7 +502,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
 	ccl_spline_free(clt->spl_nz);
 	free(clt);
 	*status=CCL_ERROR_INTEG;
-	strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_tracer(): error computing lensing window\n");
+	ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_tracer(): error computing lensing window\n");
 	return NULL;
       }
 
@@ -513,7 +513,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
 	ccl_spline_free(clt->spl_nz);
 	free(clt);
 	*status=CCL_ERROR_SPLINE;
-	strcpy(cosmo->status_message,
+	ccl_cosmology_set_status_message(cosmo,
 	       "ccl_cls.c: ccl_cl_tracer(): error initializing spline for lensing window\n");
 	return NULL;
       }
@@ -526,7 +526,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
 	  ccl_spline_free(clt->spl_nz);
 	  free(clt);
 	  *status=CCL_ERROR_SPLINE;
-	  strcpy(cosmo->status_message,
+	  ccl_cosmology_set_status_message(cosmo,
 		 "ccl_cls.c: ccl_cl_tracer(): error initializing spline for rf(z)\n");
 	  return NULL;
 	}
@@ -536,7 +536,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
 	  ccl_spline_free(clt->spl_nz);
 	  free(clt);
 	  *status=CCL_ERROR_SPLINE;
-	  strcpy(cosmo->status_message,
+	  ccl_cosmology_set_status_message(cosmo,
 		 "ccl_cls.c: ccl_cl_tracer(): error initializing spline for ba(z)\n");
 	  return NULL;
 	}
@@ -550,7 +550,7 @@ static CCL_ClTracer *cl_tracer(ccl_cosmology *cosmo,int tracer_type,
   }
   else {
     *status=CCL_ERROR_INCONSISTENT;
-    strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_tracer(): unknown tracer type\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_tracer(): unknown tracer type\n");
     return NULL;
   }
 
@@ -963,14 +963,14 @@ static void compute_transfer(CCL_ClTracer *clt,ccl_cosmology *cosmo,CCL_ClWorksp
   clt->n_k=(int *)malloc(clt->n_ls*sizeof(int));
   if(clt->n_k==NULL) {
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_cls.c: compute_transfer(): memory allocation\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: compute_transfer(): memory allocation\n");
     return;
   }
   clt->spl_transfer=(SplPar **)malloc(clt->n_ls*sizeof(SplPar *));
   if(clt->spl_transfer==NULL) {
     free(clt->n_k);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_cls.c: compute_transfer(): memory allocation\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: compute_transfer(): memory allocation\n");
     return;
   }
 
@@ -981,7 +981,7 @@ static void compute_transfer(CCL_ClTracer *clt,ccl_cosmology *cosmo,CCL_ClWorksp
     double *lkarr=get_lkarr(cosmo,w,l,chimin,chimax,&nk,status);
     if(lkarr==NULL) {
       *status=CCL_ERROR_MEMORY;
-      strcpy(cosmo->status_message,"ccl_cls.c: compute_transfer(): memory allocation\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: compute_transfer(): memory allocation\n");
       break;
     }
 
@@ -989,7 +989,7 @@ static void compute_transfer(CCL_ClTracer *clt,ccl_cosmology *cosmo,CCL_ClWorksp
     if(tkarr==NULL) {
       free(lkarr);
       *status=CCL_ERROR_MEMORY;
-      strcpy(cosmo->status_message,"ccl_cls.c: compute_transfer(): memory allocation\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: compute_transfer(): memory allocation\n");
       break;
     }
     clt->n_k[il]=nk;
@@ -1010,7 +1010,7 @@ static void compute_transfer(CCL_ClTracer *clt,ccl_cosmology *cosmo,CCL_ClWorksp
       free(lkarr);
       free(tkarr);
       *status=CCL_ERROR_MEMORY;
-      strcpy(cosmo->status_message,"ccl_cls.c: compute_transfer(): memory allocation\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: compute_transfer(): memory allocation\n");
       break;
     }
     free(lkarr);
@@ -1155,7 +1155,7 @@ static double ccl_angular_cl_native(ccl_cosmology *cosmo,CCL_ClWorkspace *cw,int
     // If an error status was already set, don't overwrite it.
     if(*status == 0){
         *status=CCL_ERROR_INTEG;
-        strcpy(cosmo->status_message,"ccl_cls.c: ccl_angular_cl_native(): error integrating over k\n");
+        ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_angular_cl_native(): error integrating over k\n");
     }
     return -1;
   }
@@ -1173,7 +1173,7 @@ void ccl_angular_cls(ccl_cosmology *cosmo,CCL_ClWorkspace *w,
   for(ii=0;ii<nl_out;ii++) {
     if(l_out[ii]>w->lmax) {
       *status=CCL_ERROR_SPLINE_EV;
-      strcpy(cosmo->status_message,"ccl_cls.c: ccl_angular_cls(); "
+      ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_angular_cls(); "
 	     "requested l beyond range allowed by workspace\n");
       return;
     }
@@ -1183,14 +1183,14 @@ void ccl_angular_cls(ccl_cosmology *cosmo,CCL_ClWorkspace *w,
   double *l_nodes=(double *)malloc(w->n_ls*sizeof(double));
   if(l_nodes==NULL) {
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_cls.c: ccl_angular_cls(); memory allocation\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_angular_cls(); memory allocation\n");
     return;
   }
   double *cl_nodes=(double *)malloc(w->n_ls*sizeof(double));
   if(cl_nodes==NULL) {
     free(l_nodes);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_angular_cls(); memory allocation\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_angular_cls(); memory allocation\n");
     return;
   }
   for(ii=0;ii<w->n_ls;ii++)
@@ -1232,7 +1232,7 @@ void ccl_angular_cls(ccl_cosmology *cosmo,CCL_ClWorkspace *w,
   if(spcl_nodes==NULL) {
     free(cl_nodes);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_cls.c: ccl_cl_angular_cls(); memory allocation\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_cls.c: ccl_cl_angular_cls(); memory allocation\n");
     return;
   }
   for(ii=0;ii<nl_out;ii++)
@@ -1267,7 +1267,7 @@ double ccl_get_tracer_fa(ccl_cosmology *cosmo,CCL_ClTracer *clt,double a,int fun
 
   if(check_clt_fa_inconsistency(clt,func_code)) {
     *status=CCL_ERROR_INCONSISTENT;
-    sprintf(cosmo->status_message ,"ccl_cls.c: inconsistent combination of tracer and internal function to be evaluated");
+    ccl_cosmology_set_status_message(cosmo ,"ccl_cls.c: inconsistent combination of tracer and internal function to be evaluated");
     return -1;
   }
 
@@ -1299,7 +1299,7 @@ int ccl_get_tracer_fas(ccl_cosmology *cosmo,CCL_ClTracer *clt,int na,double *a,d
 
   if(check_clt_fa_inconsistency(clt,func_code)) {
     *status=CCL_ERROR_INCONSISTENT;
-    sprintf(cosmo->status_message ,"ccl_cls.c: inconsistent combination of tracer and internal function to be evaluated");
+    ccl_cosmology_set_status_message(cosmo ,"ccl_cls.c: inconsistent combination of tracer and internal function to be evaluated");
     return -1;
   }
 

--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -85,49 +85,61 @@ void ccl_cosmology_read_config(void)
     memcpy(ccl_gsl, &default_gsl_params, sizeof(ccl_gsl_params));
   }
 
+
+#define MATCH(s, action) if (0 == strcmp(var_name, s)) { action ; continue;} do{} while(0)
+
+  int lineno = 0;
   while(! feof(fconfig)) {
     rtn = fgets(buf, CONFIG_LINE_BUFFER_SIZE, fconfig);
+    lineno ++;
+
     if (buf[0]==';' || buf[0]=='[' || buf[0]=='\n') {
       continue;
     }
     else {
       sscanf(buf, "%99[^=]=%le\n",var_name, &var_dbl);
+
       // Spline parameters
-      if(strcmp(var_name,"A_SPLINE_NA")==0) ccl_splines->A_SPLINE_NA=(int) var_dbl; 
-      if(strcmp(var_name,"A_SPLINE_NLOG")==0) ccl_splines->A_SPLINE_NLOG=(int) var_dbl;
-      if(strcmp(var_name,"A_SPLINE_MINLOG")==0) ccl_splines->A_SPLINE_MINLOG=var_dbl;
-      if(strcmp(var_name,"A_SPLINE_MIN")==0) ccl_splines->A_SPLINE_MIN=var_dbl;
-      if(strcmp(var_name,"A_SPLINE_MINLOG_PK")==0) ccl_splines->A_SPLINE_MINLOG_PK=var_dbl;
-      if(strcmp(var_name,"A_SPLINE_MIN_PK")==0) ccl_splines->A_SPLINE_MIN_PK=var_dbl;
-      if(strcmp(var_name,"A_SPLINE_MAX")==0) ccl_splines->A_SPLINE_MAX=var_dbl;
-      if(strcmp(var_name,"LOGM_SPLINE_DELTA")==0) ccl_splines->LOGM_SPLINE_DELTA=var_dbl;
-      if(strcmp(var_name,"LOGM_SPLINE_NM")==0) ccl_splines->LOGM_SPLINE_NM=(int) var_dbl;
-      if(strcmp(var_name,"LOGM_SPLINE_MIN")==0) ccl_splines->LOGM_SPLINE_MIN=var_dbl;
-      if(strcmp(var_name,"LOGM_SPLINE_MAX")==0) ccl_splines->LOGM_SPLINE_MAX=var_dbl;
-      if(strcmp(var_name,"A_SPLINE_NA_PK")==0) ccl_splines->A_SPLINE_NA_PK=(int) var_dbl;
-      if(strcmp(var_name,"A_SPLINE_NLOG_PK")==0) ccl_splines->A_SPLINE_NLOG_PK=(int) var_dbl;
-      if(strcmp(var_name,"K_MAX_SPLINE")==0) ccl_splines->K_MAX_SPLINE=var_dbl;
-      if(strcmp(var_name,"K_MAX")==0) ccl_splines->K_MAX=var_dbl;
-      if(strcmp(var_name,"K_MIN")==0) ccl_splines->K_MIN=var_dbl;
-      if(strcmp(var_name,"N_K")==0) ccl_splines->N_K=(int) var_dbl;
+      MATCH("A_SPLINE_NA", ccl_splines->A_SPLINE_NA=(int) var_dbl);
+      MATCH("A_SPLINE_NLOG", ccl_splines->A_SPLINE_NLOG=(int) var_dbl);
+      MATCH("A_SPLINE_MINLOG", ccl_splines->A_SPLINE_MINLOG=var_dbl);
+      MATCH("A_SPLINE_MIN", ccl_splines->A_SPLINE_MIN=var_dbl);
+      MATCH("A_SPLINE_MINLOG_PK", ccl_splines->A_SPLINE_MINLOG_PK=var_dbl);
+      MATCH("A_SPLINE_MIN_PK", ccl_splines->A_SPLINE_MIN_PK=var_dbl);
+      MATCH("A_SPLINE_MAX", ccl_splines->A_SPLINE_MAX=var_dbl);
+      MATCH("LOGM_SPLINE_DELTA", ccl_splines->LOGM_SPLINE_DELTA=var_dbl);
+      MATCH("LOGM_SPLINE_NM", ccl_splines->LOGM_SPLINE_NM=(int) var_dbl);
+      MATCH("LOGM_SPLINE_MIN", ccl_splines->LOGM_SPLINE_MIN=var_dbl);
+      MATCH("LOGM_SPLINE_MAX", ccl_splines->LOGM_SPLINE_MAX=var_dbl);
+      MATCH("A_SPLINE_NA_PK", ccl_splines->A_SPLINE_NA_PK=(int) var_dbl);
+      MATCH("A_SPLINE_NLOG_PK", ccl_splines->A_SPLINE_NLOG_PK=(int) var_dbl);
+      MATCH("K_MAX_SPLINE", ccl_splines->K_MAX_SPLINE=var_dbl);
+      MATCH("K_MAX", ccl_splines->K_MAX=var_dbl);
+      MATCH("K_MIN", ccl_splines->K_MIN=var_dbl);
+      MATCH("N_K", ccl_splines->N_K=(int) var_dbl);
+
       // 3dcorr parameters
-      if(strcmp(var_name,"N_K_3DCOR")==0) ccl_splines->N_K_3DCOR=(int) var_dbl;     
+      MATCH("N_K_3DCOR", ccl_splines->N_K_3DCOR=(int) var_dbl);
 
       // GSL parameters
-      if(strcmp(var_name,"GSL_EPSREL")==0) ccl_gsl->EPSREL=var_dbl;
-      if(strcmp(var_name,"GSL_N_ITERATION")==0) ccl_gsl->N_ITERATION=(size_t) var_dbl;
-      if(strcmp(var_name,"GSL_INTEGRATION_GAUSS_KRONROD_POINTS")==0) ccl_gsl->INTEGRATION_GAUSS_KRONROD_POINTS=(int) var_dbl;
-      if(strcmp(var_name,"GSL_INTEGRATION_EPSREL")==0) ccl_gsl->INTEGRATION_EPSREL=var_dbl;
-      if(strcmp(var_name,"GSL_INTEGRATION_DISTANCE_EPSREL")==0) ccl_gsl->INTEGRATION_DISTANCE_EPSREL=var_dbl;
-      if(strcmp(var_name,"GSL_INTEGRATION_DNDZ_EPSREL")==0) ccl_gsl->INTEGRATION_DNDZ_EPSREL=var_dbl;
-      if(strcmp(var_name,"GSL_INTEGRATION_SIGMAR_EPSREL")==0) ccl_gsl->INTEGRATION_SIGMAR_EPSREL=var_dbl;
-      if(strcmp(var_name,"GSL_INTEGRATION_NU_EPSREL")==0) ccl_gsl->INTEGRATION_NU_EPSREL=var_dbl;
-      if(strcmp(var_name,"GSL_INTEGRATION_NU_EPSABS")==0) ccl_gsl->INTEGRATION_NU_EPSABS=var_dbl;
-      if(strcmp(var_name,"GSL_INTEGRATION_LIMBER_GAUSS_KRONROD_POINTS")==0) ccl_gsl->INTEGRATION_LIMBER_GAUSS_KRONROD_POINTS=(int) var_dbl;
-      if(strcmp(var_name,"GSL_INTEGRATION_LIMBER_EPSREL")==0) ccl_gsl->INTEGRATION_LIMBER_EPSREL=var_dbl;
-      if(strcmp(var_name,"GSL_ROOT_EPSREL")==0) ccl_gsl->ROOT_EPSREL=var_dbl;
-      if(strcmp(var_name,"GSL_ROOT_N_ITERATION")==0) ccl_gsl->ROOT_N_ITERATION=(int) var_dbl;
-      if(strcmp(var_name,"GSL_ODE_GROWTH_EPSREL")==0) ccl_gsl->ODE_GROWTH_EPSREL=var_dbl;
+      MATCH("GSL_EPSREL", ccl_gsl->EPSREL=var_dbl);
+      MATCH("GSL_N_ITERATION", ccl_gsl->N_ITERATION=(size_t) var_dbl);
+      MATCH("GSL_INTEGRATION_GAUSS_KRONROD_POINTS", ccl_gsl->INTEGRATION_GAUSS_KRONROD_POINTS=(int) var_dbl);
+      MATCH("GSL_INTEGRATION_EPSREL", ccl_gsl->INTEGRATION_EPSREL=var_dbl);
+      MATCH("GSL_INTEGRATION_DISTANCE_EPSREL", ccl_gsl->INTEGRATION_DISTANCE_EPSREL=var_dbl);
+      MATCH("GSL_INTEGRATION_DNDZ_EPSREL", ccl_gsl->INTEGRATION_DNDZ_EPSREL=var_dbl);
+      MATCH("GSL_INTEGRATION_SIGMAR_EPSREL", ccl_gsl->INTEGRATION_SIGMAR_EPSREL=var_dbl);
+      MATCH("GSL_INTEGRATION_NU_EPSREL", ccl_gsl->INTEGRATION_NU_EPSREL=var_dbl);
+      MATCH("GSL_INTEGRATION_NU_EPSABS", ccl_gsl->INTEGRATION_NU_EPSABS=var_dbl);
+      MATCH("GSL_INTEGRATION_LIMBER_GAUSS_KRONROD_POINTS", ccl_gsl->INTEGRATION_LIMBER_GAUSS_KRONROD_POINTS=(int) var_dbl);
+      MATCH("GSL_INTEGRATION_LIMBER_EPSREL", ccl_gsl->INTEGRATION_LIMBER_EPSREL=var_dbl);
+      MATCH("GSL_ROOT_EPSREL", ccl_gsl->ROOT_EPSREL=var_dbl);
+      MATCH("GSL_ROOT_N_ITERATION", ccl_gsl->ROOT_N_ITERATION=(int) var_dbl);
+      MATCH("GSL_ODE_GROWTH_EPSREL", ccl_gsl->ODE_GROWTH_EPSREL=var_dbl);
+
+      char msg[256];
+      snprintf(msg, 256, "ccl_core.c: Failed to parse config file at line %d: %s", lineno, buf);
+      ccl_raise_exception(CCL_ERROR_MISSING_CONFIG_FILE, msg);
     }
   }
 

--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -3,6 +3,7 @@
 #include "ccl_utils.h"
 #include "ccl_constants.h"
 #include <stdlib.h>
+#include <stdarg.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
@@ -189,7 +190,7 @@ ccl_cosmology * ccl_cosmology_create(ccl_parameters params, ccl_configuration co
   cosmo->computed_sigma = false;
   cosmo->computed_hmfparams = false;
   cosmo->status = 0;
-  strcpy(cosmo->status_message, "");
+  ccl_cosmology_set_status_message(cosmo, "");
   
   return cosmo;
 }
@@ -795,11 +796,13 @@ void ccl_data_free(ccl_data * data)
 INPUT: ccl_cosmology struct, status_string
 TASK: set the status message safely.
 */
-void ccl_cosmology_set_status_message(ccl_cosmology * cosmo, const char * message)
+void ccl_cosmology_set_status_message(ccl_cosmology * cosmo, const char * message, ...)
 {
   const int trunc = 480; /* must be < 500 - 4 */
-
-  strncpy(cosmo->status_message, message, trunc);
+  va_list va;
+  va_start(va, message);
+  vsnprintf(cosmo->status_message, trunc, message, va);
+  va_end(va);
 
   /* if truncation happens, message[trunc - 1] is not NULL, ... will show up. */
   strcpy(&cosmo->status_message[trunc], "...");

--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -13,6 +13,11 @@
 #include "ccl_params.h"
 #include "ccl_error.h"
 #include <stdlib.h>
+//
+// Macros for replacing relative paths
+#define EXPAND_STR(s) STRING(s)
+#define STRING(s) #s
+
 
 const ccl_configuration default_config = {ccl_boltzmann_class, ccl_halofit, ccl_nobaryons, ccl_tinker10, ccl_duffy2008, ccl_emu_strict};
 

--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -791,6 +791,20 @@ void ccl_data_free(ccl_data * data)
     gsl_interp_accel_free(data->accelerator_k);
 }
 
+/* ------- ROUTINE: ccl_cosmology_set_status_message -------- 
+INPUT: ccl_cosmology struct, status_string
+TASK: set the status message safely.
+*/
+void ccl_cosmology_set_status_message(ccl_cosmology * cosmo, const char * message)
+{
+  const int trunc = 480; /* must be < 500 - 4 */
+
+  strncpy(cosmo->status_message, message, trunc);
+
+  /* if truncation happens, message[trunc - 1] is not NULL, ... will show up. */
+  strcpy(&cosmo->status_message[trunc], "...");
+}
+
 /* ------- ROUTINE: ccl_parameters_free -------- 
 INPUT: ccl_parameters struct
 TASK: free allocated quantities in the parameters struct

--- a/src/ccl_correlation.c
+++ b/src/ccl_correlation.c
@@ -65,14 +65,14 @@ static void ccl_tracer_corr_fftlog(ccl_cosmology *cosmo,
   l_arr=ccl_log_spacing(ELL_MIN_FFTLOG,ELL_MAX_FFTLOG,N_ELL_FFTLOG);
   if(l_arr==NULL) {
     *status=CCL_ERROR_LINSPACE;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_tracer_corr_fftlog ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_tracer_corr_fftlog ran out of memory\n");
     return;
   }
   cl_arr=malloc(N_ELL_FFTLOG*sizeof(double));
   if(cl_arr==NULL) {
     free(l_arr);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_tracer_corr_fftlog ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_tracer_corr_fftlog ran out of memory\n");
     return;
   }
 
@@ -82,7 +82,7 @@ static void ccl_tracer_corr_fftlog(ccl_cosmology *cosmo,
     free(l_arr);
     free(cl_arr);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_tracer_corr_fftlog ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_tracer_corr_fftlog ran out of memory\n");
     return;
   }
 
@@ -112,14 +112,14 @@ static void ccl_tracer_corr_fftlog(ccl_cosmology *cosmo,
     free(l_arr);
     free(cl_arr);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_tracer_corr_fftlog ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_tracer_corr_fftlog ran out of memory\n");
     return;
   }
   wth_arr=(double *)malloc(sizeof(double)*N_ELL_FFTLOG);
   if(wth_arr==NULL) {
     free(l_arr); free(cl_arr); free(th_arr);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_tracer_corr_fftlog ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_tracer_corr_fftlog ran out of memory\n");
     return;
   }
 
@@ -198,7 +198,7 @@ static void ccl_tracer_corr_bessel(ccl_cosmology *cosmo,
   corr_int_par *cp=malloc(sizeof(corr_int_par));
   if(cp==NULL) {
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_tracer_corr_bessel ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_tracer_corr_bessel ran out of memory\n");
     return;
   }
 
@@ -211,7 +211,7 @@ static void ccl_tracer_corr_bessel(ccl_cosmology *cosmo,
   if(cp->cl_spl==NULL) {
     free(cp);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_tracer_corr_bessel ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_tracer_corr_bessel ran out of memory\n");
     return;
   }
   if(corr_type==CCL_CORR_GG)
@@ -310,20 +310,20 @@ static void ccl_tracer_corr_legendre(ccl_cosmology *cosmo,
 
   if(corr_type==CCL_CORR_LM || corr_type==CCL_CORR_LP){
     *status=CCL_ERROR_NOT_IMPLEMENTED;
-    strcpy(cosmo->status_message,"ccl_correlation.c: CCL does not support full-sky xi+- calcuations.\nhttps://arxiv.org/abs/1702.05301 indicates flat-sky to be sufficient.\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: CCL does not support full-sky xi+- calcuations.\nhttps://arxiv.org/abs/1702.05301 indicates flat-sky to be sufficient.\n");
     return;
   }
   l_arr=malloc((ELL_MAX_FFTLOG+1)*sizeof(double));
   if(l_arr==NULL) {
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_tracer_corr_legendre ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_tracer_corr_legendre ran out of memory\n");
     return;
   }
   cl_arr=malloc((ELL_MAX_FFTLOG+1)*sizeof(double));
   if(cl_arr==NULL) {
     free(l_arr);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_tracer_corr_legendre ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_tracer_corr_legendre ran out of memory\n");
     return;
   }
 
@@ -334,7 +334,7 @@ static void ccl_tracer_corr_legendre(ccl_cosmology *cosmo,
     free(cl_arr);
     free(l_arr);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_tracer_corr_legendre ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_tracer_corr_legendre ran out of memory\n");
     return;
   }
 
@@ -367,7 +367,7 @@ static void ccl_tracer_corr_legendre(ccl_cosmology *cosmo,
     free(cl_arr);
     free(l_arr);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_tracer_corr_legendre ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_tracer_corr_legendre ran out of memory\n");
     return;
   }
   for (int i=0;i<n_theta;i++) {
@@ -380,7 +380,7 @@ static void ccl_tracer_corr_legendre(ccl_cosmology *cosmo,
 	free(Pl_theta[j]);
       free(Pl_theta);
       *status=CCL_ERROR_MEMORY;
-      strcpy(cosmo->status_message,"ccl_correlation.c: ccl_tracer_corr_legendre ran out of memory\n");
+      ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_tracer_corr_legendre ran out of memory\n");
       return;
     }
   }
@@ -427,7 +427,7 @@ void ccl_correlation(ccl_cosmology *cosmo,
   }
   else {
     *status=CCL_ERROR_INCONSISTENT;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_correlation. Unknown algorithm\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_correlation. Unknown algorithm\n");
   }
 
   ccl_check_status(cosmo,status);
@@ -457,7 +457,7 @@ void ccl_correlation_3d(ccl_cosmology *cosmo, double a,
   k_arr=ccl_log_spacing(ccl_splines->K_MIN,ccl_splines->K_MAX,N_ARR);
   if(k_arr==NULL) {
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_correlation_3d ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_correlation_3d ran out of memory\n");
     return;
   }
 
@@ -465,7 +465,7 @@ void ccl_correlation_3d(ccl_cosmology *cosmo, double a,
   if(pk_arr==NULL) {
     free(k_arr);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_correlation_3d ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_correlation_3d ran out of memory\n");
     return;
   }  
 
@@ -480,14 +480,14 @@ void ccl_correlation_3d(ccl_cosmology *cosmo, double a,
     free(k_arr);
     free(pk_arr);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_correlation_3d ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_correlation_3d ran out of memory\n");
     return;
   }
   xi_arr=malloc(sizeof(double)*N_ARR);
   if(xi_arr==NULL) {
     free(k_arr); free(pk_arr); free(r_arr);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_correlation.c: ccl_correlation_3d ran out of memory\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_correlation.c: ccl_correlation_3d ran out of memory\n");
     return;
   }
 

--- a/src/ccl_emu17.c
+++ b/src/ccl_emu17.c
@@ -165,42 +165,42 @@ static void emu(double *xstar, double **ystar, int* status, ccl_cosmology* cosmo
         if((xstar[i] < xmin[i]) || (xstar[i] > xmax[i])) {
             switch(i) {
                 case 0:
-                    sprintf(cosmo->status_message, 
+                    ccl_cosmology_set_status_message(cosmo, 
                             "ccl_pkemu(): omega_m must be between %f and %f.\n", 
                             xmin[i], xmax[i]);
                     break;
                 case 1:
-                    sprintf(cosmo->status_message, 
+                    ccl_cosmology_set_status_message(cosmo, 
                             "ccl_pkemu(): omega_b must be between %f and %f.\n", 
                             xmin[i], xmax[i]);
                     break;
                 case 2:
-                    sprintf(cosmo->status_message, 
+                    ccl_cosmology_set_status_message(cosmo, 
                             "ccl_pkemu(): sigma8 must be between %f and %f.\n", 
                             xmin[i], xmax[i]);
                     break;
                 case 3:
-                    sprintf(cosmo->status_message, 
+                    ccl_cosmology_set_status_message(cosmo, 
                             "ccl_pkemu(): h must be between %f and %f.\n", 
                             xmin[i], xmax[i]);
                     break;
                 case 4:
-                    sprintf(cosmo->status_message, 
+                    ccl_cosmology_set_status_message(cosmo, 
                             "ccl_pkemu(): n_s must be between %f and %f.\n", 
                             xmin[i], xmax[i]);
                     break;
                 case 5:
-                    sprintf(cosmo->status_message, 
+                    ccl_cosmology_set_status_message(cosmo, 
                             "ccl_pkemu(): w_0 must be between %f and %f.\n", 
                             xmin[i], xmax[i]);
                     break;
                 case 6:
-                    sprintf(cosmo->status_message, 
+                    ccl_cosmology_set_status_message(cosmo, 
                             "ccl_pkemu(): (-w_0-w_a)^(1/4) must be between %f and %f.\n", 
                             xmin[i], xmax[i]);
                     break;
                 case 7:
-                    sprintf(cosmo->status_message, 
+                    ccl_cosmology_set_status_message(cosmo, 
                             "ccl_pkemu(): omega_nu must be between %f and %f.\n", 
                             xmin[i], xmax[i]);
                     break;
@@ -211,7 +211,7 @@ static void emu(double *xstar, double **ystar, int* status, ccl_cosmology* cosmo
         }
     } // for(i=0; i<p; i++)
     if((xstar[p] < z[0]) || (xstar[p] > z[rs-1])) {
-        sprintf(cosmo->status_message, 
+        ccl_cosmology_set_status_message(cosmo, 
                 "ccl_pkemu(): z must be between %f and %f.\n", 
                 z[0], z[rs-1]);
         *status = CCL_ERROR_EMULATOR_BOUND;

--- a/src/ccl_halomod.c
+++ b/src/ccl_halomod.c
@@ -62,7 +62,7 @@ double ccl_halo_concentration(ccl_cosmology *cosmo, double halomass, double a, d
 
     if (odelta != 200.) {
       *status = CCL_ERROR_CONC_DV;
-      strcpy(cosmo->status_message, "ccl_halomod.c: halo_concentration(): Bhattacharya (2011) concentration relation only valid for Delta_v = 200 \n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_halomod.c: halo_concentration(): Bhattacharya (2011) concentration relation only valid for Delta_v = 200 \n");
       return NAN;
     }
     
@@ -96,7 +96,7 @@ double ccl_halo_concentration(ccl_cosmology *cosmo, double halomass, double a, d
     } else {
 
       *status = CCL_ERROR_CONC_DV;
-      strcpy(cosmo->status_message, "ccl_halomod.c: halo_concentration(): Duffy (2008) virial concentration only valid for virial Delta_v or 200\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_halomod.c: halo_concentration(): Duffy (2008) virial concentration only valid for virial Delta_v or 200\n");
       return NAN;
       
     }
@@ -200,7 +200,7 @@ static double one_halo_integral(ccl_cosmology *cosmo, double k, double a, int *s
   if (qagstatus != GSL_SUCCESS) {
     ccl_raise_gsl_warning(qagstatus, "ccl_halomod.c: one_halo_integral():");
     *status = CCL_ERROR_ONE_HALO_INT;
-    sprintf(cosmo->status_message ,"ccl_halomod.c: one_halo_integral(): Integration failure\n");
+    ccl_cosmology_set_status_message(cosmo ,"ccl_halomod.c: one_halo_integral(): Integration failure\n");
     return NAN;      
   } else {
     return result;
@@ -263,7 +263,7 @@ static double two_halo_integral(ccl_cosmology *cosmo, double k, double a, int *s
   if (qagstatus != GSL_SUCCESS) {
     ccl_raise_gsl_warning(qagstatus, "ccl_halomod.c: two_halo_integral():");
     *status = CCL_ERROR_TWO_HALO_INT;
-    sprintf(cosmo->status_message ,"ccl_halomod.c: two_halo_integral(): Integration failure\n");
+    ccl_cosmology_set_status_message(cosmo ,"ccl_halomod.c: two_halo_integral(): Integration failure\n");
     return NAN;      
   } else {
     return result;

--- a/src/ccl_massfunc.c
+++ b/src/ccl_massfunc.c
@@ -85,7 +85,7 @@ void ccl_cosmology_compute_hmfparams(ccl_cosmology *cosmo, int *status)
     if (*status) {
       gsl_spline_free(alphahmf);
       *status = CCL_ERROR_SPLINE ;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating alpha(D) spline\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating alpha(D) spline\n");
       return;
     }
 
@@ -95,7 +95,7 @@ void ccl_cosmology_compute_hmfparams(ccl_cosmology *cosmo, int *status)
       gsl_spline_free(alphahmf);
       gsl_spline_free(betahmf);
       *status = CCL_ERROR_SPLINE ;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating beta(D) spline\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating beta(D) spline\n");
       return;
     }
 
@@ -106,7 +106,7 @@ void ccl_cosmology_compute_hmfparams(ccl_cosmology *cosmo, int *status)
       gsl_spline_free(betahmf);
       gsl_spline_free(gammahmf);
       *status = CCL_ERROR_SPLINE ;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating gamma(D) spline\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating gamma(D) spline\n");
       return;
     }
 
@@ -118,7 +118,7 @@ void ccl_cosmology_compute_hmfparams(ccl_cosmology *cosmo, int *status)
       gsl_spline_free(gammahmf);
       gsl_spline_free(phihmf);
       *status = CCL_ERROR_SPLINE ;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating phi(D) spline\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating phi(D) spline\n");
       return;
     }
 
@@ -131,7 +131,7 @@ void ccl_cosmology_compute_hmfparams(ccl_cosmology *cosmo, int *status)
       gsl_spline_free(phihmf);
       gsl_spline_free(etahmf);
       *status = CCL_ERROR_SPLINE ;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating eta(D) spline\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating eta(D) spline\n");
       return;
     }
     if(cosmo->data.accelerator_d==NULL)
@@ -164,7 +164,7 @@ void ccl_cosmology_compute_hmfparams(ccl_cosmology *cosmo, int *status)
     if (*status) {
       gsl_spline_free(alphahmf);
       *status = CCL_ERROR_SPLINE ;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating alpha(D) spline\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating alpha(D) spline\n");
       return;
     }
 
@@ -174,7 +174,7 @@ void ccl_cosmology_compute_hmfparams(ccl_cosmology *cosmo, int *status)
       gsl_spline_free(alphahmf);
       gsl_spline_free(betahmf);
       *status = CCL_ERROR_SPLINE ;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating beta(D) spline\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating beta(D) spline\n");
       return;
     }
 
@@ -185,7 +185,7 @@ void ccl_cosmology_compute_hmfparams(ccl_cosmology *cosmo, int *status)
       gsl_spline_free(betahmf);
       gsl_spline_free(gammahmf);
       *status = CCL_ERROR_SPLINE ;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating gamma(D) spline\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating gamma(D) spline\n");
       return;
     }
 
@@ -197,7 +197,7 @@ void ccl_cosmology_compute_hmfparams(ccl_cosmology *cosmo, int *status)
       gsl_spline_free(gammahmf);
       gsl_spline_free(phihmf);
       *status = CCL_ERROR_SPLINE ;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating phi(D) spline\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_cosmology_compute_hmfparams(): Error creating phi(D) spline\n");
       return;
     }
 
@@ -247,7 +247,7 @@ static double massfunc_f(ccl_cosmology *cosmo, double halomass, double a, double
     // Check if odelta is outside the interpolated range
     if (odelta != Dv_BryanNorman(cosmo, a, status)) {
       *status = CCL_ERROR_HMF_DV;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: massfunc_f(): Sheth-Tormen called with not virial Delta_v\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: massfunc_f(): Sheth-Tormen called with not virial Delta_v\n");
       return NAN;
     }
 
@@ -266,7 +266,7 @@ static double massfunc_f(ccl_cosmology *cosmo, double halomass, double a, double
     // Check if odelta is outside the interpolated range
     if ((odelta < 200) || (odelta > 3200)) {
       *status = CCL_ERROR_HMF_INTERP;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: massfunc_f(): Tinker 2008 only supported in range of Delta = 200 to Delta = 3200.\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: massfunc_f(): Tinker 2008 only supported in range of Delta = 200 to Delta = 3200.\n");
       return NAN;
     }
 
@@ -288,7 +288,7 @@ static double massfunc_f(ccl_cosmology *cosmo, double halomass, double a, double
     if(gslstatus != GSL_SUCCESS) {
       ccl_raise_gsl_warning(gslstatus, "ccl_massfunc.c: ccl_massfunc_f():");
       *status |= gslstatus;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_massfunc_f(): interpolation error for Tinker MF\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_massfunc_f(): interpolation error for Tinker MF\n");
       return NAN;
     }
     return fit_A*(pow(sigma/fit_b,-fit_a)+1.0)*exp(-fit_c/sigma/sigma);
@@ -300,7 +300,7 @@ static double massfunc_f(ccl_cosmology *cosmo, double halomass, double a, double
     // Check if odelta is outside the interpolated range
     if ((odelta < 200) || (odelta > 3200)) {
       *status = CCL_ERROR_HMF_INTERP;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: massfunc_f(): Tinker 2010 only supported in range of Delta = 200 to Delta = 3200.\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: massfunc_f(): Tinker 2010 only supported in range of Delta = 200 to Delta = 3200.\n");
       return 0;
     }
 
@@ -325,7 +325,7 @@ static double massfunc_f(ccl_cosmology *cosmo, double halomass, double a, double
     if(gslstatus != GSL_SUCCESS) {
       ccl_raise_gsl_warning(gslstatus, "ccl_massfunc.c: ccl_massfunc_f():");
       *status |= gslstatus;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_massfunc_f(): interpolation error for Tinker 2010 MF\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_massfunc_f(): interpolation error for Tinker 2010 MF\n");
       return NAN;
     }
     return nu*fit_A*(1.+pow(fit_b*nu,-2.*fit_d))*pow(nu, 2.*fit_a)*exp(-0.5*fit_c*nu*nu);
@@ -334,7 +334,7 @@ static double massfunc_f(ccl_cosmology *cosmo, double halomass, double a, double
   case ccl_watson:
     if(odelta!=200.) {
       *status = CCL_ERROR_HMF_INTERP;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_massfunc_f(): Watson HMF only supported for Delta = 200.\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_massfunc_f(): Watson HMF only supported for Delta = 200.\n");
       return NAN;
     }
     Omega_m_a = ccl_omega_x(cosmo, a, ccl_species_m_label,status);
@@ -348,7 +348,7 @@ static double massfunc_f(ccl_cosmology *cosmo, double halomass, double a, double
   case ccl_angulo:
     if(odelta!=200.) {
       *status = CCL_ERROR_HMF_INTERP;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_massfunc_f(): Angulo HMF only supported for Delta = 200.\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_massfunc_f(): Angulo HMF only supported for Delta = 200.\n");
       return NAN;
     }
     fit_A = 0.201;
@@ -360,7 +360,7 @@ static double massfunc_f(ccl_cosmology *cosmo, double halomass, double a, double
 
   default:
     *status = CCL_ERROR_MF;
-    sprintf(cosmo->status_message ,
+    ccl_cosmology_set_status_message(cosmo ,
 	    "ccl_massfunc.c: ccl_massfunc(): Unknown or non-implemented mass function method: %d \n",
 	    cosmo->config.mass_function_method);
     return NAN;
@@ -382,7 +382,7 @@ static double ccl_halo_b1(ccl_cosmology *cosmo, double halomass, double a, doubl
     // Check if Delta_v is the virial Delta_v
     if (odelta != Dv_BryanNorman(cosmo, a, status)) {
       *status = CCL_ERROR_HMF_DV;
-      strcpy(cosmo->status_message, "ccl_massfunc.c: halo_b1(): Sheth-Tormen called with not virial Delta_v\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: halo_b1(): Sheth-Tormen called with not virial Delta_v\n");
       return NAN;
     }
 
@@ -417,7 +417,7 @@ static double ccl_halo_b1(ccl_cosmology *cosmo, double halomass, double a, doubl
 
   default:
     *status = CCL_ERROR_MF;
-    sprintf(cosmo->status_message ,
+    ccl_cosmology_set_status_message(cosmo ,
 	    "ccl_massfunc.c: ccl_halo_b1(): No b(M) fitting function implemented for mass_function_method: %d \n",
       cosmo->config.mass_function_method);
     return 0;
@@ -438,7 +438,7 @@ void ccl_cosmology_compute_sigma(ccl_cosmology *cosmo, int *status)
       (m[nm-1]>10E17)
       ) {
     *status =CCL_ERROR_LINSPACE;
-    strcpy(cosmo->status_message,"ccl_cosmology_compute_sigmas(): Error creating linear spacing in m\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_cosmology_compute_sigmas(): Error creating linear spacing in m\n");
     return;
   }
 
@@ -458,7 +458,7 @@ void ccl_cosmology_compute_sigma(ccl_cosmology *cosmo, int *status)
     free(y);
     gsl_spline_free(logsigma);
     *status = CCL_ERROR_SPLINE ;
-    strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_cosmology_compute_sigma(): Error creating sigma(M) spline\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_cosmology_compute_sigma(): Error creating sigma(M) spline\n");
     return;
   }
   double na, nb;
@@ -490,7 +490,7 @@ void ccl_cosmology_compute_sigma(ccl_cosmology *cosmo, int *status)
     free(y);
     gsl_spline_free(logsigma);
     *status = CCL_ERROR_SPLINE ;
-    strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_cosmology_compute_sigma(): Error evaluating grid points for dlnsigma/dlogM spline\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_cosmology_compute_sigma(): Error evaluating grid points for dlnsigma/dlogM spline\n");
     return;
   }
 
@@ -501,7 +501,7 @@ void ccl_cosmology_compute_sigma(ccl_cosmology *cosmo, int *status)
     free(y);
     gsl_spline_free(logsigma);
     *status = CCL_ERROR_SPLINE ;
-    strcpy(cosmo->status_message, "ccl_massfunc.c: ccl_cosmology_compute_sigma(): Error creating dlnsigma/dlogM spline\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_massfunc.c: ccl_cosmology_compute_sigma(): Error creating dlnsigma/dlogM spline\n");
     return;
   }
 
@@ -549,7 +549,7 @@ double ccl_massfunc(ccl_cosmology *cosmo, double halomass, double a, double odel
 {
   if (cosmo->params.N_nu_mass>0){
 	  *status = CCL_ERROR_NOT_IMPLEMENTED;
-	  strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_growth(): Support for the halo mass function in cosmologies with massive neutrinos is not yet implemented.\n");
+	  ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_cosmology_compute_growth(): Support for the halo mass function in cosmologies with massive neutrinos is not yet implemented.\n");
 	  return NAN;
   }
 
@@ -569,7 +569,7 @@ double ccl_halo_bias(ccl_cosmology *cosmo, double halomass, double a, double ode
 {
   if (cosmo->params.N_nu_mass>0){
 	  *status = CCL_ERROR_NOT_IMPLEMENTED;
-	  strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_growth(): Support for the halo bias in cosmologies with massive neutrinos is not yet implemented.\n");
+	  ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_cosmology_compute_growth(): Support for the halo bias in cosmologies with massive neutrinos is not yet implemented.\n");
 	  return NAN;
   }
 
@@ -611,7 +611,7 @@ double ccl_sigmaM(ccl_cosmology *cosmo, double halomass, double a, int *status)
 {
   if (cosmo->params.N_nu_mass>0){
 	  *status = CCL_ERROR_NOT_IMPLEMENTED;
-	  strcpy(cosmo->status_message,"ccl_background.c: ccl_cosmology_compute_growth(): Support for the sigma(M) function in cosmologies with massive neutrinos is not yet implemented.\n");
+	  ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_cosmology_compute_growth(): Support for the sigma(M) function in cosmologies with massive neutrinos is not yet implemented.\n");
 	  return NAN;
   }
 

--- a/src/ccl_power.c
+++ b/src/ccl_power.c
@@ -38,7 +38,7 @@ static void ccl_free_class_structs(ccl_cosmology *cosmo,
   if(init_arr[i_init--]) {
     if (spectra_free(sp) == _FAILURE_) {
       *status = CCL_ERROR_CLASS;
-      sprintf(cosmo->status_message ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS spectra:%s\n",sp->error_message);
+      ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS spectra:%s\n",sp->error_message);
       return;
     }
   }
@@ -46,7 +46,7 @@ static void ccl_free_class_structs(ccl_cosmology *cosmo,
   if(init_arr[i_init--]) {
     if (transfer_free(tr) == _FAILURE_) {
       *status = CCL_ERROR_CLASS;
-      sprintf(cosmo->status_message ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS transfer:%s\n",tr->error_message);
+      ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS transfer:%s\n",tr->error_message);
       return;
     }
   }
@@ -54,7 +54,7 @@ static void ccl_free_class_structs(ccl_cosmology *cosmo,
   if(init_arr[i_init--]) {
     if (nonlinear_free(nl) == _FAILURE_) {
       *status = CCL_ERROR_CLASS;
-      sprintf(cosmo->status_message ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS nonlinear:%s\n",nl->error_message);
+      ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS nonlinear:%s\n",nl->error_message);
       return;
     }
   }
@@ -62,7 +62,7 @@ static void ccl_free_class_structs(ccl_cosmology *cosmo,
   if(init_arr[i_init--]) {
     if (primordial_free(pm) == _FAILURE_) {
       *status = CCL_ERROR_CLASS;
-      sprintf(cosmo->status_message ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS pm:%s\n",pm->error_message);
+      ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS pm:%s\n",pm->error_message);
       return;
     }
   }
@@ -70,7 +70,7 @@ static void ccl_free_class_structs(ccl_cosmology *cosmo,
   if(init_arr[i_init--]) {
     if (perturb_free(pt) == _FAILURE_) {
       *status = CCL_ERROR_CLASS;
-      sprintf(cosmo->status_message ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS pt:%s\n",pt->error_message);
+      ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS pt:%s\n",pt->error_message);
       return;
     }
   }
@@ -78,7 +78,7 @@ static void ccl_free_class_structs(ccl_cosmology *cosmo,
   if(init_arr[i_init--]) {
     if (thermodynamics_free(th) == _FAILURE_) {
       *status = CCL_ERROR_CLASS;
-      sprintf(cosmo->status_message ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS thermo:%s\n",th->error_message);
+      ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS thermo:%s\n",th->error_message);
       return;
     }
   }
@@ -86,7 +86,7 @@ static void ccl_free_class_structs(ccl_cosmology *cosmo,
   if(init_arr[i_init--]) {
     if (background_free(ba) == _FAILURE_) {
       *status = CCL_ERROR_CLASS;
-      sprintf(cosmo->status_message ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS bg:%s\n",ba->error_message);
+      ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_free_class_structs(): Error freeing CLASS bg:%s\n",ba->error_message);
       return;
     }
   }
@@ -180,48 +180,48 @@ static void ccl_run_class(ccl_cosmology *cosmo,
 
   if(input_init(fc,pr,ba,th,pt,tr,pm,sp,nl,le,op,errmsg) == _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS input:%s\n",errmsg);
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS input:%s\n",errmsg);
     return;
   }
   if (background_init(pr,ba) == _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS background:%s\n",ba->error_message);
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS background:%s\n",ba->error_message);
     return;
   }
   init_arr[i_init++]=1;
   if (thermodynamics_init(pr,ba,th) == _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS thermodynamics:%s\n",th->error_message);
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS thermodynamics:%s\n",th->error_message);
     return;
   }
   init_arr[i_init++]=1;
   if (perturb_init(pr,ba,th,pt) == _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS pertubations:%s\n",pt->error_message);
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS pertubations:%s\n",pt->error_message);
     return;
   }
   init_arr[i_init++]=1;
   if (primordial_init(pr,pt,pm) == _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS primordial:%s\n",pm->error_message);
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS primordial:%s\n",pm->error_message);
     return;
   }
   init_arr[i_init++]=1;
   if (nonlinear_init(pr,ba,th,pt,pm,nl) == _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS nonlinear:%s\n",nl->error_message);
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS nonlinear:%s\n",nl->error_message);
     return;
   }
   init_arr[i_init++]=1;
   if (transfer_init(pr,ba,th,pt,nl,tr) == _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS transfer:%s\n",tr->error_message);
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS transfer:%s\n",tr->error_message);
     return;
   }
   init_arr[i_init++]=1;
   if (spectra_init(pr,ba,pt,pm,nl,tr,sp) == _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS spectra:%s\n",sp->error_message);
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error running CLASS spectra:%s\n",sp->error_message);
     return;
   }
   init_arr[i_init++]=1;
@@ -358,7 +358,7 @@ static void ccl_fill_class_parameters(ccl_cosmology * cosmo, struct file_content
   //normalization comes last, so that all other parameters are filled in for determining A_s if sigma8 is specified
   if (isfinite(cosmo->params.sigma8) && isfinite(cosmo->params.A_s)){
       *status = CCL_ERROR_INCONSISTENT;
-      strcpy(cosmo->status_message ,"ccl_power.c: class_parameters(): Error initializing CLASS parameters: both sigma8 and A_s defined\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_power.c: class_parameters(): Error initializing CLASS parameters: both sigma8 and A_s defined\n");
     return;
   }
   if (isfinite(cosmo->params.sigma8)) {
@@ -371,7 +371,7 @@ static void ccl_fill_class_parameters(ccl_cosmology * cosmo, struct file_content
   }
   else {
     *status = CCL_ERROR_INCONSISTENT;
-    strcpy(cosmo->status_message ,"ccl_power.c: class_parameters(): Error initializing CLASS pararmeters: neither sigma8 nor A_s defined\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: class_parameters(): Error initializing CLASS pararmeters: neither sigma8 nor A_s defined\n");
     return;
   }
 
@@ -399,7 +399,7 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
   int init_arr[7]={0,0,0,0,0,0,0};
   if (parser_init(&fc,parser_length,"none",errmsg) == _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): parser init error:%s\n",errmsg);
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_cosmology_compute_power_class(): parser init error:%s\n",errmsg);
     return;
   }
 
@@ -416,7 +416,7 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
 
   if (parser_free(&fc)== _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    strcpy(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error freeing CLASS parser\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_class(): Error freeing CLASS parser\n");
     ccl_free_class_structs(cosmo, &ba,&th,&pt,&tr,&pm,&sp,&nl,&le,init_arr,status);
     return;
   }
@@ -443,7 +443,7 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
   double * y2d_nl = malloc(nk * na * sizeof(double));
   if (z==NULL|| x==NULL || y2d_lin==NULL || y2d_nl==NULL) {
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_class(): memory allocation error\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_class(): memory allocation error\n");
   }
   else{
     // After this loop x will contain log(k), y will contain log(P_nl), z will contain log(P_lin)
@@ -466,7 +466,7 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
       free(y2d_nl);
       free(y2d_lin);
       *status = CCL_ERROR_CLASS;
-      strcpy(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error computing CLASS power spectrum\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_class(): Error computing CLASS power spectrum\n");
 
       ccl_free_class_structs(cosmo, &ba,&th,&pt,&tr,&pm,&sp,&nl,&le,init_arr,status);
 
@@ -481,7 +481,7 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
       free(y2d_lin);
       gsl_spline2d_free(log_power);
       ccl_free_class_structs(cosmo, &ba,&th,&pt,&tr,&pm,&sp,&nl,&le,init_arr,status);
-      strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_class(): Error creating log_power spline\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_class(): Error creating log_power spline\n");
       return;
     }
     else {
@@ -491,7 +491,7 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
     // At the moment KMIN can't be less than CLASS's kmin in the nonlinear case.
     if (kmin<(exp(sp.ln_k[0]))) {
       *status = CCL_ERROR_CLASS;
-      strcpy(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): K_MIN is less than CLASS's kmin. Not yet supported for nonlinear P(k).\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_class(): K_MIN is less than CLASS's kmin. Not yet supported for nonlinear P(k).\n");
     }
 
     //These are the limits of the splining range
@@ -515,7 +515,7 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
 	free(y2d_nl);
 	free(y2d_lin);
 	*status = CCL_ERROR_CLASS;
-	strcpy(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error computing CLASS power spectrum\n");
+	ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_class(): Error computing CLASS power spectrum\n");
 	ccl_free_class_structs(cosmo, &ba,&th,&pt,&tr,&pm,&sp,&nl,&le,init_arr,status);
 	return;
 
@@ -531,7 +531,7 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
 	free(y2d_lin);
 	gsl_spline2d_free(log_power_nl);
 	ccl_free_class_structs(cosmo, &ba,&th,&pt,&tr,&pm,&sp,&nl,&le,init_arr,status);
-	strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_class(): Error creating log_power_nl spline\n");
+	ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_class(): Error creating log_power_nl spline\n");
 	return;
       }
       else {
@@ -595,7 +595,7 @@ void ccl_cosmology_write_power_class_z(char *filename, ccl_cosmology * cosmo, do
   int init_arr[7]={0,0,0,0,0,0,0};
   if (parser_init(&fc,parser_length,"none",errmsg) == _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    sprintf(cosmo->status_message ,"ccl_power.c: write_power_class_z(): parser init error:%s\n",errmsg);
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: write_power_class_z(): parser init error:%s\n",errmsg);
     return;
   }
 
@@ -611,7 +611,7 @@ void ccl_cosmology_write_power_class_z(char *filename, ccl_cosmology * cosmo, do
   }
   if (parser_free(&fc)== _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    strcpy(cosmo->status_message ,"ccl_power.c: write_power_class_z(): Error freeing CLASS parser\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: write_power_class_z(): Error freeing CLASS parser\n");
     ccl_free_class_structs(cosmo, &ba,&th,&pt,&tr,&pm,&sp,&nl,&le,init_arr,status);
     return;
   }
@@ -619,7 +619,7 @@ void ccl_cosmology_write_power_class_z(char *filename, ccl_cosmology * cosmo, do
   f = fopen(filename,"w");
   if (!f){
     *status = CCL_ERROR_CLASS;
-    strcpy(cosmo->status_message ,"ccl_power.c: write_power_class_z(): Error opening output file\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: write_power_class_z(): Error opening output file\n");
     ccl_free_class_structs(cosmo, &ba,&th,&pt,&tr,&pm,&sp,&nl,&le,init_arr,status);
     fclose(f);
     return;
@@ -633,7 +633,7 @@ void ccl_cosmology_write_power_class_z(char *filename, ccl_cosmology * cosmo, do
   fclose(f);
   if(s) {
     *status = CCL_ERROR_CLASS;
-    strcpy(cosmo->status_message ,"ccl_power.c: write_power_class_z(): Error writing CLASS power spectrum\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: write_power_class_z(): Error writing CLASS power spectrum\n");
   }
 
   ccl_free_class_structs(cosmo, &ba,&th,&pt,&tr,&pm,&sp,&nl,&le,init_arr,status);
@@ -824,7 +824,7 @@ static void ccl_cosmology_compute_power_eh(ccl_cosmology * cosmo, int * status)
   // Exit if sigma8 wasn't specified
   if (isnan(cosmo->params.sigma8)) {
     *status = CCL_ERROR_INCONSISTENT;
-    strcpy(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_eh(): sigma8 was not set, but is required for E&H method\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_eh(): sigma8 was not set, but is required for E&H method\n");
     return;
   }
 
@@ -832,7 +832,7 @@ static void ccl_cosmology_compute_power_eh(ccl_cosmology * cosmo, int * status)
   eh_struct *eh = eh_struct_new(&(cosmo->params));
   if (eh == NULL) {
     *status = CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message, "ccl_power.c: ccl_cosmology_compute_power_eh(): memory allocation error\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_eh(): memory allocation error\n");
     return;
   }
 
@@ -851,7 +851,7 @@ static void ccl_cosmology_compute_power_eh(ccl_cosmology * cosmo, int * status)
     if (z != NULL) free(z);
     if (y2d != NULL) free(y2d);
     *status = CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message, "ccl_power.c: ccl_cosmology_compute_power_eh(): memory allocation error\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_eh(): memory allocation error\n");
     return;
   }
 
@@ -886,7 +886,7 @@ static void ccl_cosmology_compute_power_eh(ccl_cosmology * cosmo, int * status)
     free(eh); free(x); free(y); free(z); free(y2d);
     gsl_spline2d_free(log_power_lin);
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message, "ccl_power.c: ccl_cosmology_compute_power_eh(): Error creating log_power_lin spline\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_eh(): Error creating log_power_lin spline\n");
     return;
   }
 
@@ -927,7 +927,7 @@ static void ccl_cosmology_compute_power_eh(ccl_cosmology * cosmo, int * status)
     free(eh); free(x); free(y); free(z); free(y2d);
     gsl_spline2d_free(log_power_lin);
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message, "ccl_power.c: ccl_cosmology_compute_power_eh(): Error creating log_power_lin spline\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_eh(): Error creating log_power_lin spline\n");
     return;
   }
   else
@@ -943,7 +943,7 @@ static void ccl_cosmology_compute_power_eh(ccl_cosmology * cosmo, int * status)
     gsl_spline2d_free(log_power_lin);
     gsl_spline2d_free(log_power_nl);
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message, "ccl_power.c: ccl_cosmology_compute_power_eh(): Error creating log_power_nl spline\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_eh(): Error creating log_power_nl spline\n");
     return;
   }
   else
@@ -999,7 +999,7 @@ static void ccl_cosmology_compute_power_bbks(ccl_cosmology * cosmo, int * status
   // Exit if sigma8 wasn't specified
   if (isnan(cosmo->params.sigma8)) {
     *status = CCL_ERROR_INCONSISTENT;
-    strcpy(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_bbks(): sigma8 not set, required for BBKS\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_bbks(): sigma8 not set, required for BBKS\n");
     return;
   }
 
@@ -1015,7 +1015,7 @@ static void ccl_cosmology_compute_power_bbks(ccl_cosmology * cosmo, int * status
     if (z != NULL) free(z);
     if (y2d != NULL) free(y2d);
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_bbks(): memory allocation error\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_bbks(): memory allocation error\n");
     return;
   }
 
@@ -1047,7 +1047,7 @@ static void ccl_cosmology_compute_power_bbks(ccl_cosmology * cosmo, int * status
     free(x); free(y); free(z); free(y2d);
     gsl_spline2d_free(log_power_lin);
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message,
+    ccl_cosmology_set_status_message(cosmo,
            "ccl_power.c: ccl_cosmology_compute_power_bbks(): Error creating log_power_lin spline\n");
     return;
   }
@@ -1089,7 +1089,7 @@ static void ccl_cosmology_compute_power_bbks(ccl_cosmology * cosmo, int * status
     free(x); free(y); free(z); free(y2d);
     gsl_spline2d_free(log_power_lin);
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message,
+    ccl_cosmology_set_status_message(cosmo,
            "ccl_power.c: ccl_cosmology_compute_power_bbks(): Error creating log_power_lin spline\n");
     return;
   }
@@ -1106,7 +1106,7 @@ static void ccl_cosmology_compute_power_bbks(ccl_cosmology * cosmo, int * status
     gsl_spline2d_free(log_power_nl);
     gsl_spline2d_free(log_power_lin);
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_bbks(): Error creating log_power_nl spline\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_bbks(): Error creating log_power_nl spline\n");
     return;
   }
   else {
@@ -1148,14 +1148,14 @@ static void ccl_cosmology_compute_power_emu(ccl_cosmology * cosmo, int * status)
   int init_arr[7]={0,0,0,0,0,0,0};
   if (parser_init(&fc,parser_length,"none",errmsg) == _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): parser init error:%s\n",errmsg);
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_class(): parser init error:%s\n",errmsg);
     return;
   }
 
   // Check ranges to see if the cosmology is valid
   if((cosmo->params.h<0.55) || (cosmo->params.h>0.85)){
     *status=CCL_ERROR_INCONSISTENT;
-    strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_emu(): h is outside allowed range\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_emu(): h is outside allowed range\n");
     return;
   }
 
@@ -1169,12 +1169,12 @@ static void ccl_cosmology_compute_power_emu(ccl_cosmology * cosmo, int * status)
 			  double diff3 = pow((cosmo->params.mnu[2] - cosmo->params.mnu[0]) * (cosmo->params.mnu[2] - cosmo->params.mnu[0]), 0.5);
 			  if (diff1>1e-12 || diff2>1e-12 || diff3>1e-12){
 				*status = CCL_ERROR_INCONSISTENT;
-				strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_emu(): In the default configuration, you must pass a list of 3 equal neutrino masses or pass a sum and set mnu_type = ccl_mnu_sum_equal. If you wish to over-ride this, set config->emulator_neutrinos_method = 'ccl_emu_equalize'. This will force the neutrinos to be of equal mass but will result in internal inconsistencies.\n");
+				ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_emu(): In the default configuration, you must pass a list of 3 equal neutrino masses or pass a sum and set mnu_type = ccl_mnu_sum_equal. If you wish to over-ride this, set config->emulator_neutrinos_method = 'ccl_emu_equalize'. This will force the neutrinos to be of equal mass but will result in internal inconsistencies.\n");
 				return;
 			    }
           }else if (cosmo->params.N_nu_mass!=3){
 			    *status = CCL_ERROR_INCONSISTENT;
-				strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_emu(): In the default configuration, you must pass a list of 3 equal neutrino masses or pass a sum and set mnu_type = ccl_mnu_sum_equal. If you wish to over-ride this, set config->emulator_neutrinos_method = 'ccl_emu_equalize'. This will force the neutrinos to be of equal mass but will result in internal inconsistencies.\n");
+				ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_emu(): In the default configuration, you must pass a list of 3 equal neutrino masses or pass a sum and set mnu_type = ccl_mnu_sum_equal. If you wish to over-ride this, set config->emulator_neutrinos_method = 'ccl_emu_equalize'. This will force the neutrinos to be of equal mass but will result in internal inconsistencies.\n");
 				return;
 			}
       }else if (cosmo->config.emulator_neutrinos_method == ccl_emu_equalize){
@@ -1185,26 +1185,26 @@ static void ccl_cosmology_compute_power_emu(ccl_cosmology * cosmo, int * status)
   } else {
     if(fabs(cosmo->params.N_nu_rel - 3.04)>1.e-6){
       *status=CCL_ERROR_INCONSISTENT;
-      strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_emu(): Set Neff = 3.04 for cosmic emulator predictions in absence of massive neutrinos.\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_emu(): Set Neff = 3.04 for cosmic emulator predictions in absence of massive neutrinos.\n");
       return;
     }
     }
   double w0wacomb = -cosmo->params.w0 - cosmo->params.wa;
   if(w0wacomb<0.3*0.3*0.3*0.3){
     *status=CCL_ERROR_INCONSISTENT;
-    strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_emu(): w0 and wa do not satisfy the emulator bound\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_emu(): w0 and wa do not satisfy the emulator bound\n");
     return;
   }
   if(cosmo->params.Omega_n_mass*cosmo->params.h*cosmo->params.h>0.01){
     *status=CCL_ERROR_INCONSISTENT;
-    strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_emu(): Omega_nu does not satisfy the emulator bound\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_emu(): Omega_nu does not satisfy the emulator bound\n");
     return;
     }
 
   // Check to see if sigma8 was defined
   if(isnan(cosmo->params.sigma8)){
     *status=CCL_ERROR_INCONSISTENT;
-    strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_emu(): sigma8 is not defined; specify sigma8 instead of A_s\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_emu(): sigma8 is not defined; specify sigma8 instead of A_s\n");
     return;
   }
 
@@ -1221,7 +1221,7 @@ static void ccl_cosmology_compute_power_emu(ccl_cosmology * cosmo, int * status)
   }
   if (parser_free(&fc)== _FAILURE_) {
     *status = CCL_ERROR_CLASS;
-    strcpy(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_class(): Error freeing CLASS parser\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_class(): Error freeing CLASS parser\n");
     ccl_free_class_structs(cosmo, &ba,&th,&pt,&tr,&pm,&sp,&nl,&le,init_arr,status);
     return;
   }
@@ -1246,7 +1246,7 @@ static void ccl_cosmology_compute_power_emu(ccl_cosmology * cosmo, int * status)
   double * y2d_lin = malloc(nk * na * sizeof(double));
   if (z==NULL|| x==NULL || y2d_lin==NULL) {
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_class(): memory allocation error\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_class(): memory allocation error\n");
   }
   else{
     // After this loop x will contain log(k), y will contain log(P_nl), z will contain log(P_lin)
@@ -1268,7 +1268,7 @@ static void ccl_cosmology_compute_power_emu(ccl_cosmology * cosmo, int * status)
       free(z);
       free(y2d_lin);
       *status = CCL_ERROR_CLASS;
-      strcpy(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power_emu(): Error computing CLASS power spectrum\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_emu(): Error computing CLASS power spectrum\n");
 
       ccl_free_class_structs(cosmo, &ba,&th,&pt,&tr,&pm,&sp,&nl,&le,init_arr,status);
 
@@ -1282,7 +1282,7 @@ static void ccl_cosmology_compute_power_emu(ccl_cosmology * cosmo, int * status)
       free(y2d_lin);
       gsl_spline2d_free(log_power);
       ccl_free_class_structs(cosmo, &ba,&th,&pt,&tr,&pm,&sp,&nl,&le,init_arr,status);
-      strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_emu(): Error creating log_power spline\n");
+      ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_emu(): Error creating log_power spline\n");
       return;
     }
     else {
@@ -1306,7 +1306,7 @@ static void ccl_cosmology_compute_power_emu(ccl_cosmology * cosmo, int * status)
   double * y2d = malloc(351 * na * sizeof(double));
   if (zemu==NULL || y2d==NULL || logx==NULL || xstar==NULL){
     *status=CCL_ERROR_MEMORY;
-    strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_emu(): memory allocation error\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_emu(): memory allocation error\n");
     return;
   }
 
@@ -1348,7 +1348,7 @@ static void ccl_cosmology_compute_power_emu(ccl_cosmology * cosmo, int * status)
     free(y2d);
     gsl_spline2d_free(log_power_nl);
     *status = CCL_ERROR_SPLINE;
-    strcpy(cosmo->status_message,"ccl_power.c: ccl_cosmology_compute_power_emu(): Error creating log_power spline\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: ccl_cosmology_compute_power_emu(): Error creating log_power spline\n");
     return;
 
   }
@@ -1384,7 +1384,7 @@ void ccl_cosmology_compute_power(ccl_cosmology * cosmo, int * status)
 	  break;
         default:
 	  *status = CCL_ERROR_INCONSISTENT;
-	  sprintf(cosmo->status_message ,"ccl_power.c: ccl_cosmology_compute_power(): Unknown or non-implemented transfer function method: %d \n",cosmo->config.transfer_function_method);
+	  ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_cosmology_compute_power(): Unknown or non-implemented transfer function method: %d \n",cosmo->config.transfer_function_method);
     }
 
     ccl_check_status(cosmo,status);
@@ -1414,7 +1414,7 @@ static double ccl_power_extrapol_highk(ccl_cosmology * cosmo, double k, double a
   if(gslstatus != GSL_SUCCESS) {
     ccl_raise_gsl_warning(gslstatus, "ccl_power.c: ccl_power_extrapol_highk():");
     *status = CCL_ERROR_SPLINE_EV;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_power_extrapol_highk(): Spline evaluation error\n");
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_power_extrapol_highk(): Spline evaluation error\n");
     return NAN;
   }
   //GSL derivatives
@@ -1422,14 +1422,14 @@ static double ccl_power_extrapol_highk(ccl_cosmology * cosmo, double k, double a
   if(gslstatus != GSL_SUCCESS) {
     ccl_raise_gsl_warning(gslstatus, "ccl_power.c: ccl_power_extrapol_highk():");
     *status = CCL_ERROR_SPLINE_EV;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_power_extrapol_highk(): Spline evaluation error\n");
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_power_extrapol_highk(): Spline evaluation error\n");
     return NAN;
   }
   gslstatus = gsl_spline2d_eval_deriv_xx_e (powerspl, lkmid, a, NULL,NULL,&deriv2_pk_kmid);
   if(gslstatus != GSL_SUCCESS) {
     ccl_raise_gsl_warning(gslstatus, "ccl_power.c: ccl_power_extrapol_highk():");
     *status = CCL_ERROR_SPLINE_EV;
-    sprintf(cosmo->status_message ,"ccl_power.c: ccl_power_extrapol_highk(): Spline evaluation error\n");
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_power_extrapol_highk(): Spline evaluation error\n");
     return NAN;
   }
   log_p_1=lpk_kmid+deriv_pk_kmid*(log(k)-lkmid)+deriv2_pk_kmid/2.*(log(k)-lkmid)*(log(k)-lkmid);
@@ -1454,7 +1454,7 @@ static double ccl_power_extrapol_lowk(ccl_cosmology * cosmo, double k, double a,
   if(gslstatus != GSL_SUCCESS) {
     ccl_raise_gsl_warning(gslstatus, "ccl_power.c: ccl_power_extrapol_lowk():");
     *status=CCL_ERROR_SPLINE_EV;
-    sprintf(cosmo->status_message,"ccl_power.c: ccl_power_extrapol_lowk(): Spline evaluation error\n");
+    ccl_cosmology_set_status_message(cosmo,"ccl_power.c: ccl_power_extrapol_lowk(): Spline evaluation error\n");
     return NAN;
   }
 
@@ -1473,7 +1473,7 @@ double ccl_linear_matter_power(ccl_cosmology * cosmo, double k, double a, int * 
 {
   if ((cosmo->config.transfer_function_method == ccl_emulator) && (a<A_MIN_EMU)){
     *status = CCL_ERROR_INCONSISTENT;
-    sprintf(cosmo->status_message ,"ccl_power.c: the cosmic emulator cannot be used above z=2\n");
+    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: the cosmic emulator cannot be used above z=2\n");
     return NAN;
   }
 
@@ -1502,7 +1502,7 @@ double ccl_linear_matter_power(ccl_cosmology * cosmo, double k, double a, int * 
       if(gslstatus != GSL_SUCCESS) {
         ccl_raise_gsl_warning(gslstatus, "ccl_power.c: ccl_linear_matter_power():");
         *status = CCL_ERROR_SPLINE_EV;
-        sprintf(cosmo->status_message ,"ccl_power.c: ccl_linear_matter_power(): Spline evaluation error\n");
+        ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_linear_matter_power(): Spline evaluation error\n");
         return NAN;
       }
       else {
@@ -1556,7 +1556,7 @@ double ccl_nonlin_matter_power(ccl_cosmology * cosmo, double k, double a, int *s
       if(gslstatus != GSL_SUCCESS) {
         ccl_raise_gsl_warning(gslstatus, "ccl_power.c: ccl_nonlin_matter_power():");
 	*status = CCL_ERROR_SPLINE_EV;
-	sprintf(cosmo->status_message ,"ccl_power.c: ccl_nonlin_matter_power(): Spline evaluation error\n");
+	ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_nonlin_matter_power(): Spline evaluation error\n");
 	return NAN;
       }
       else {
@@ -1575,7 +1575,7 @@ double ccl_nonlin_matter_power(ccl_cosmology * cosmo, double k, double a, int *s
       pk=pk*fbcm;
       if(pwstatus){
         *status = CCL_ERROR_SPLINE_EV;
-        sprintf(cosmo->status_message ,"ccl_power.c: ccl_nonlin_matter_power(): Error in BCM correction\n");
+        ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_nonlin_matter_power(): Error in BCM correction\n");
         return NAN;
       }
     }
@@ -1584,7 +1584,7 @@ double ccl_nonlin_matter_power(ccl_cosmology * cosmo, double k, double a, int *s
   case ccl_emu:
     if ((cosmo->config.transfer_function_method == ccl_emulator) && (a<A_MIN_EMU)){
       *status = CCL_ERROR_EMULATOR_BOUND;
-      sprintf(cosmo->status_message, "ccl_power.c: the cosmic emulator cannot be used above z=2\
+      ccl_cosmology_set_status_message(cosmo, "ccl_power.c: the cosmic emulator cannot be used above z=2\
 \n");
       return NAN;
     }
@@ -1605,7 +1605,7 @@ double ccl_nonlin_matter_power(ccl_cosmology * cosmo, double k, double a, int *s
       if(gslstatus != GSL_SUCCESS) {
         ccl_raise_gsl_warning(gslstatus, "ccl_power.c: ccl_nonlin_matter_power():");
         *status = CCL_ERROR_SPLINE_EV;
-        sprintf(cosmo->status_message ,"ccl_power.c: ccl_nonlin_matter_power(): Spline evaluation error\n");
+        ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_nonlin_matter_power(): Spline evaluation error\n");
         return NAN;
       }
       else {
@@ -1623,7 +1623,7 @@ double ccl_nonlin_matter_power(ccl_cosmology * cosmo, double k, double a, int *s
       pk = pk*fbcm;
       if(pwstatus){
 	    *status = CCL_ERROR_SPLINE_EV;
-	    sprintf(cosmo->status_message ,"ccl_power.c: ccl_nonlin_matter_power(): Error in BCM correction\n");
+	    ccl_cosmology_set_status_message(cosmo ,"ccl_power.c: ccl_nonlin_matter_power(): Error in BCM correction\n");
 	    return NAN;
       }
     }


### PR DESCRIPTION
As the commits say:

1. Remove two barely used macros from the global namespace

2. Add a vaarg function that sets status_message with truncation.

3. Die gracefully if parameter file is unparsable.