### PR TITLE
BUG fix PyPi release by adding extra files to the sdist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.0.1 Changes
+
+## Bug Fixes
+- Fixed a PyPi installation bug where the proper files for `CMAKE` were not
+  included in the source distribution.
+
 # v 2.0 Changes
 
 ## Python library

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,8 @@ recursive-include include *
 recursive-include src *
 recursive-include pyccl *.i CMakeLists.txt
 recursive-exclude examples *.ipynb
-prune benchmarks
+recursive-include benchmarks *.c
+recursive-include benchmarks *.h
 include CMakeLists.txt
 include pyccl/CMakeLists.txt
 include LICENSE


### PR DESCRIPTION
This PR adds some extra files to the sdist in order to fix the PyPi release. IDK how we did not catch this before. :/