### PR TITLE
BUG mem leak in power spectrum for v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## C library
+- Fixed memory leak in CLASS power spectrum computations (#561, #562).
+
 # v 1.0 API changes :
 
 ## C library

--- a/src/ccl_power.c
+++ b/src/ccl_power.c
@@ -409,6 +409,9 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
   if (*status == CCL_ERROR_CLASS) {
     //printed error message while running CLASS
     ccl_free_class_structs(cosmo, &ba,&th,&pt,&tr,&pm,&sp,&nl,&le,init_arr,status);
+    
+    // free the parser
+    parser_free(&fc);
     return;
   }
 


### PR DESCRIPTION
This PR fixes the memory leak on the v1.0 release branch in addition to master. 

Closes #547 