### PR TITLE
Removes SWIG naming option

### DIFF
--- a/pyccl/CMakeLists.txt
+++ b/pyccl/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 include(BuildSWIG)
 include(UseSWIG)
-set (UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
+#set (UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
 
 find_package(PythonLibsNew)
 find_package(NumPy)


### PR DESCRIPTION
Removing an option that sets the naming convention for SWIG, and which was apparently broken in the latest release 3.12 or cmake. Closes #455 