### PR TITLE
BUG eval power spectrum near zero better v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## C library
+- Fixed a bug where CLASS would crash due to small rounding errors at z = 0 
+  when evaluating power spectra (#563, #564).
+
 # v 1.0 API changes :
 
 ## C library

--- a/src/ccl_power.c
+++ b/src/ccl_power.c
@@ -462,7 +462,7 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
 	//The 2D interpolation routines access the function values y_{k_ia_j} with the following ordering:
 	//y_ij = y2d[j*N_k + i]
 	//with i = 0,...,N_k-1 and j = 0,...,N_a-1.
-	newstatus |= spectra_pk_at_k_and_z(&ba, &pm, &sp,x[i],1./a[j]-1., &psout_l,&ic);
+	newstatus |= spectra_pk_at_k_and_z(&ba, &pm, &sp,x[i],1./a[j]-1.+1e-10, &psout_l,&ic);
 	y2d_lin[j*nk+i] = log(psout_l);
       }
       x[i] = log(x[i]);
@@ -526,7 +526,7 @@ static void ccl_cosmology_compute_power_class(ccl_cosmology * cosmo, int * statu
       double psout_nl;
       for (int i=0; i<nk; i++) {
 	for (int j = 0; j < na; j++) {
-	  newstatus |= spectra_pk_nl_at_k_and_z(&ba, &pm, &sp,exp(x[i]),1./a[j]-1.,&psout_nl);
+	  newstatus |= spectra_pk_nl_at_k_and_z(&ba, &pm, &sp,exp(x[i]),1./a[j]-1.+1e-10,&psout_nl);
 	  y2d_nl[j*nk+i] = log(psout_nl);
 	}
       }
@@ -1289,7 +1289,7 @@ static void ccl_cosmology_compute_power_emu(ccl_cosmology * cosmo, int * status)
 	//The 2D interpolation routines access the function values y_{k_ia_j} with the following ordering:
 	//y_ij = y2d[j*N_k + i]
 	//with i = 0,...,N_k-1 and j = 0,...,N_a-1.
-	s |= spectra_pk_at_k_and_z(&ba, &pm, &sp,x[i],1./a[j]-1., &psout_l,&ic);
+	s |= spectra_pk_at_k_and_z(&ba, &pm, &sp,x[i],1./a[j]-1.+1e-10, &psout_l,&ic);
 	y2d_lin[j*nk+i] = log(psout_l);
       }
       x[i] = log(x[i]);


### PR DESCRIPTION
This PR fixes the power spectrum bug eval at zero for the v1.0 branch. 