### PR TITLE
Spline integral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 ## Python library
+- Added a "spline" integration method to carry out Limber integrals.
 - Added a function for the angular diameter distance difference between two scale factors (#645)
 - Extended implementation of halo profiles (#722).
 - Improved FFTLog API (#722).
@@ -8,6 +9,7 @@
 - Improved implementation of halo model quantities (n(M), b(M), c(M)) (#668, #655, #656, #657, #636).
 
 ## C library
+- Added a "spline" integration method to carry out Limber integrals.
 - Added function for the angular diameter distance difference between two scale factors (#645)
 - Removed old C/C++ examples (#725)
 - Extended implementation of halo profiles (#722).

--- a/benchmarks/test_cls.py
+++ b/benchmarks/test_cls.py
@@ -194,7 +194,28 @@ def set_up(request):
 def test_cls(set_up, t1, t2, bm,
              a1b1, a1b2, a2b1, a2b2, fl):
     cosmo, trcs, lfc, bmk = set_up
-    cl = ccl.angular_cl(cosmo, trcs[t1], trcs[t2], lfc['ells']) * lfc[fl]
+    cl = ccl.angular_cl(cosmo, trcs[t1], trcs[t2], lfc['ells'],
+                        limber_integration_method='quad') * lfc[fl]
     el = np.sqrt((bmk[a1b1] * bmk[a2b2] + bmk[a1b2] * bmk[a2b1]) /
                  (2 * lfc['ells'] + 1.))
     assert np.all(np.fabs(cl - bmk[bm]) < 0.1 * el)
+
+
+@pytest.mark.parametrize("t1,t2,bm,a1b1,a1b2,a2b1,a2b2,fl",
+                         [('g1', 'g1', 'dd_11',   # NC1-NC1
+                           'dd_11', 'dd_11', 'dd_11', 'dd_11',
+                           'fl_one'),
+                          ('g1', 'g2', 'dd_12',   # NC1-NC2
+                           'dd_11', 'dd_12', 'dd_12', 'dd_22',
+                           'fl_one'),
+                          ('l2', 'l2', 'll_22',   # WL2-WL2
+                           'll_22', 'll_22', 'll_22', 'll_22',
+                           'fl_ll')])
+def test_cls_spline(set_up, t1, t2, bm,
+                    a1b1, a1b2, a2b1, a2b2, fl):
+    cosmo, trcs, lfc, bmk = set_up
+    cl = ccl.angular_cl(cosmo, trcs[t1], trcs[t2], lfc['ells'],
+                        limber_integration_method='spline') * lfc[fl]
+    el = np.sqrt((bmk[a1b1] * bmk[a2b2] + bmk[a1b2] * bmk[a2b1]) /
+                 (2 * lfc['ells'] + 1.))
+    assert np.all(np.fabs(cl - bmk[bm]) < 0.2 * el)

--- a/benchmarks/test_cls.py
+++ b/benchmarks/test_cls.py
@@ -195,7 +195,7 @@ def test_cls(set_up, t1, t2, bm,
              a1b1, a1b2, a2b1, a2b2, fl):
     cosmo, trcs, lfc, bmk = set_up
     cl = ccl.angular_cl(cosmo, trcs[t1], trcs[t2], lfc['ells'],
-                        limber_integration_method='quad') * lfc[fl]
+                        limber_integration_method='qag_quad') * lfc[fl]
     el = np.sqrt((bmk[a1b1] * bmk[a2b2] + bmk[a1b2] * bmk[a2b1]) /
                  (2 * lfc['ells'] + 1.))
     assert np.all(np.fabs(cl - bmk[bm]) < 0.1 * el)

--- a/include/ccl_cls.h
+++ b/include/ccl_cls.h
@@ -41,7 +41,7 @@ void ccl_angular_cls_nonlimber(ccl_cosmology *cosmo,
          ccl_cl_tracer_collection_t *trc2,
          ccl_f2d_t *psp,
          int nl_out,int *l_out,double *cl_out,
-	 int *status);
+         int *status);
 
 CCL_END_DECLS
 #endif

--- a/include/ccl_cls.h
+++ b/include/ccl_cls.h
@@ -21,7 +21,9 @@ void ccl_angular_cls_limber(ccl_cosmology *cosmo,
        ccl_cl_tracer_collection_t *trc1,
        ccl_cl_tracer_collection_t *trc2,
        ccl_f2d_t *psp,
-       int nl_out, double *l_out, double *cl_out, int *status);
+       int nl_out, double *l_out, double *cl_out,
+       ccl_integration_t integration_method,
+       int *status);
 /**
  * Computes non-Limber power spectrum for two different tracers at a given ell.
  * @param cosmo Cosmological parameters
@@ -39,7 +41,7 @@ void ccl_angular_cls_nonlimber(ccl_cosmology *cosmo,
          ccl_cl_tracer_collection_t *trc2,
          ccl_f2d_t *psp,
          int nl_out,int *l_out,double *cl_out,
-         int *status);
+	 int *status);
 
 CCL_END_DECLS
 #endif

--- a/include/ccl_core.h
+++ b/include/ccl_core.h
@@ -125,6 +125,7 @@ typedef struct ccl_spline_params {
   double K_MAX_SPLINE;
   double K_MAX;
   double K_MIN;
+  double DLOGK_INTEGRATION;
   int N_K;
   int N_K_3DCOR;
 

--- a/include/ccl_utils.h
+++ b/include/ccl_utils.h
@@ -57,8 +57,8 @@ double ccl_j_bessel(int l,double x);
  * @return spline integral
  */
 double ccl_integ_spline(int n,double *x,double *y,
-			double a, double b,
-			gsl_interp_type *T, int *status);
+                        double a, double b,
+                        gsl_interp_type *T, int *status);
 
 CCL_END_DECLS
 

--- a/include/ccl_utils.h
+++ b/include/ccl_utils.h
@@ -10,7 +10,7 @@
 CCL_BEGIN_DECLS
 
 typedef enum ccl_integration_t {
-  ccl_integration_quad = 500,  // GSL's quad
+  ccl_integration_qag_quad = 500,  // GSL's quad
   ccl_integration_spline = 501,  // Spline integral
 } ccl_integration_t;
 
@@ -58,7 +58,7 @@ double ccl_j_bessel(int l,double x);
  */
 double ccl_integ_spline(int n,double *x,double *y,
                         double a, double b,
-                        gsl_interp_type *T, int *status);
+                        const gsl_interp_type *T, int *status);
 
 CCL_END_DECLS
 

--- a/include/ccl_utils.h
+++ b/include/ccl_utils.h
@@ -9,6 +9,11 @@
 
 CCL_BEGIN_DECLS
 
+typedef enum ccl_integration_t {
+  ccl_integration_quad = 500,  // GSL's quad
+  ccl_integration_spline = 501,  // Spline integral
+} ccl_integration_t;
+
 /**
  * Compute bin edges of N-1 linearly spaced bins on the interval [xmin,xmax]
  * @param xmin minimum value of spacing

--- a/include/ccl_utils.h
+++ b/include/ccl_utils.h
@@ -42,6 +42,19 @@ double * ccl_log_spacing(double xmin, double xmax, int N);
 double ccl_j_bessel(int l,double x);
 //Spherical Bessel function of order l (adapted from CAMB)
 
+/**
+ * Compute spline integral.
+ * @param n number of elements in input array.
+ * @param x input x-values.
+ * @param y input y-values.
+ * @param a lower end of integration range.
+ * @param b upper end of integration range (use b<a if you just want to integrate over all of y).
+ * @return spline integral
+ */
+double ccl_integ_spline(int n,double *x,double *y,
+			double a, double b,
+			gsl_interp_type *T, int *status);
+
 CCL_END_DECLS
 
 #endif

--- a/pyccl/ccl_cls.i
+++ b/pyccl/ccl_cls.i
@@ -22,7 +22,7 @@ void angular_cl_vec(ccl_cosmology * cosmo,
                     ccl_cl_tracer_collection_t *clt2,
                     ccl_f2d_t *pspec, double l_limber,
                     double* ell, int nell,
-		    int integration_type,
+                    int integration_type,
                     int nout, double* output,
                     int *status) {
 
@@ -72,7 +72,7 @@ void angular_cl_vec(ccl_cosmology * cosmo,
       _ell[i - (index_nonlimber_last+1)] = ell[i];
 
     ccl_angular_cls_limber(cosmo, clt1, clt2, pspec, (nell - (index_nonlimber_last+1)), _ell, _cl_ell,
-			   integration_type, status);
+                           integration_type, status);
 
     for (int i=index_nonlimber_last+1; i < nell; i++)
       output[i] = _cl_ell[i - (index_nonlimber_last+1)];

--- a/pyccl/ccl_cls.i
+++ b/pyccl/ccl_cls.i
@@ -22,6 +22,7 @@ void angular_cl_vec(ccl_cosmology * cosmo,
                     ccl_cl_tracer_collection_t *clt2,
                     ccl_f2d_t *pspec, double l_limber,
                     double* ell, int nell,
+		    int integration_type,
                     int nout, double* output,
                     int *status) {
 
@@ -70,7 +71,8 @@ void angular_cl_vec(ccl_cosmology * cosmo,
     for (int i=index_nonlimber_last+1; i < nell; i++)
       _ell[i - (index_nonlimber_last+1)] = ell[i];
 
-    ccl_angular_cls_limber(cosmo, clt1, clt2, pspec, (nell - (index_nonlimber_last+1)), _ell, _cl_ell, status);
+    ccl_angular_cls_limber(cosmo, clt1, clt2, pspec, (nell - (index_nonlimber_last+1)), _ell, _cl_ell,
+			   integration_type, status);
 
     for (int i=index_nonlimber_last+1; i < nell; i++)
       output[i] = _cl_ell[i - (index_nonlimber_last+1)];

--- a/pyccl/cls.py
+++ b/pyccl/cls.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .errors import CCLWarning
 from . import ccllib as lib
-from .pyutils import check
+from .pyutils import check, integ_types
 from .pk2d import Pk2D
 
 # Define symbolic 'None' type for arrays, to allow proper handling by swig
@@ -13,7 +13,7 @@ NoneArr = np.array([])
 
 
 def angular_cl(cosmo, cltracer1, cltracer2, ell, p_of_k_a=None,
-               l_limber=-1.):
+               l_limber=-1., limber_integration_method='quad'):
     """Calculate the angular (cross-)power spectrum for a pair of tracers.
 
     Args:
@@ -25,6 +25,8 @@ def angular_cl(cosmo, cltracer1, cltracer2, ell, p_of_k_a=None,
             the non-linear matter power spectrum will be used.
         l_limber (float) : Angular wavenumber beyond which Limber's
             approximation will be used. Defaults to -1.
+        limber_integration_method (string) : integration method to be used
+            for the Limber integrals. Possibilities: 'quad'.
 
     Returns:
         float or array_like: Angular (cross-)power spectrum values,
@@ -36,6 +38,10 @@ def angular_cl(cosmo, cltracer1, cltracer2, ell, p_of_k_a=None,
             "CCL does not properly use the hyperspherical Bessel functions "
             "when computing angular power spectra in non-flat cosmologies!",
             category=CCLWarning)
+
+    if limber_integration_method not in ['quad']:
+        raise ValueError("Integration method %s not supported" %
+                         limber_integration_method)
 
     # we need the distances for the integrals
     cosmo.compute_distances()
@@ -74,7 +80,8 @@ def angular_cl(cosmo, cltracer1, cltracer2, ell, p_of_k_a=None,
     # Return Cl values, according to whether ell is an array or not
     cl, status = lib.angular_cl_vec(
         cosmo, clt1, clt2, psp, l_limber,
-        ell_use, ell_use.size, status)
+        ell_use, integ_types[limber_integration_method],
+        ell_use.size, status)
     if np.ndim(ell) == 0:
         cl = cl[0]
 

--- a/pyccl/cls.py
+++ b/pyccl/cls.py
@@ -13,7 +13,7 @@ NoneArr = np.array([])
 
 
 def angular_cl(cosmo, cltracer1, cltracer2, ell, p_of_k_a=None,
-               l_limber=-1., limber_integration_method='quad'):
+               l_limber=-1., limber_integration_method='qag_quad'):
     """Calculate the angular (cross-)power spectrum for a pair of tracers.
 
     Args:
@@ -26,9 +26,9 @@ def angular_cl(cosmo, cltracer1, cltracer2, ell, p_of_k_a=None,
         l_limber (float) : Angular wavenumber beyond which Limber's
             approximation will be used. Defaults to -1.
         limber_integration_method (string) : integration method to be used
-            for the Limber integrals. Possibilities: 'quad' (GSL's `quad`
-            method) and 'spline' (the integrand is splined and then
-            integrated analytically).
+            for the Limber integrals. Possibilities: 'qag_quad' (GSL's `qag`
+            method backed up by `quad` when it fails) and 'spline' (the
+            integrand is splined and then integrated analytically).
 
     Returns:
         float or array_like: Angular (cross-)power spectrum values,
@@ -41,7 +41,7 @@ def angular_cl(cosmo, cltracer1, cltracer2, ell, p_of_k_a=None,
             "when computing angular power spectra in non-flat cosmologies!",
             category=CCLWarning)
 
-    if limber_integration_method not in ['quad', 'spline']:
+    if limber_integration_method not in ['qag_quad', 'spline']:
         raise ValueError("Integration method %s not supported" %
                          limber_integration_method)
 

--- a/pyccl/cls.py
+++ b/pyccl/cls.py
@@ -26,7 +26,9 @@ def angular_cl(cosmo, cltracer1, cltracer2, ell, p_of_k_a=None,
         l_limber (float) : Angular wavenumber beyond which Limber's
             approximation will be used. Defaults to -1.
         limber_integration_method (string) : integration method to be used
-            for the Limber integrals. Possibilities: 'quad'.
+            for the Limber integrals. Possibilities: 'quad' (GSL's `quad`
+            method) and 'spline' (the integrand is splined and then
+            integrated analytically).
 
     Returns:
         float or array_like: Angular (cross-)power spectrum values,
@@ -39,7 +41,7 @@ def angular_cl(cosmo, cltracer1, cltracer2, ell, p_of_k_a=None,
             "when computing angular power spectra in non-flat cosmologies!",
             category=CCLWarning)
 
-    if limber_integration_method not in ['quad']:
+    if limber_integration_method not in ['quad', 'spline']:
         raise ValueError("Integration method %s not supported" %
                          limber_integration_method)
 

--- a/pyccl/pyutils.py
+++ b/pyccl/pyutils.py
@@ -7,7 +7,7 @@ import functools
 import warnings
 import numpy as np
 
-integ_types = {'quad': lib.integration_quad,
+integ_types = {'qag_quad': lib.integration_qag_quad,
                'spline': lib.integration_spline}
 
 extrap_types = {'none': lib.f1d_extrap_0,

--- a/pyccl/pyutils.py
+++ b/pyccl/pyutils.py
@@ -7,6 +7,9 @@ import functools
 import warnings
 import numpy as np
 
+integ_types = {'quad': lib.integration_quad,
+               'spline': lib.integration_spline}
+
 extrap_types = {'none': lib.f1d_extrap_0,
                 'constant': lib.f1d_extrap_const,
                 'linx_liny': lib.f1d_extrap_linx_liny,

--- a/pyccl/tests/test_swig_interface.py
+++ b/pyccl/tests/test_swig_interface.py
@@ -102,7 +102,7 @@ def test_swig_cls():
         ccllib.angular_cl_vec,
         COSMO,
         None, None, None,
-        1, 0, 501,
+        1, 0, pyccl.pyutils.integ_types['spline'],
         "none",
         status)
 

--- a/pyccl/tests/test_swig_interface.py
+++ b/pyccl/tests/test_swig_interface.py
@@ -102,7 +102,7 @@ def test_swig_cls():
         ccllib.angular_cl_vec,
         COSMO,
         None, None, None,
-        1, 0,
+        1, 0, 501,
         "none",
         status)
 

--- a/src/ccl_cls.c
+++ b/src/ccl_cls.c
@@ -137,22 +137,52 @@ static double cl_integrand(double lk, void *params) {
   return k*pk*d1*d2;
 }
 
-void ccl_angular_cls_limber(ccl_cosmology *cosmo,
-                           ccl_cl_tracer_collection_t *trc1,
-                           ccl_cl_tracer_collection_t *trc2,
-                           ccl_f2d_t *psp,
-                           int nl_out, double *l_out, double *cl_out,
-                           int *status) {
-  int local_status;
-  int clastatus, lind;
-  integ_cl_par ipar;
-  gsl_function F;
-  double lkmin, lkmax, l;
-  double result, eresult;
+static void integ_cls_limber_quad(ccl_cosmology *cosmo,
+				  gsl_function *F,
+				  double lkmin, double lkmax,
+				  gsl_integration_workspace *w,
+				  double *result, double *eresult,
+				  int *status)
+{
   int gslstatus;
-  gsl_integration_workspace *w;
-  gsl_integration_cquad_workspace *w_cquad;
   size_t nevals;
+  gsl_integration_cquad_workspace *w_cquad = NULL;
+  // Integrate
+  gslstatus = gsl_integration_qag(F, lkmin, lkmax, 0,
+				  cosmo->gsl_params.INTEGRATION_LIMBER_EPSREL,
+				  cosmo->gsl_params.N_ITERATION,
+				  cosmo->gsl_params.INTEGRATION_LIMBER_GAUSS_KRONROD_POINTS,
+				  w, result, eresult);
+
+  // Test if a round-off error occured in the evaluation of the integral
+  // If so, try another integration function, more robust but potentially slower
+  if (gslstatus == GSL_EROUND) {
+    ccl_raise_gsl_warning(gslstatus,
+			  "ccl_cls.c: ccl_angular_cl_limber(): "
+			  "Default GSL integration failure, attempting backup method.");
+    w_cquad = gsl_integration_cquad_workspace_alloc(cosmo->gsl_params.N_ITERATION);
+    if (w_cquad == NULL)
+      *status = CCL_ERROR_MEMORY;
+
+    if (*status == 0) {
+      nevals = 0;
+      gslstatus = gsl_integration_cquad(F, lkmin, lkmax, 0,
+					cosmo->gsl_params.INTEGRATION_LIMBER_EPSREL,
+					w_cquad, result, eresult, &nevals);
+    }
+  }
+  gsl_integration_cquad_workspace_free(w_cquad);
+  if(*status == 0)
+    *status = gslstatus;
+}
+
+void ccl_angular_cls_limber(ccl_cosmology *cosmo,
+			    ccl_cl_tracer_collection_t *trc1,
+			    ccl_cl_tracer_collection_t *trc2,
+			    ccl_f2d_t *psp,
+			    int nl_out, double *l_out, double *cl_out,
+			    ccl_integration_t integration_method,
+			    int *status) {
 
   // make sure to init core things for safety
   if (!cosmo->computed_distances) {
@@ -178,33 +208,39 @@ void ccl_angular_cls_limber(ccl_cosmology *cosmo,
   else
     psp_use = psp;
 
-  #pragma omp parallel private(lind, clastatus, ipar, lkmin, lkmax, result, \
-                               eresult, gslstatus, w, w_cquad, nevals, l, F, \
-                               local_status) \
-                       shared(cosmo, trc1, trc2, l_out, cl_out, \
-                              nl_out, status, psp_use) \
+  #pragma omp parallel shared(cosmo, trc1, trc2, l_out, cl_out, \
+                              nl_out, status, psp_use, integration_method) \
                        default(none)
   {
-    w_cquad = NULL;
-    w = NULL;
-    local_status = *status;
+    int clastatus, lind;
+    integ_cl_par ipar;
+    gsl_integration_workspace *w = NULL;
+    int local_status = *status;
+    gsl_function F;
+    double lkmin, lkmax, l, result, eresult;
 
     if (local_status == 0) {
-      w = gsl_integration_workspace_alloc(cosmo->gsl_params.N_ITERATION);
-      if (w == NULL) {
-        local_status = CCL_ERROR_MEMORY;
-      }
-    }
-
-    if (local_status == 0) {
-      // Set up integrating function
+      // Set up integrating function parameters
       ipar.cosmo = cosmo;
       ipar.trc1 = trc1;
       ipar.trc2 = trc2;
       ipar.psp = psp_use;
       ipar.status = &clastatus;
-      F.function = &cl_integrand;
-      F.params = &ipar;
+    }
+
+    if(integration_method == ccl_integration_quad) {
+      if (local_status == 0) {
+	w = gsl_integration_workspace_alloc(cosmo->gsl_params.N_ITERATION);
+	if (w == NULL) {
+	  local_status = CCL_ERROR_MEMORY;
+	}
+      }
+
+      if (local_status == 0) {
+	// Set up integrating function
+	F.function = &cl_integrand;
+	F.params = &ipar;
+      }
     }
 
     #pragma omp for schedule(dynamic)
@@ -217,50 +253,23 @@ void ccl_angular_cls_limber(ccl_cosmology *cosmo,
         // Get integration limits
         get_k_interval(cosmo, trc1, trc2, l, &lkmin, &lkmax);
 
-        // Integrate
-        gslstatus = gsl_integration_qag(&F, lkmin, lkmax, 0,
-                                        cosmo->gsl_params.INTEGRATION_LIMBER_EPSREL,
-                                        cosmo->gsl_params.N_ITERATION,
-                                        cosmo->gsl_params.INTEGRATION_LIMBER_GAUSS_KRONROD_POINTS,
-                                        w, &result, &eresult);
+	// Integrate
+	integ_cls_limber_quad(cosmo, &F, lkmin, lkmax, w,
+			      &result, &eresult, &local_status);
 
-        // Test if a round-off error occured in the evaluation of the integral
-        // If so, try another integration function, more robust but potentially slower
-        if (gslstatus == GSL_EROUND) {
-          ccl_raise_gsl_warning(
-              gslstatus,
-              "ccl_cls.c: ccl_angular_cl_limber(): "
-              "Default GSL integration failure, attempting backup method.");
-
-          if (w_cquad == NULL) {
-            w_cquad = gsl_integration_cquad_workspace_alloc(cosmo->gsl_params.N_ITERATION);
-            if (w_cquad == NULL) {
-              local_status = CCL_ERROR_MEMORY;
-            }
-          }
-
-          if (local_status == 0) {
-            nevals = 0;
-            gslstatus = gsl_integration_cquad(
-              &F, lkmin, lkmax, 0,
-              cosmo->gsl_params.INTEGRATION_LIMBER_EPSREL,
-              w_cquad, &result, &eresult, &nevals);
-          }
-        }
-
-        if (gslstatus == GSL_SUCCESS && (*ipar.status == 0) && local_status == 0) {
+        if ((*ipar.status == 0) && (local_status == 0)) {
           cl_out[lind] = result / (l+0.5);
         }
         else {
-          ccl_raise_gsl_warning(gslstatus, "ccl_cls.c: ccl_angular_cl_limber():");
+          ccl_raise_gsl_warning(local_status, "ccl_cls.c: ccl_angular_cl_limber():");
           cl_out[lind] = NAN;
           local_status = CCL_ERROR_INTEG;
         }
       }
     }
 
-    gsl_integration_workspace_free(w);
-    gsl_integration_cquad_workspace_free(w_cquad);
+    if(integration_method == ccl_integration_quad)
+      gsl_integration_workspace_free(w);
 
     if (local_status) {
       #pragma omp atomic write

--- a/src/ccl_cls.c
+++ b/src/ccl_cls.c
@@ -140,8 +140,7 @@ static double cl_integrand(double lk, void *params) {
 static void integ_cls_limber_spline(ccl_cosmology *cosmo,
 				    integ_cl_par *ipar,
 				    double lkmin, double lkmax,
-				    double *result, int *status)
-{
+				    double *result, int *status) {
   int ik;
   int nk = (int)(fmax((lkmax - lkmin) / cosmo->spline_params.DLOGK_INTEGRATION + 0.5,
 		      1))+1;
@@ -181,8 +180,7 @@ static void integ_cls_limber_quad(ccl_cosmology *cosmo,
 				  double lkmin, double lkmax,
 				  gsl_integration_workspace *w,
 				  double *result, double *eresult,
-				  int *status)
-{
+				  int *status) {
   int gslstatus;
   size_t nevals;
   gsl_integration_cquad_workspace *w_cquad = NULL;

--- a/src/ccl_cls.c
+++ b/src/ccl_cls.c
@@ -175,12 +175,12 @@ static void integ_cls_limber_spline(ccl_cosmology *cosmo,
   free(lk_arr);
 }
 
-static void integ_cls_limber_quad(ccl_cosmology *cosmo,
-				  gsl_function *F,
-				  double lkmin, double lkmax,
-				  gsl_integration_workspace *w,
-				  double *result, double *eresult,
-				  int *status) {
+static void integ_cls_limber_qag_quad(ccl_cosmology *cosmo,
+				      gsl_function *F,
+				      double lkmin, double lkmax,
+				      gsl_integration_workspace *w,
+				      double *result, double *eresult,
+				      int *status) {
   int gslstatus;
   size_t nevals;
   gsl_integration_cquad_workspace *w_cquad = NULL;
@@ -265,7 +265,7 @@ void ccl_angular_cls_limber(ccl_cosmology *cosmo,
       ipar.status = &clastatus;
     }
 
-    if(integration_method == ccl_integration_quad) {
+    if(integration_method == ccl_integration_qag_quad) {
       if (local_status == 0) {
 	w = gsl_integration_workspace_alloc(cosmo->gsl_params.N_ITERATION);
 	if (w == NULL) {
@@ -291,9 +291,9 @@ void ccl_angular_cls_limber(ccl_cosmology *cosmo,
         get_k_interval(cosmo, trc1, trc2, l, &lkmin, &lkmax);
 
 	// Integrate
-	if(integration_method == ccl_integration_quad) {
-	  integ_cls_limber_quad(cosmo, &F, lkmin, lkmax, w,
-				&result, &eresult, &local_status);
+	if(integration_method == ccl_integration_qag_quad) {
+	  integ_cls_limber_qag_quad(cosmo, &F, lkmin, lkmax, w,
+				    &result, &eresult, &local_status);
 	}
 	else if(integration_method == ccl_integration_spline) {
 	  integ_cls_limber_spline(cosmo, &ipar, lkmin, lkmax,
@@ -313,8 +313,7 @@ void ccl_angular_cls_limber(ccl_cosmology *cosmo,
       }
     }
 
-    if(integration_method == ccl_integration_quad)
-      gsl_integration_workspace_free(w);
+    gsl_integration_workspace_free(w);
 
     if (local_status) {
       #pragma omp atomic write

--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -116,7 +116,7 @@ const ccl_spline_params default_spline_params = {
   50,  // K_MAX_SPLINE
   1E3,  // K_MAX
   5E-5,  // K_MIN
-  0.05,  // DLOGK_INTEGRATION
+  0.025,  // DLOGK_INTEGRATION
   167,  // N_K
   100000,  // N_K_3DCOR
 

--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -116,6 +116,7 @@ const ccl_spline_params default_spline_params = {
   50,  // K_MAX_SPLINE
   1E3,  // K_MAX
   5E-5,  // K_MIN
+  0.05,  // DLOGK_INTEGRATION
   167,  // N_K
   100000,  // N_K_3DCOR
 

--- a/src/ccl_haloprofile.c
+++ b/src/ccl_haloprofile.c
@@ -48,10 +48,9 @@ void ccl_einasto_norm_integral(int n_m, double *r_s, double *r_delta, double *al
     } //end omp for
   
     gsl_integration_workspace_free(w);
-#pragma omp critical
-    {
-      if(status_this)
-	*status = status_this;
+    if(status_this) {
+      #pragma omp atomic write
+      *status = status_this;
     }
   } //end omp parallel
 }
@@ -97,10 +96,9 @@ void ccl_hernquist_norm_integral(int n_m, double *r_s, double *r_delta,
     } //end omp for
   
     gsl_integration_workspace_free(w);
-#pragma omp critical
-    {
-      if(status_this)
-	*status = status_this;
+    if(status_this) {
+      #pragma omp atomic write
+      *status = status_this;
     }
   } //end omp parallel
 }

--- a/src/ccl_utils.c
+++ b/src/ccl_utils.c
@@ -264,3 +264,51 @@ double ccl_j_bessel(int l,double x)
 
   return jl;
 }
+
+double ccl_integ_spline(int n,double *x,double *y,
+			double a, double b,
+			gsl_interp_type *T, int *status)
+{
+  gsl_spline *s = NULL;
+  double result = NAN;
+  if(b==a) {
+    return 0;
+  }
+  if(b<a) {
+    b=y[n-1];
+    a=y[0];
+  }
+
+  if((b>y[n-1]) || (a<y[0])) {
+    ccl_raise_warning(CCL_ERROR_SPLINE,
+		      "ERROR: integration limits beyond interpolated range\n");
+    *status = CCL_ERROR_SPLINE;
+    return NAN;
+  }
+
+  if(*status==0) {
+    s = gsl_spline_alloc(T, n);
+    if(s == NULL) {
+      *status = CCL_ERROR_MEMORY;
+      result = NAN;
+    }
+  }
+
+  if(*status==0) {
+    if(gsl_spline_init(s, x, y, n)) {
+      *status = CCL_ERROR_SPLINE;
+      result = NAN;
+    }
+  }
+
+  if(*status==0) {
+    int sstat = gsl_spline_eval_integ_e(s, a, b, NULL, &result);
+    if(sstat) {
+      *status = CCL_ERROR_SPLINE_EV;
+      result = NAN;
+    }
+  }
+
+  gsl_spline_free(s);
+  return result;
+}

--- a/src/ccl_utils.c
+++ b/src/ccl_utils.c
@@ -267,7 +267,7 @@ double ccl_j_bessel(int l,double x)
 
 double ccl_integ_spline(int n,double *x,double *y,
 			double a, double b,
-			gsl_interp_type *T, int *status)
+			const gsl_interp_type *T, int *status)
 {
   gsl_spline *s = NULL;
   double result = NAN;

--- a/src/ccl_utils.c
+++ b/src/ccl_utils.c
@@ -275,11 +275,11 @@ double ccl_integ_spline(int n,double *x,double *y,
     return 0;
   }
   if(b<a) {
-    b=y[n-1];
-    a=y[0];
+    b=x[n-1];
+    a=x[0];
   }
 
-  if((b>y[n-1]) || (a<y[0])) {
+  if((b>x[n-1]) || (a<x[0])) {
     ccl_raise_warning(CCL_ERROR_SPLINE,
 		      "ERROR: integration limits beyond interpolated range\n");
     *status = CCL_ERROR_SPLINE;


### PR DESCRIPTION
This branch:

- Defines a spline integrator function at the C level
- Allows the user to switch to it (instead of using the default GSL integrator)

Three reasons for this:

- Spline integrals are potentially faster and not much less accurate than GSL's quad.
- They won't fail, which can be convenient (they may just give you a less accurate answer).
- I need this type of integration for the halo model power spectrum branch.
