### PR TITLE
BUG fix lensing C(ell) notebook typo

### DIFF
--- a/examples/Lensing angular power spectrum.ipynb
+++ b/examples/Lensing angular power spectrum.ipynb
@@ -150,7 +150,7 @@
    "source": [
     "z_ia = np.linspace(0., 3., 5) # Only 5 redshift bins\n",
     "bias_ia2 = np.ones(z_ia.size)\n",
-    "lens2_ia = ccl.ClTracerLensing(cosmo, True, n=(z, dNdz), bias_ia=(z_ia, bias_ia), f_red=(z, f_red))"
+    "lens2_ia = ccl.ClTracerLensing(cosmo, True, n=(z, dNdz), bias_ia=(z_ia, bias_ia2), f_red=(z, f_red))"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes the typo in the notebook. Closes #425