### PR TITLE
Enable missing tests

### DIFF
--- a/cmake/Modules/BuildAngpow.cmake
+++ b/cmake/Modules/BuildAngpow.cmake
@@ -7,6 +7,7 @@ ExternalProject_Add(ANGPOW
         PREFIX ANGPOW
         GIT_REPOSITORY https://github.com/LSSTDESC/Angpow4CCL.git
         GIT_TAG ${AngpowTag}
+        GIT_SHALLOW 1
         DOWNLOAD_NO_PROGRESS 1
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/extern
                    -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/extern/lib/pkgconfig

--- a/cmake/Modules/BuildCLASS.cmake
+++ b/cmake/Modules/BuildCLASS.cmake
@@ -18,6 +18,7 @@ ExternalProject_Add(CLASS
         PREFIX CLASS
         GIT_REPOSITORY https://github.com/lesgourg/class_public.git
         GIT_TAG ${CLASSTag}
+        GIT_SHALLOW 1
         DOWNLOAD_NO_PROGRESS 1
         PATCH_COMMAND patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/cmake/class-2.6.3.patch
         # In the configuration step, we comment out the default compiler and

--- a/tests/ccl_test_emu.c
+++ b/tests/ccl_test_emu.c
@@ -163,8 +163,6 @@ CTEST2(emu,model_1) {
 }
 
 
-//Additional tests for other cosmologies are possible:
-/*
 CTEST2(emu,model_2) {
   int model=2;
   compare_emu(model,data);
@@ -189,4 +187,3 @@ CTEST2(emu,model_6) {
   int model=6;
   compare_emu(model,data);
 }
-*/

--- a/tests/ccl_test_emu_nu.c
+++ b/tests/ccl_test_emu_nu.c
@@ -180,8 +180,6 @@ CTEST2(emu_nu,model_1) {
 }
 
 
-//Additional tests are possible:
-/*
 CTEST2(emu_nu,model_2) {
   int model=2;
   compare_emu_nu(model,data);
@@ -196,4 +194,3 @@ CTEST2(emu_nu,model_4) {
   int model=4;
   compare_emu_nu(model,data);
   }
-*/


### PR DESCRIPTION
This branch enables the previously commented-out tests for the cosmic emulator power spectra. This is a fall back option in case we don't manage to get flags for the tests this week (#498). I think we should merge this for now. 