### PR TITLE
Disable GIT_SHALLOW for cmake < 3.10.

### DIFF
--- a/cmake/Modules/BuildAngpow.cmake
+++ b/cmake/Modules/BuildAngpow.cmake
@@ -1,5 +1,12 @@
 include(ExternalProject)
 
+# Old versions of cmake don't seem to play nice with the GIT_SHALLOW option
+if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
+  set(SHALLOW_GIT_CLONE 0)
+else()
+  set(SHALLOW_GIT_CLONE 1)
+endif()
+
 set(AngpowTag v0.4.1)
 
 # Downloads and compiles Angpow
@@ -7,7 +14,7 @@ ExternalProject_Add(ANGPOW
         PREFIX ANGPOW
         GIT_REPOSITORY https://github.com/LSSTDESC/Angpow4CCL.git
         GIT_TAG ${AngpowTag}
-        GIT_SHALLOW 1
+        GIT_SHALLOW ${SHALLOW_GIT_CLONE}
         DOWNLOAD_NO_PROGRESS 1
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/extern
                    -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/extern/lib/pkgconfig

--- a/cmake/Modules/BuildAngpow.cmake
+++ b/cmake/Modules/BuildAngpow.cmake
@@ -1,10 +1,8 @@
 include(ExternalProject)
 
 # Old versions of cmake don't seem to play nice with the GIT_SHALLOW option
-if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
-  set(SHALLOW_GIT_CLONE 0)
-else()
-  set(SHALLOW_GIT_CLONE 1)
+if(${CMAKE_VERSION} VERSION_GREATER "3.10.0")
+  set(SHALLOW_GIT_CLONE GIT_SHALLOW 1)
 endif()
 
 set(AngpowTag v0.4.1)
@@ -14,7 +12,7 @@ ExternalProject_Add(ANGPOW
         PREFIX ANGPOW
         GIT_REPOSITORY https://github.com/LSSTDESC/Angpow4CCL.git
         GIT_TAG ${AngpowTag}
-        GIT_SHALLOW ${SHALLOW_GIT_CLONE}
+        ${SHALLOW_GIT_CLONE}
         DOWNLOAD_NO_PROGRESS 1
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/extern
                    -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}/extern/lib/pkgconfig

--- a/cmake/Modules/BuildCLASS.cmake
+++ b/cmake/Modules/BuildCLASS.cmake
@@ -1,5 +1,12 @@
 include(ExternalProject)
 
+# Old versions of cmake don't seem to play nice with the GIT_SHALLOW option
+if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
+  set(SHALLOW_GIT_CLONE 0)
+else()
+  set(SHALLOW_GIT_CLONE 1)
+endif()
+
 set(CLASSTag v2.6.3)
 
 # In case the compiler being used  is clang, remove the omp flag
@@ -18,7 +25,7 @@ ExternalProject_Add(CLASS
         PREFIX CLASS
         GIT_REPOSITORY https://github.com/lesgourg/class_public.git
         GIT_TAG ${CLASSTag}
-        GIT_SHALLOW 1
+        GIT_SHALLOW ${SHALLOW_GIT_CLONE}
         DOWNLOAD_NO_PROGRESS 1
         PATCH_COMMAND patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/cmake/class-2.6.3.patch
         # In the configuration step, we comment out the default compiler and

--- a/cmake/Modules/BuildCLASS.cmake
+++ b/cmake/Modules/BuildCLASS.cmake
@@ -1,10 +1,8 @@
 include(ExternalProject)
 
 # Old versions of cmake don't seem to play nice with the GIT_SHALLOW option
-if(${CMAKE_VERSION} VERSION_LESS "3.10.0")
-  set(SHALLOW_GIT_CLONE 0)
-else()
-  set(SHALLOW_GIT_CLONE 1)
+if(${CMAKE_VERSION} VERSION_GREATER "3.10.0")
+  set(SHALLOW_GIT_CLONE GIT_SHALLOW 1)
 endif()
 
 set(CLASSTag v2.6.3)
@@ -25,7 +23,7 @@ ExternalProject_Add(CLASS
         PREFIX CLASS
         GIT_REPOSITORY https://github.com/lesgourg/class_public.git
         GIT_TAG ${CLASSTag}
-        GIT_SHALLOW ${SHALLOW_GIT_CLONE}
+        ${SHALLOW_GIT_CLONE}
         DOWNLOAD_NO_PROGRESS 1
         PATCH_COMMAND patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/cmake/class-2.6.3.patch
         # In the configuration step, we comment out the default compiler and


### PR DESCRIPTION
Using `GIT_SHALLOW` in `ExternalProject_Add` makes the cloning a lot faster but seems to break for older cmake versions. This PR attempts to address that. 

Requires testing from people with old cmake versions!