### PR TITLE
Force A_SPLINE_MAX to be 1.0.

### DIFF
--- a/pyccl/tests/test_spline_params.py
+++ b/pyccl/tests/test_spline_params.py
@@ -1,0 +1,17 @@
+import pytest
+import pyccl as ccl
+
+def test_spline_params():
+    cosmo = ccl.Cosmology(
+                Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
+                transfer_function='bbks', matter_power_spectrum='linear')
+    cosmo.cosmo.spline_params.A_SPLINE_MAX = 0.9
+    with pytest.raises(ccl.CCLError):
+        ccl.angular_diameter_distance(cosmo, a1=1.0)
+    
+    with pytest.raises(ccl.CCLError):
+        ccl.growth_factor(cosmo, a=1.0)
+
+    with pytest.raises(ccl.CCLError):
+        ccl.linear_matter_power(cosmo, k=1.0, a=1.0)
+    

--- a/pyccl/tests/test_spline_params.py
+++ b/pyccl/tests/test_spline_params.py
@@ -1,6 +1,7 @@
 import pytest
 import pyccl as ccl
 
+
 def test_spline_params():
     cosmo = ccl.Cosmology(
                 Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
@@ -8,10 +9,9 @@ def test_spline_params():
     cosmo.cosmo.spline_params.A_SPLINE_MAX = 0.9
     with pytest.raises(ccl.CCLError):
         ccl.angular_diameter_distance(cosmo, a1=1.0)
-    
+
     with pytest.raises(ccl.CCLError):
         ccl.growth_factor(cosmo, a=1.0)
 
     with pytest.raises(ccl.CCLError):
         ccl.linear_matter_power(cosmo, k=1.0, a=1.0)
-    

--- a/readthedocs/source/notation_and_other_cosmological_conventions.rst
+++ b/readthedocs/source/notation_and_other_cosmological_conventions.rst
@@ -142,7 +142,7 @@ parameters.
   - A_SPLINE_MIN: the transition scale factor between logarithmically spaced
     spline points and linearly spaced spline points.
   - A_SPLINE_MAX: the the maximum value of the scale factor splines used for
-    distances, etc.
+    distances, etc. Must be set to 1.0.
   - LOGM_SPLINE_NM: the number of logarithmically spaced values in mass for
     splines used in the computation of the halo mass function.
   - LOGM_SPLINE_MIN: the base-10 logarithm of the minimum halo mass for

--- a/src/ccl_background.c
+++ b/src/ccl_background.c
@@ -647,6 +647,11 @@ void ccl_cosmology_compute_growth(ccl_cosmology* cosmo, int* status)
   double *y2 = NULL;
 	double df, integ;
 
+  if(cosmo->spline_params.A_SPLINE_MAX != 1.) {
+    *status = CCL_ERROR_COMPUTECHI;
+    ccl_cosmology_set_status_message(cosmo, "ccl_background.c: A_SPLINE_MAX must be 1.0\n");
+  }
+
   if (*status == 0) {
     a = ccl_linlog_spacing(
       cosmo->spline_params.A_SPLINE_MINLOG, cosmo->spline_params.A_SPLINE_MIN,

--- a/src/ccl_background.c
+++ b/src/ccl_background.c
@@ -447,9 +447,9 @@ void ccl_cosmology_compute_distances(ccl_cosmology * cosmo, int *status)
   if(cosmo->computed_distances)
     return;
 
-  if(cosmo->spline_params.A_SPLINE_MAX>1.) {
+  if(cosmo->spline_params.A_SPLINE_MAX != 1.) {
     *status = CCL_ERROR_COMPUTECHI;
-    ccl_cosmology_set_status_message(cosmo, "ccl_background.c: scale factor cannot be larger than 1.\n");
+    ccl_cosmology_set_status_message(cosmo, "ccl_background.c: A_SPLINE_MAX must be 1.0\n");
     return;
   }
 

--- a/src/ccl_power.c
+++ b/src/ccl_power.c
@@ -430,6 +430,11 @@ TASK: compute linear power spectrum
 void ccl_cosmology_compute_linear_power(ccl_cosmology* cosmo, ccl_f2d_t *psp, int* status) {
   if (cosmo->computed_linear_power) return;
 
+  if(cosmo->spline_params.A_SPLINE_MAX != 1.) {
+    *status = CCL_ERROR_COMPUTECHI;
+    ccl_cosmology_set_status_message(cosmo, "ccl_power.c: A_SPLINE_MAX must be 1.0\n");
+  }
+
   if (*status == 0) {
     // get linear P(k)
     switch (cosmo->config.transfer_function_method) {


### PR DESCRIPTION
Currently the `A_SPLINE_MAX` spline parameter can in principle be set to something `<= 1.0`. This however breaks things (#354). This PR forces `A_SPLINE_MAX` to 1.0 by throwing an error if set to anything else. 

It would probably be good to check the other spline parameters has well at some point.