### PR TITLE
Make A_SPLINE_MAX functionally a constant

### DIFF
--- a/include/ccl_core.h
+++ b/include/ccl_core.h
@@ -107,7 +107,7 @@ typedef struct ccl_spline_params {
   double A_SPLINE_MIN;
   double A_SPLINE_MINLOG_PK;
   double A_SPLINE_MIN_PK;
-  const double A_SPLINE_MAX;
+  double A_SPLINE_MAX;
   double A_SPLINE_MINLOG;
   int A_SPLINE_NLOG;
 

--- a/include/ccl_core.h
+++ b/include/ccl_core.h
@@ -107,7 +107,7 @@ typedef struct ccl_spline_params {
   double A_SPLINE_MIN;
   double A_SPLINE_MINLOG_PK;
   double A_SPLINE_MIN_PK;
-  double A_SPLINE_MAX;
+  const double A_SPLINE_MAX;
   double A_SPLINE_MINLOG;
   int A_SPLINE_NLOG;
 

--- a/pyccl/ccl_core.i
+++ b/pyccl/ccl_core.i
@@ -4,7 +4,8 @@
 /* put additional #include here */
 %}
 
-// SWIG black magic
+// SWIG black magic. Change the behaviour of setting A_SPLINE_MAX to thowing an
+// error.
 %typemap(memberin) double A_SPLINE_MAX {
     if($input) {
         PyErr_SetString(PyExc_RuntimeError, "A_SPLINE_MAX is fixed to 1.0 and is not mutable.");
@@ -12,10 +13,6 @@
     }
 }
 
-// Redefine A_SPLINE_MAX as not const so that the setter throws our error message.
-typedef struct ccl_spline_params {
-    double A_SPLINE_MAX;
-} ccl_spline_params;
 %include "../include/ccl_core.h"
 
 // Enable vectorised arguments for arrays

--- a/pyccl/ccl_core.i
+++ b/pyccl/ccl_core.i
@@ -4,6 +4,18 @@
 /* put additional #include here */
 %}
 
+// SWIG black magic
+%typemap(memberin) double A_SPLINE_MAX {
+    if($input) {
+        PyErr_SetString(PyExc_RuntimeError, "A_SPLINE_MAX is fixed to 1.0 and is not mutable.");
+        SWIG_fail;
+    }
+}
+
+// Redefine A_SPLINE_MAX as not const so that the setter throws our error message.
+typedef struct ccl_spline_params {
+    double A_SPLINE_MAX;
+} ccl_spline_params;
 %include "../include/ccl_core.h"
 
 // Enable vectorised arguments for arrays

--- a/pyccl/tests/test_spline_params.py
+++ b/pyccl/tests/test_spline_params.py
@@ -1,0 +1,13 @@
+import pytest
+import pyccl as ccl
+
+
+def test_spline_params():
+    cosmo = ccl.Cosmology(
+                Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
+                transfer_function='bbks', matter_power_spectrum='linear')
+
+    assert cosmo.cosmo.spline_params.A_SPLINE_MAX == 1.0
+
+    with pytest.raises(RuntimeError):
+        cosmo.cosmo.spline_params.A_SPLINE_MAX = 0.9

--- a/src/ccl_background.c
+++ b/src/ccl_background.c
@@ -447,12 +447,6 @@ void ccl_cosmology_compute_distances(ccl_cosmology * cosmo, int *status)
   if(cosmo->computed_distances)
     return;
 
-  if(cosmo->spline_params.A_SPLINE_MAX>1.) {
-    *status = CCL_ERROR_COMPUTECHI;
-    ccl_cosmology_set_status_message(cosmo, "ccl_background.c: scale factor cannot be larger than 1.\n");
-    return;
-  }
-
   // Create logarithmically and then linearly-spaced values of the scale factor
   int na = cosmo->spline_params.A_SPLINE_NA+cosmo->spline_params.A_SPLINE_NLOG-1;
   double * a = ccl_linlog_spacing(

--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -280,6 +280,10 @@ ccl_cosmology * ccl_cosmology_create(ccl_parameters params, ccl_configuration co
   cosmo->status = 0;
   ccl_cosmology_set_status_message(cosmo, "");
 
+  if(cosmo->spline_params.A_SPLINE_MAX !=1.) {
+    cosmo->status = CCL_ERROR_SPLINE;
+    ccl_cosmology_set_status_message(cosmo, "ccl_core.c: A_SPLINE_MAX needs to be 1.\n");
+  }
 
   return cosmo;
 }


### PR DESCRIPTION
This is a cleaner implementation of PR #748 . On the C-level, it makes `A_SPLINE_MAX` a const and checks its value in `ccl_cosmology_create`. On the Python-level it overwrites the setter to throw a `RuntimeError` with an informative error message.

I think the only way to bypass these checks is to create a new `ccl_spline_params` struct with  A_SPLINE_MAX != 1 and replace the `spline_params` in an existing `ccl_cosmology` struct. If a user goes that far, they can probably break other things just as easily.