### PR TITLE
Add Fast-PT installation guide to docs

### DIFF
--- a/pyccl/nl_pt/power.py
+++ b/pyccl/nl_pt/power.py
@@ -57,8 +57,9 @@ class PTCalculator(object):
                 documentation for more details.
         """
         assert HAVE_FASTPT, (
-                "You must have the `FASTPT` python package "
-                "installed to use CCL to get PT observables!")
+                "You must have the `FAST-PT` python package "
+                "installed to use CCL to get PT observables! "
+                "You can install it with pip install fast-pt.")
 
         self.with_dd = with_dd
         self.with_NC = with_NC

--- a/readthedocs/source/developer_installation.rst
+++ b/readthedocs/source/developer_installation.rst
@@ -21,7 +21,7 @@ To install CCL using a ``pip`` developer installation, you can execute
 from the top-level directory in the repository. You will need ``CMake`` in
 order to install CCL in this way. See :ref:`getting-cmake` for help installing
 ``CMake`` if you do not already have it. In order to run the tests,
-you will need ``CAMB``, ``CLASS``, and ``Fast-PT`` installed. See the instructions for
+you will need ``CAMB``, ``CLASS``, and ``FAST-PT`` installed. See the instructions for
 :ref:`boltzmann-codes` and :ref:`getting-fast-pt` for details.
 
 

--- a/readthedocs/source/developer_installation.rst
+++ b/readthedocs/source/developer_installation.rst
@@ -21,8 +21,8 @@ To install CCL using a ``pip`` developer installation, you can execute
 from the top-level directory in the repository. You will need ``CMake`` in
 order to install CCL in this way. See :ref:`getting-cmake` for help installing
 ``CMake`` if you do not already have it. In order to run the tests,
-you will need both ``CAMB`` and ``CLASS`` installed. See the instructions for
-:ref:`boltzmann-codes` for details.
+you will need ``CAMB``, ``CLASS``, and ``FastPT`` installed. See the instructions for
+:ref:`boltzmann-codes` and :ref:`getting-fast-pt` for details.
 
 
 C-layer Dependencies and Requirements

--- a/readthedocs/source/developer_installation.rst
+++ b/readthedocs/source/developer_installation.rst
@@ -21,7 +21,7 @@ To install CCL using a ``pip`` developer installation, you can execute
 from the top-level directory in the repository. You will need ``CMake`` in
 order to install CCL in this way. See :ref:`getting-cmake` for help installing
 ``CMake`` if you do not already have it. In order to run the tests,
-you will need ``CAMB``, ``CLASS``, and ``FastPT`` installed. See the instructions for
+you will need ``CAMB``, ``CLASS``, and ``Fast-PT`` installed. See the instructions for
 :ref:`boltzmann-codes` and :ref:`getting-fast-pt` for details.
 
 

--- a/readthedocs/source/installation.rst
+++ b/readthedocs/source/installation.rst
@@ -5,7 +5,7 @@ Installation
 CCL can be installed from ``pip``, ``conda``, or directly from source.
 It is configured to install most of its requirements automatically. However, if
 you want to use CCL with Boltzmann codes like ``CLASS`` or ``CAMB``, or do 
-perturbation theory calculations with ``Fast-PT``, you will
+perturbation theory calculations with ``FAST-PT``, you will
 need to make sure the ``Python`` wrappers for these packages are installed
 as well. See the instructions for :ref:`boltzmann-codes` and 
 :ref:`getting-fast-pt` below.
@@ -74,17 +74,17 @@ should already be in your environment.
 
 .. _getting-fast-pt:
 
-Getting Fast-PT
+Getting FAST-PT
 ===============
 
-To use ``Fast-PT`` with CCL, you can install it with:
+To use ``FAST-PT`` with CCL, you can install it with:
 
 .. code-block:: bash
 
    $ pip install fast-pt
 
 Note the hyphen in the package name! You can also get it directly from the 
-`Fast-PT <https://github.com/JoeMcEwen/FAST-PT>`_ repo.
+`FAST-PT <https://github.com/JoeMcEwen/FAST-PT>`_ repo.
 
 .. _getting-cmake:
 

--- a/readthedocs/source/installation.rst
+++ b/readthedocs/source/installation.rst
@@ -4,9 +4,11 @@ Installation
 
 CCL can be installed from ``pip``, ``conda``, or directly from source.
 It is configured to install most of its requirements automatically. However, if
-you want to use CCL with Boltzmann codes like ``CLASS`` or ``CAMB``, you will
+you want to use CCL with Boltzmann codes like ``CLASS`` or ``CAMB``, or do 
+perturbation theory calculations with ``Fast-PT``, you will
 need to make sure the ``Python`` wrappers for these packages are installed
-as well. See the instructions for :ref:`boltzmann-codes` below.
+as well. See the instructions for :ref:`boltzmann-codes` and 
+:ref:`getting-fast-pt` below.
 
 CCL works on Linux or Mac OS. Windows installation is not supported.
 
@@ -72,17 +74,17 @@ should already be in your environment.
 
 .. _getting-fast-pt:
 
-Getting FastPT
-==============
+Getting Fast-PT
+===============
 
-To use ``FastPT`` with CCL, you can install it with:
+To use ``Fast-PT`` with CCL, you can install it with:
 
 .. code-block:: bash
 
    $ pip install fast-pt
 
 Note the hyphen in the package name! You can also get it directly from the 
-`FastPT <https://github.com/JoeMcEwen/FAST-PT>`_ repo.
+`Fast-PT <https://github.com/JoeMcEwen/FAST-PT>`_ repo.
 
 .. _getting-cmake:
 

--- a/readthedocs/source/installation.rst
+++ b/readthedocs/source/installation.rst
@@ -6,7 +6,7 @@ CCL can be installed from ``pip``, ``conda``, or directly from source.
 It is configured to install most of its requirements automatically. However, if
 you want to use CCL with Boltzmann codes like ``CLASS`` or ``CAMB``, or do 
 perturbation theory calculations with ``FAST-PT``, you will
-need to make sure the ``Python`` wrappers for these packages are installed
+need to make sure these packages and their ``Python`` wrappers are installed
 as well. See the instructions for :ref:`boltzmann-codes` and 
 :ref:`getting-fast-pt` below.
 

--- a/readthedocs/source/installation.rst
+++ b/readthedocs/source/installation.rst
@@ -70,6 +70,19 @@ An installation with ``pip`` should work as well. See the `CAMB <https://github.
 repo for more details. Note that if you installed CCL with ``conda``, ``camb``
 should already be in your environment.
 
+.. _getting-fast-pt:
+
+Getting FastPT
+==============
+
+To use ``FastPT`` with CCL, you can install it with:
+
+.. code-block:: bash
+
+   $ pip install fast-pt
+
+Note the hyphen in the package name! You can also get it directly from the 
+`FastPT <https://github.com/JoeMcEwen/FAST-PT>`_ repo.
 
 .. _getting-cmake:
 


### PR DESCRIPTION
Added notes on how to install `Fast-PT` to docs, as well as the error message when `Fast-PT` is missing.