### PR TITLE
Avoid -ffast-math when compiling CLASS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -187,6 +187,10 @@ export CC=gcc
 export CLASS_PARAM_DIR=your_ccl_path/CCL/build/extern/share/class/
 ```
 or add this to your `.bashrc`.
+3. In some systems (for example, NERSC) the `-ffast-math` compiler flag used to compile CLASS will cause segfaults. To avoid this, you can disable this flag by adding `-DCLASS_NO_FFAST_MATH=ON` when calling `cmake` from the `build` directory. I.e.:
+```sh
+$ cmake -DCLASS_NO_FFAST_MATH=ON < any other -D cmake flags > ..
+```
 
 ## Development workflow
 

--- a/cmake/Modules/BuildCLASS.cmake
+++ b/cmake/Modules/BuildCLASS.cmake
@@ -15,6 +15,13 @@ else()
   set(CLASS_OMPFLAG "OMPFLAG   = -fopenmp")
 endif()
 
+#At NERSC, -ffast-math causes trouble
+if (CLASS_NO_FFAST_MATH)
+   set(CLASS_OPTFLAG "OPTFLAG = -O4")
+else()
+   set(CLASS_OPTFLAG "OPTFLAG = -O4 -ffast-math")
+endif()
+
 # Define class install path and sscape the slashes for the Perl command
 STRING(REPLACE "/" "\\/" CLASS_INSTALL_DIR "__CLASSDIR__='\"${CMAKE_INSTALL_PREFIX}/share/ccl\"'")
 
@@ -30,6 +37,7 @@ ExternalProject_Add(CLASS
         # provide an appropriate omp flag
         CONFIGURE_COMMAND     perl -pi -e "s/^CC /# CC /" Makefile &&
                               perl -pi -e "s/^OMPFLAG .*/${CLASS_OMPFLAG}/" Makefile &&
+                              perl -pi -e "s/^OPTFLAG .*/${CLASS_OPTFLAG}/" Makefile &&
                               perl -pi -e "s/__CLASSDIR__.*/${CLASS_INSTALL_DIR}/" Makefile
         BUILD_COMMAND         make CC=${CMAKE_C_COMPILER} libclass.a
         INSTALL_COMMAND       mkdir -p ${CMAKE_BINARY_DIR}/extern/lib &&


### PR DESCRIPTION
In some systems (critically NERSC) the `-ffast-math` compiler flag used to compile CLASS will cause segfaults. This PR adds a `cmake` flag to avoid this issue.

While addressing this, I have also realized that the NERSC instructions on the wiki are outdated, as is [this page](https://confluence.slac.stanford.edu/display/~heather/Building+CCL+at+NERSC). I'll update them after this gets merged.

This PR addresses #539 