### PR TITLE
BUG cannot have `va` stuff in critical section for some compilers

### DIFF
--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -885,16 +885,18 @@ TASK: set the status message safely.
 void ccl_cosmology_set_status_message(ccl_cosmology * cosmo, const char * message, ...) {
   const int trunc = 480; /* must be < 500 - 4 */
 
+  va_list va;
+  va_start(va, message);
+
   #pragma omp critical
   {
-    va_list va;
-    va_start(va, message);
     vsnprintf(cosmo->status_message, trunc, message, va);
-    va_end(va);
 
     /* if truncation happens, message[trunc - 1] is not NULL, ... will show up. */
     strcpy(&cosmo->status_message[trunc], "...");
   }
+
+  va_end(va);
 }
 
 /* ------- ROUTINE: ccl_parameters_free --------


### PR DESCRIPTION
I was working on getting us into conda-forge and their compilers found this bug.