### PR TITLE
ENH raise an error if a C ccl cosmology object is passed

### DIFF
--- a/pyccl/cls.py
+++ b/pyccl/cls.py
@@ -1,6 +1,6 @@
 from . import ccllib as lib
 from . import constants as const
-from .core import _cosmology_obj, check
+from .core import check
 import numpy as np
 
 # Mapping between names for tracers and internal CCL tracer types
@@ -97,7 +97,7 @@ class ClTracer(object):
                  z=None, n=None, bias=None, mag_bias=None, bias_ia=None,
                  f_red=None, z_source=1100.):
         # Verify cosmo object
-        cosmo = _cosmology_obj(cosmo)
+        cosmo = cosmo.cosmo
 
         # Check tracer type
         if tracer_type not in tracer_types.keys():
@@ -159,7 +159,7 @@ class ClTracer(object):
         """
         # Access ccl_cosmology object
         cosmo_in = cosmo
-        cosmo = _cosmology_obj(cosmo)
+        cosmo = cosmo.cosmo
 
         # Check that specified function type exists
         if function not in function_types.keys():
@@ -387,7 +387,7 @@ def angular_cl(cosmo, cltracer1, cltracer2, ell,
             :math:`\ell`.
     """
     # Access ccl_cosmology object
-    cosmo = _cosmology_obj(cosmo)
+    cosmo = cosmo.cosmo
 
     if non_limber_method not in nonlimber_methods.keys():
         raise ValueError(

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -656,7 +656,7 @@ def check(status, cosmo=None):
 
     # Get status message from Cosmology object, if there is one
     if cosmo is not None:
-        msg = _cosmology_obj(cosmo).status_message
+        msg = cosmo.cosmo.status_message
     else:
         msg = ""
 
@@ -667,19 +667,3 @@ def check(status, cosmo=None):
     # Check for unknown error
     if status != 0:
         raise RuntimeError("Error %d: %s" % (status, msg))
-
-
-def _cosmology_obj(cosmo):
-    """Returns a ccl_cosmology object, given an input Cosmology wrapper class.
-
-    Args:
-        cosmo (:obj:`Cosmology`): The input cosmology which gets
-                                  converted to a ccl_cosmology.
-
-    Returns:
-        ccl_cosmo (:obj:`ccl.cosmology`): The CCL C cosmology object.
-    """
-    if isinstance(cosmo, Cosmology):
-        return cosmo.cosmo
-    else:
-        raise TypeError("Invalid Cosmology object!")

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -670,17 +670,16 @@ def check(status, cosmo=None):
 
 
 def _cosmology_obj(cosmo):
-    """Returns a ccl_cosmology object, given an input object which may be
-    ccl_cosmology, the Cosmology wrapper class, or an invalid type.
+    """Returns a ccl_cosmology object, given an input Cosmology wrapper class.
 
     Args:
-        cosmo (ccl_cosmology or Cosmology): The input cosmology which gets
-                                            converted to a ccl_cosmology.
+        cosmo (:obj:`Cosmology`): The input cosmology which gets
+                                  converted to a ccl_cosmology.
 
+    Returns:
+        ccl_cosmo (:obj:`ccl.cosmology`): The CCL C cosmology object.
     """
-    if isinstance(cosmo, lib.cosmology):
-        return cosmo
-    elif isinstance(cosmo, Cosmology):
+    if isinstance(cosmo, Cosmology):
         return cosmo.cosmo
     else:
-        raise TypeError("Invalid Cosmology or ccl_cosmology object.")
+        raise TypeError("Invalid Cosmology object!")

--- a/pyccl/correlation.py
+++ b/pyccl/correlation.py
@@ -8,7 +8,7 @@ Choices of algorithms used to compute correlation functions:
 
 from . import ccllib as lib
 from . import constants as const
-from .core import _cosmology_obj, check
+from .core import check
 import numpy as np
 
 correlation_methods = {
@@ -51,7 +51,7 @@ def correlation(cosmo, ell, C_ell, theta, corr_type='gg', method='fftlog'):
             angular separations.
     """
     cosmo_in = cosmo
-    cosmo = _cosmology_obj(cosmo)
+    cosmo = cosmo.cosmo
     status = 0
 
     # Convert to lower case
@@ -94,7 +94,7 @@ def correlation_3d(cosmo, a, r):
         Value(s) of the correlation function at the input distance(s).
     """
     cosmo_in = cosmo
-    cosmo = _cosmology_obj(cosmo)
+    cosmo = cosmo.cosmo
     status = 0
 
     # Convert scalar input into an array

--- a/pyccl/pyutils.py
+++ b/pyccl/pyutils.py
@@ -2,7 +2,7 @@
 well as wrappers to automatically vectorize functions."""
 from . import ccllib as lib
 import numpy as np
-from .core import check, _cosmology_obj
+from .core import check
 
 
 def debug_mode(debug):
@@ -81,7 +81,7 @@ def _vectorize_fn(fn, fn_vec, cosmo, x, returns_status=True):
 
     # Access ccl_cosmology object
     cosmo_in = cosmo
-    cosmo = _cosmology_obj(cosmo)
+    cosmo = cosmo.cosmo
 
     status = 0
 
@@ -129,7 +129,7 @@ def _vectorize_fn2(fn, fn_vec, cosmo, x, z, returns_status=True):
     """
     # Access ccl_cosmology object
     cosmo_in = cosmo
-    cosmo = _cosmology_obj(cosmo)
+    cosmo = cosmo.cosmo
     status = 0
 
     # If a scalar was passed, convert to an array
@@ -176,7 +176,7 @@ def _vectorize_fn3(fn, fn_vec, cosmo, x, n, returns_status=True):
     """
     # Access ccl_cosmology object
     cosmo_in = cosmo
-    cosmo = _cosmology_obj(cosmo)
+    cosmo = cosmo.cosmo
     status = 0
 
     if isinstance(x, int):
@@ -223,7 +223,7 @@ def _vectorize_fn4(fn, fn_vec, cosmo, x, a, d, returns_status=True):
     """
     # Access ccl_cosmology object
     cosmo_in = cosmo
-    cosmo = _cosmology_obj(cosmo)
+    cosmo = cosmo.cosmo
     status = 0
 
     if isinstance(x, int):

--- a/tests/ccl_test_core.py
+++ b/tests/ccl_test_core.py
@@ -170,7 +170,7 @@ def test_parameters_mgrowth():
 def test_parameters_read_write():
     """Check that Parameters objects can be read and written"""
     import tempfile
-    params = ccl.Parameters(Omega_c=0.25, Omega_b=0.05, h=0.7, A_s=2.1e-9, 
+    params = ccl.Parameters(Omega_c=0.25, Omega_b=0.05, h=0.7, A_s=2.1e-9,
                             n_s=0.96)
 
     # Make a temporary file name
@@ -194,7 +194,13 @@ def test_parameters_read_write():
     assert_raises(IOError, ccl.Parameters.read_yaml, filename=temp_file_name)
     assert_raises(IOError, params.read_yaml, filename=temp_file_name+"/nonexistent_directory/params.yml")
 
+def test_no_c_cosmology_object():
+    """Check that using a C cosmology object raises an error"""
+    params = ccl.Parameters(Omega_c=0.25, Omega_b=0.05, h=0.7, A_s=2.1e-9,
+                            n_s=0.96)
+    cosmo = ccl.Cosmology(params=params)
 
+    assert_raises(TypeError, ccl.core._cosmology_obj, cosmo.cosmo)
 
 
 def test_cosmology_init():

--- a/tests/ccl_test_core.py
+++ b/tests/ccl_test_core.py
@@ -199,7 +199,6 @@ def test_no_c_cosmology_object():
     params = ccl.Parameters(Omega_c=0.25, Omega_b=0.05, h=0.7, A_s=2.1e-9,
                             n_s=0.96)
     cosmo = ccl.Cosmology(params=params)
-
     assert_raises(TypeError, ccl.core._cosmology_obj, cosmo.cosmo)
 
 

--- a/tests/ccl_test_core.py
+++ b/tests/ccl_test_core.py
@@ -194,13 +194,6 @@ def test_parameters_read_write():
     assert_raises(IOError, ccl.Parameters.read_yaml, filename=temp_file_name)
     assert_raises(IOError, params.read_yaml, filename=temp_file_name+"/nonexistent_directory/params.yml")
 
-def test_no_c_cosmology_object():
-    """Check that using a C cosmology object raises an error"""
-    params = ccl.Parameters(Omega_c=0.25, Omega_b=0.05, h=0.7, A_s=2.1e-9,
-                            n_s=0.96)
-    cosmo = ccl.Cosmology(params=params)
-    assert_raises(TypeError, ccl.core._cosmology_obj, cosmo.cosmo)
-
 
 def test_cosmology_init():
     """


### PR DESCRIPTION
This PR changes the code to raise an error if the C cosmology object is being used. 

Closes #475 