### PR TITLE
Changed yaml.load to yaml.safe_load in core.py

### DIFF
--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -218,7 +218,7 @@ class Cosmology(object):
             filename (:obj:`str`) Filename to read parameters from.
         """
         with open(filename, 'r') as fp:
-            params = yaml.load(fp, Loader=yaml.Loader)
+            params = yaml.safe_load(fp)
 
         # Now we assemble an init for the object since the CCL YAML has
         # extra info we don't need and different formatting.


### PR DESCRIPTION
The newer versions of pyyaml produce a warning when using `yaml.load`.  This switches to `yaml.safe_load`, which disables some features that we aren't using.