### PR TITLE
Compiles CCL for version of  python used to call pip or setup.py

### DIFF
--- a/pyccl/CMakeLists.txt
+++ b/pyccl/CMakeLists.txt
@@ -5,7 +5,7 @@ include(BuildSWIG)
 include(UseSWIG)
 #set (UseSWIG_TARGET_NAME_PREFERENCE STANDARD)
 
-find_package(PythonLibsNew)
+find_package(PythonLibsNew ${PYTHON_VERSION})
 find_package(NumPy)
 include_directories(BEFORE ${PYTHON_INCLUDE_DIRS} ${NUMPY_INCLUDE_DIRS})
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ class build(_build):
     """Specialized Python source builder."""
     def run(self):
         call(["mkdir", "-p", "build"])
-        if call(["cmake", "-H.", "-Bbuild"]) != 0:
+        v = sys.version_info
+        if call(["cmake", "-H.", "-Bbuild" ,
+                 "-DPYTHON_VERSION=%d.%d.%d"%(v.major, v.minor, v.micro)]) != 0:
             raise Exception("Could not run CMake configuration. Make sure CMake is installed !")
         if call(["make", "-Cbuild", "_ccllib"]) != 0:
             raise Exception("Could not build CCL")


### PR DESCRIPTION
This PR aims fixes #541 .  So far, pyccl was compiled for the default python interpreter found in the environment. In some cases, one may want to compile pyccl for a different version, like :
```
$ python2 setup.py build
```
when python3 is the default interpreter. 

With this PR, CMake will accept a new command line option `PYTHON_VERSION` which is used internally when looking for the python interpreter. This could be used in a call to cmake like so:
```
$ cmake .. -DPYTHON_VERSION=2
```
but in practice, the setup.py will take care of providing this option. So, all that is needed is to run `python2 setup.py build` like before.