### PR TITLE
CCL terms of reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,8 @@ For known installation issues and further information on how CCL was benchmarked
 # License, Credits, Feedback etc
 This code has been released by DESC, although it is still under active development. It is accompanied by a journal paper that describes the development and validation of `CCL`, which you can find on the  arxiv:[1812.05995](https://arxiv.org/abs/1812.05995). If you make use of the ideas or software here, please cite that paper and provide a link to this repository: https://github.com/LSSTDESC/CCL. You are welcome to re-use the code, which is open source and available under terms consistent with our [LICENSE](https://github.com/LSSTDESC/CCL/blob/master/LICENSE), which is a [BSD 3-Clause](https://opensource.org/licenses/BSD-3-Clause) license. 
 
+External contributors and DESC members wishing to use CCL for non-DESC projects should consult with the TJP working group conveners, ideally before the work has started, but definitely before any publication or posting of the work to the arXiv.
+
 For free use of the `CLASS` library, the `CLASS` developers require that the `CLASS` paper be cited: CLASS II: Approximation schemes, D. Blas, J. Lesgourgues, T. Tram, arXiv:1104.2933, JCAP 1107 (2011) 034. The `CLASS` repository can be found in http://class-code.net. Finally, CCL uses code from the [FFTLog](http://casa.colorado.edu/~ajsh/FFTLog/) package.  We have obtained permission from the FFTLog author to include modified versions of his source code.
 
 # Contact

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,58 @@
+Core Cosmology Library: Terms of reference
+---------------------------------------
+
+This document lays out terms of reference for CCL developers and contributors in the wider TJP and LSST DESC context.
+
+Background
+---------------------------------------
+
+CCL was created to provide theoretical predictions of large-scale structure statistics for DESC cosmological analyses but it has also become a publicly available tool. 
+
+Scope
+---------------------------------------
+
+CCL has a commitment to support key DESC analyses. In this regard, CCL aims to
+
+-support cosmological models that are priorities for WGs (e.g., as defined by the "Beyond wCDM" taskforce);
+-ensure sufficient flexibility such that modifications can be implemented at a later stage as needed (e.g., models for observational systematics or changes to how the non-linear power spectrum is computed for various parts of the analysis);
+-support core predictions (e.g., shear correlation functions), but not necessarily every statistic that could be computed from those core predictions (e.g., COSEBIs).
+
+CCL interface support is as follows.
+
+-Public APIs are maintained in Python only (i.e., version bumping is not necessary following changes in the C interface).
+-The C implementation can be used for speed as needed.
+-Documentation should be maintained in the main README, readthedocs and the benchmarks folder.
+-Examples will be maintained in a separate repository.
+
+Boundaries of CCL (with respect to various models and systematics)
+
+-Not all models need to have equal support. CCL aims to support the DESC analyses, not to support all possible statistics in all models.
+-CCL should provide a generic framework to enable modeling of systematics effects. However, overly specific models for systematics are best located in other repositories (e.g., firecrown).
+
+Boundaries of CCL (with respect to other TJP software)
+
+-TJP will necessarily develop other software tools to support DESC cosmological analyses. CCL development should ensure internal consistency between the various tools by defining a common parameterization of theoretical quantities (e.g., kernels for Limber integration, the metric potentials, etc.).
+-CCL development should also proceed in a manner to avoid significant duplication of effort within the collaboration.
+
+Standards to establish the quality of code that can be part of CCL
+---------------------------------------
+
+-Contributions to CCL should be well-documented in python (only doc-string level docs are required, readthedocs does the rest). C code is expected to be commented, though not documented.
+-Features added to CCL should pass required tests.
+	  1.one (publicly available) benchmark with an independent prediction should be provided to test the specific feature that has been added. The benchmark code can use CCL input as long as that is not affecting the validation procedure. 
+	  2.Tests should run in continuous integration scheme used for CCL.
+	  3.Unit tests should be written as identified in code review.
+-All PRs are code reviewed by at least one person (two are suggested for PRs that bring in new features or propose significant changes to the CCL API).
+CCL uses semantic versioning.
+-We should aim to tag new versions with bug fixes on a monthly basis with the expectation that no release is made if no new bugs have been fixed.
+-Critical bug fixes should be released almost immediately via bump of the micro version and a new release. 
+
+Guidelines towards contribution
+---------------------------------------
+
+-Contributions should be made via PRs, and such PRs should be reviewed as described above.  
+-Response to code review requests should be prompt and happen within a few days of being requested on github by the author of the PR. Code review by members of the CCL development team should happen within a week of the request being accepted. 
+-CONTRIBUTING file should be consulted by those making PRs.
+-Developers should use standard DESC channels to interact with the team (e.g., Slack, telecons, etc.).
+-Developers should seek consensus with the team as needed about new features being incorporated (especially for API changes or additions). This process should happen via the CCL telecons, slack channel, or github comments generally before a new feature is merged. More minor changes, like bug fixes or refactoring, do not necessarily need this process.
+-External contributions. They come in different forms: bug fixes or new features. They should proceed in full awareness of the LSST DESC Publication Policy. In particular, the use of new features added to the library, but not officially released, may require more formal steps to be taken within the DESC. External contributors and DESC members wishing to use CCL for non-DESC projects should consult with the TJP working group conveners, ideally before the work has started, but definitely before any publication or posting of the work to the arXiv.

--- a/TERMS.md
+++ b/TERMS.md
@@ -13,66 +13,66 @@ Scope
 
 CCL has a commitment to support key DESC analyses. In this regard, CCL aims to
 
--support cosmological models that are priorities for WGs (e.g., as defined by the "Beyond wCDM" taskforce);
+- support cosmological models that are priorities for WGs (e.g., as defined by the "Beyond wCDM" taskforce);
 
--ensure sufficient flexibility such that modifications can be implemented at a later stage as needed (e.g., models for observational systematics or changes to how the non-linear power spectrum is computed for various parts of the analysis);
+- ensure sufficient flexibility such that modifications can be implemented at a later stage as needed (e.g., models for observational systematics or changes to how the non-linear power spectrum is computed for various parts of the analysis);
 
--support core predictions (e.g., shear correlation functions), but not necessarily every statistic that could be computed from those core predictions (e.g., COSEBIs).
+- support core predictions (e.g., shear correlation functions), but not necessarily every statistic that could be computed from those core predictions (e.g., COSEBIs).
 
 CCL interface support is as follows.
 
--Public APIs are maintained in Python only (i.e., version bumping is not necessary following changes in the C interface).
+- Public APIs are maintained in Python only (i.e., version bumping is not necessary following changes in the C interface).
 
--The C implementation can be used for speed as needed.
+- The C implementation can be used for speed as needed.
 
--Documentation should be maintained in the main README, readthedocs and the benchmarks folder.
+- Documentation should be maintained in the main README, readthedocs and the benchmarks folder.
 
--Examples will be maintained in a separate repository.
+- Examples will be maintained in a separate repository.
 
 Boundaries of CCL (with respect to various models and systematics)
 
--Not all models need to have equal support. CCL aims to support the DESC analyses, not to support all possible statistics in all models.
+- Not all models need to have equal support. CCL aims to support the DESC analyses, not to support all possible statistics in all models.
 
--CCL should provide a generic framework to enable modeling of systematics effects. However, overly specific models for systematics are best located in other repositories (e.g., firecrown).
+- CCL should provide a generic framework to enable modeling of systematics effects. However, overly specific models for systematics are best located in other repositories (e.g., firecrown).
 
 Boundaries of CCL (with respect to other TJP software)
 
--TJP will necessarily develop other software tools to support DESC cosmological analyses. CCL development should ensure internal consistency between the various tools by defining a common parameterization of theoretical quantities (e.g., kernels for Limber integration, the metric potentials, etc.).
+- TJP will necessarily develop other software tools to support DESC cosmological analyses. CCL development should ensure internal consistency between the various tools by defining a common parameterization of theoretical quantities (e.g., kernels for Limber integration, the metric potentials, etc.).
 
--CCL development should also proceed in a manner to avoid significant duplication of effort within the collaboration.
+- CCL development should also proceed in a manner to avoid significant duplication of effort within the collaboration.
 
 Standards to establish the quality of code that can be part of CCL
 ---------------------------------------
 
--Contributions to CCL should be well-documented in python (only doc-string level docs are required, readthedocs does the rest). C code is expected to be commented, though not documented.
+- Contributions to CCL should be well-documented in python (only doc-string level docs are required, readthedocs does the rest). C code is expected to be commented, though not documented.
 
--Features added to CCL should pass required tests.
+- Features added to CCL should pass required tests.
 
-1.one (publicly available) benchmark with an independent prediction should be provided to test the specific feature that has been added. The benchmark code can use CCL input as long as that is not affecting the validation procedure. 
+	1. one (publicly available) benchmark with an independent prediction should be provided to test the specific feature that has been added. The benchmark code can use CCL input as long as that is not affecting the validation procedure. 
 	   
-2.Tests should run in continuous integration scheme used for CCL.
+	2. Tests should run in continuous integration scheme used for CCL.
 
-3.Unit tests should be written as identified in code review.
+	3. Unit tests should be written as identified in code review.
 
--All PRs are code reviewed by at least one person (two are suggested for PRs that bring in new features or propose significant changes to the CCL API).
+- All PRs are code reviewed by at least one person (two are suggested for PRs that bring in new features or propose significant changes to the CCL API).
 
--CCL uses semantic versioning.
+- CCL uses semantic versioning.
 
--We should aim to tag new versions with bug fixes on a monthly basis with the expectation that no release is made if no new bugs have been fixed.
+- We should aim to tag new versions with bug fixes on a monthly basis with the expectation that no release is made if no new bugs have been fixed.
 
--Critical bug fixes should be released almost immediately via bump of the micro version and a new release. 
+- Critical bug fixes should be released almost immediately via bump of the micro version and a new release. 
 
 Guidelines towards contribution
 ---------------------------------------
 
--Contributions should be made via PRs, and such PRs should be reviewed as described above.  
+- Contributions should be made via PRs, and such PRs should be reviewed as described above.  
 
--Response to code review requests should be prompt and happen within a few days of being requested on github by the author of the PR. Code review by members of the CCL development team should happen within a week of the request being accepted. 
+- Response to code review requests should be prompt and happen within a few days of being requested on github by the author of the PR. Code review by members of the CCL development team should happen within a week of the request being accepted. 
 
--CONTRIBUTING file should be consulted by those making PRs.
+- CONTRIBUTING file should be consulted by those making PRs.
 
--Developers should use standard DESC channels to interact with the team (e.g., Slack, telecons, etc.).
+- Developers should use standard DESC channels to interact with the team (e.g., Slack, telecons, etc.).
 
--Developers should seek consensus with the team as needed about new features being incorporated (especially for API changes or additions). This process should happen via the CCL telecons, slack channel, or github comments generally before a new feature is merged. More minor changes, like bug fixes or refactoring, do not necessarily need this process.
+- Developers should seek consensus with the team as needed about new features being incorporated (especially for API changes or additions). This process should happen via the CCL telecons, slack channel, or github comments generally before a new feature is merged. More minor changes, like bug fixes or refactoring, do not necessarily need this process.
 
--External contributions. They come in different forms: bug fixes or new features. They should proceed in full awareness of the LSST DESC Publication Policy. In particular, the use of new features added to the library, but not officially released, may require more formal steps to be taken within the DESC. External contributors and DESC members wishing to use CCL for non-DESC projects should consult with the TJP working group conveners, ideally before the work has started, but definitely before any publication or posting of the work to the arXiv.
+- External contributions. They come in different forms: bug fixes or new features. They should proceed in full awareness of the LSST DESC Publication Policy. In particular, the use of new features added to the library, but not officially released, may require more formal steps to be taken within the DESC. External contributors and DESC members wishing to use CCL for non-DESC projects should consult with the TJP working group conveners, ideally before the work has started, but definitely before any publication or posting of the work to the arXiv.

--- a/TERMS.md
+++ b/TERMS.md
@@ -33,7 +33,7 @@ Boundaries of CCL (with respect to various models and systematics)
 
 - Not all models need to have equal support. CCL aims to support the DESC analyses, not to support all possible statistics in all models.
 
-- CCL should provide a generic framework to enable modeling of systematics effects. However, overly specific models for systematics are best located in other repositories (e.g., firecrown).
+- CCL should provide a generic framework to enable modeling of systematics effects. However, overly specific models for systematics, for example, for galaxy bias, detector effects or intrinsic alignments, are best located in other repositories (e.g., firecrown).
 
 Boundaries of CCL (with respect to other TJP software)
 
@@ -52,7 +52,7 @@ Standards to establish the quality of code that can be part of CCL
 	   
 	2. Tests should run in continuous integration scheme used for CCL.
 
-	3. Unit tests should be written as identified in code review.
+	3. Unit tests should be written following the suggestions of the PR reviewers.
 
 - All PRs are code reviewed by at least one person (two are suggested for PRs that bring in new features or propose significant changes to the CCL API).
 

--- a/TERMS.md
+++ b/TERMS.md
@@ -14,45 +14,65 @@ Scope
 CCL has a commitment to support key DESC analyses. In this regard, CCL aims to
 
 -support cosmological models that are priorities for WGs (e.g., as defined by the "Beyond wCDM" taskforce);
+
 -ensure sufficient flexibility such that modifications can be implemented at a later stage as needed (e.g., models for observational systematics or changes to how the non-linear power spectrum is computed for various parts of the analysis);
+
 -support core predictions (e.g., shear correlation functions), but not necessarily every statistic that could be computed from those core predictions (e.g., COSEBIs).
 
 CCL interface support is as follows.
 
 -Public APIs are maintained in Python only (i.e., version bumping is not necessary following changes in the C interface).
+
 -The C implementation can be used for speed as needed.
+
 -Documentation should be maintained in the main README, readthedocs and the benchmarks folder.
+
 -Examples will be maintained in a separate repository.
 
 Boundaries of CCL (with respect to various models and systematics)
 
 -Not all models need to have equal support. CCL aims to support the DESC analyses, not to support all possible statistics in all models.
+
 -CCL should provide a generic framework to enable modeling of systematics effects. However, overly specific models for systematics are best located in other repositories (e.g., firecrown).
 
 Boundaries of CCL (with respect to other TJP software)
 
 -TJP will necessarily develop other software tools to support DESC cosmological analyses. CCL development should ensure internal consistency between the various tools by defining a common parameterization of theoretical quantities (e.g., kernels for Limber integration, the metric potentials, etc.).
+
 -CCL development should also proceed in a manner to avoid significant duplication of effort within the collaboration.
 
 Standards to establish the quality of code that can be part of CCL
 ---------------------------------------
 
 -Contributions to CCL should be well-documented in python (only doc-string level docs are required, readthedocs does the rest). C code is expected to be commented, though not documented.
+
 -Features added to CCL should pass required tests.
-	  1.one (publicly available) benchmark with an independent prediction should be provided to test the specific feature that has been added. The benchmark code can use CCL input as long as that is not affecting the validation procedure. 
-	  2.Tests should run in continuous integration scheme used for CCL.
-	  3.Unit tests should be written as identified in code review.
+
+1.one (publicly available) benchmark with an independent prediction should be provided to test the specific feature that has been added. The benchmark code can use CCL input as long as that is not affecting the validation procedure. 
+	   
+2.Tests should run in continuous integration scheme used for CCL.
+
+3.Unit tests should be written as identified in code review.
+
 -All PRs are code reviewed by at least one person (two are suggested for PRs that bring in new features or propose significant changes to the CCL API).
-CCL uses semantic versioning.
+
+-CCL uses semantic versioning.
+
 -We should aim to tag new versions with bug fixes on a monthly basis with the expectation that no release is made if no new bugs have been fixed.
+
 -Critical bug fixes should be released almost immediately via bump of the micro version and a new release. 
 
 Guidelines towards contribution
 ---------------------------------------
 
 -Contributions should be made via PRs, and such PRs should be reviewed as described above.  
+
 -Response to code review requests should be prompt and happen within a few days of being requested on github by the author of the PR. Code review by members of the CCL development team should happen within a week of the request being accepted. 
+
 -CONTRIBUTING file should be consulted by those making PRs.
+
 -Developers should use standard DESC channels to interact with the team (e.g., Slack, telecons, etc.).
+
 -Developers should seek consensus with the team as needed about new features being incorporated (especially for API changes or additions). This process should happen via the CCL telecons, slack channel, or github comments generally before a new feature is merged. More minor changes, like bug fixes or refactoring, do not necessarily need this process.
+
 -External contributions. They come in different forms: bug fixes or new features. They should proceed in full awareness of the LSST DESC Publication Policy. In particular, the use of new features added to the library, but not officially released, may require more formal steps to be taken within the DESC. External contributors and DESC members wishing to use CCL for non-DESC projects should consult with the TJP working group conveners, ideally before the work has started, but definitely before any publication or posting of the work to the arXiv.


### PR DESCRIPTION
Adds the terms of reference discussed in the telecons and the Slack channel.