### PR TITLE
Shallow git clone when getting CLASS and Angpow

### DIFF
--- a/cmake/Modules/BuildAngpow.cmake
+++ b/cmake/Modules/BuildAngpow.cmake
@@ -7,6 +7,7 @@ ExternalProject_Add(ANGPOW
         PREFIX ANGPOW
         GIT_REPOSITORY https://github.com/LSSTDESC/Angpow4CCL.git
         GIT_TAG ${AngpowTag}
+        GIT_SHALLOW 1
         DOWNLOAD_NO_PROGRESS 1
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/extern
                    -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/extern/lib/pkgconfig

--- a/cmake/Modules/BuildCLASS.cmake
+++ b/cmake/Modules/BuildCLASS.cmake
@@ -18,6 +18,7 @@ ExternalProject_Add(CLASS
         PREFIX CLASS
         GIT_REPOSITORY https://github.com/lesgourg/class_public.git
         GIT_TAG ${CLASSTag}
+        GIT_SHALLOW 1
         DOWNLOAD_NO_PROGRESS 1
         PATCH_COMMAND patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/cmake/class-2.6.3.patch
         # In the configuration step, we comment out the default compiler and


### PR DESCRIPTION
When building CCL from scratch, the cloning into CLASS stage tends to take a while. This PR attempts to address this by passing `GIT_SHALLOW` to cmake for CLASS and Angpow. Anecdotally, this speeds up the installation by quite a bit.