### PR TITLE
Remove warnings for v2.1

### DIFF
--- a/benchmarks/test_camb_class_consistent.py
+++ b/benchmarks/test_camb_class_consistent.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+import warnings
 
 import pyccl as ccl
 
@@ -16,7 +17,13 @@ def test_camb_class_consistent_smoke(kwargs=None, pkerr=1e-3):
         Omega_c=0.25, Omega_b=0.05, h=0.7, n_s=0.95, A_s=2e-9,
         transfer_function='boltzmann_class', **kwargs)
 
-    rel_sigma8 = np.abs(ccl.sigma8(c_camb) / ccl.sigma8(c_class) - 1)
+    with warnings.catch_warnings():
+        # We do some tests here with massive neutrinos, which currently raises
+        # a warning.
+        # XXX: Do you really want to be raising a warning for this?
+        #      This seems spurious to me.  (MJ)
+        warnings.simplefilter("ignore")
+        rel_sigma8 = np.abs(ccl.sigma8(c_camb) / ccl.sigma8(c_class) - 1)
 
     a = 0.845
     k = np.logspace(-3, 1, 100)

--- a/benchmarks/test_correlation_MG2.py
+++ b/benchmarks/test_correlation_MG2.py
@@ -122,18 +122,18 @@ def set_up(request):
 
 
 @pytest.mark.parametrize("t1,t2,bm,er,kind,pref",
-                         [('g1', 'g1', 'dd_11', 'dd_11', 'gg', 1),
-                          ('g2', 'g2', 'dd_22', 'dd_22', 'gg', 1),
-                          ('g1', 'l1', 'dl_11', 'dl_11', 'gl', 1),
-                          ('g1', 'l2', 'dl_12', 'dl_12', 'gl', 1),
-                          ('g2', 'l1', 'dl_21', 'dl_21', 'gl', 1),
-                          ('g2', 'l2', 'dl_22', 'dl_22', 'gl', 1),
-                          ('l1', 'l1', 'll_11_p', 'll_11_p', 'l+', 1),
-                          ('l1', 'l2', 'll_12_p', 'll_12_p', 'l+', 1),
-                          ('l2', 'l2', 'll_22_p', 'll_22_p', 'l+', 1),
-                          ('l1', 'l1', 'll_11_m', 'll_11_m', 'l-', 1),
-                          ('l1', 'l2', 'll_12_m', 'll_12_m', 'l-', 1),
-                          ('l2', 'l2', 'll_22_m', 'll_22_m', 'l-', 1)])
+                         [('g1', 'g1', 'dd_11', 'dd_11', 'NN', 1),
+                          ('g2', 'g2', 'dd_22', 'dd_22', 'NN', 1),
+                          ('g1', 'l1', 'dl_11', 'dl_11', 'NG', 1),
+                          ('g1', 'l2', 'dl_12', 'dl_12', 'NG', 1),
+                          ('g2', 'l1', 'dl_21', 'dl_21', 'NG', 1),
+                          ('g2', 'l2', 'dl_22', 'dl_22', 'NG', 1),
+                          ('l1', 'l1', 'll_11_p', 'll_11_p', 'GG+', 1),
+                          ('l1', 'l2', 'll_12_p', 'll_12_p', 'GG+', 1),
+                          ('l2', 'l2', 'll_22_p', 'll_22_p', 'GG+', 1),
+                          ('l1', 'l1', 'll_11_m', 'll_11_m', 'GG-', 1),
+                          ('l1', 'l2', 'll_12_m', 'll_12_m', 'GG-', 1),
+                          ('l2', 'l2', 'll_22_m', 'll_22_m', 'GG-', 1)])
 def test_xi(set_up, corr_method, t1, t2, bm, er, kind, pref):
     cosmo, trcs, bms, ers, fls = set_up
     method, errfac = corr_method
@@ -147,7 +147,7 @@ def test_xi(set_up, corr_method, t1, t2, bm, er, kind, pref):
     # Our benchmarks have theta in arcmin
     # but CCL requires it in degrees:
     theta_deg = bms['theta'] / 60.
-    xi = ccl.correlation(cosmo, ell, cli, theta_deg, corr_type=kind,
+    xi = ccl.correlation(cosmo, ell, cli, theta_deg, type=kind,
                          method=method)
     xi *= pref
 

--- a/benchmarks/test_haloprofile.py
+++ b/benchmarks/test_haloprofile.py
@@ -107,15 +107,24 @@ def test_haloprofile(model):
         np.log(rmin) +
         np.log(rmax/rmin) * np.arange(data.shape[0]) / (data.shape[0]-1))
 
+    mdef = ccl.halos.MassDef(halomassdef, 'matter')
+    c = ccl.halos.ConcentrationConstant(c=concentration, mdef=mdef)
+    kwargs = {}
+
     if model == 'nfw':
-        prof_func = ccl.nfw_profile_3d
+        p = ccl.halos.HaloProfileNFW(c, truncated=False)
+        prof = p.real(COSMO, r, halomass, a, mdef)
     elif model == 'projected_nfw':
-        prof_func = ccl.nfw_profile_2d
+        p = ccl.halos.HaloProfileNFW(c, truncated=False,
+                                     projected_analytic=True)
+        prof = p.projected(COSMO, r, halomass, a, mdef)
     elif model == 'einasto':
-        prof_func = ccl.einasto_profile_3d
+        mdef = ccl.halos.MassDef(halomassdef, 'matter', c_m_relation=c)
+        p = ccl.halos.HaloProfileEinasto(c, truncated=False)
+        prof = p.real(COSMO, r, halomass, a, mdef)
     elif model == 'hernquist':
-        prof_func = ccl.hernquist_profile_3d
-    prof = prof_func(COSMO, concentration, halomass, halomassdef, a, r)
+        p = ccl.halos.HaloProfileHernquist(c, truncated=False)
+        prof = p.real(COSMO, r, halomass, a, mdef)
 
     tol = np.clip(np.abs(HALOPROFILE_TOLERANCE * data[:, 1]), 1e-12, np.inf)
     err = np.abs(prof - data[:, 1])

--- a/benchmarks/test_haloprofile.py
+++ b/benchmarks/test_haloprofile.py
@@ -109,7 +109,6 @@ def test_haloprofile(model):
 
     mdef = ccl.halos.MassDef(halomassdef, 'matter')
     c = ccl.halos.ConcentrationConstant(c=concentration, mdef=mdef)
-    kwargs = {}
 
     if model == 'nfw':
         p = ccl.halos.HaloProfileNFW(c, truncated=False)

--- a/benchmarks/test_power_nu.py
+++ b/benchmarks/test_power_nu.py
@@ -31,7 +31,6 @@ def test_power_nu(model):
 
     a = 1
 
-
     data_lin = np.loadtxt("./benchmarks/data/model%d_pk_nu.txt" % (model+1))
     k_lin = data_lin[:, 0] * cosmo['h']
     pk_lin = data_lin[:, 1] / (cosmo['h']**3)

--- a/benchmarks/test_power_nu.py
+++ b/benchmarks/test_power_nu.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import warnings
 
 import pyccl as ccl
 
@@ -30,10 +31,19 @@ def test_power_nu(model):
 
     a = 1
 
+
     data_lin = np.loadtxt("./benchmarks/data/model%d_pk_nu.txt" % (model+1))
     k_lin = data_lin[:, 0] * cosmo['h']
     pk_lin = data_lin[:, 1] / (cosmo['h']**3)
-    pk_lin_ccl = ccl.linear_matter_power(cosmo, k_lin, a)
+
+    with warnings.catch_warnings():
+        # Linear power with massive neutrinos raises a warning.
+        # Ignore it.
+        # XXX: Do you really want to be raising a warning for this?
+        #      This seems spurious to me.  (MJ)
+        warnings.simplefilter("ignore")
+        pk_lin_ccl = ccl.linear_matter_power(cosmo, k_lin, a)
+
     err = np.abs(pk_lin_ccl/pk_lin - 1)
     assert np.allclose(err, 0, rtol=0, atol=POWER_NU_TOL)
 

--- a/include/ccl_core.h
+++ b/include/ccl_core.h
@@ -135,13 +135,13 @@ typedef struct ccl_spline_params {
   int N_ELL_CORR;
 
   // interpolation types
-  gsl_interp_type* A_SPLINE_TYPE;
-  gsl_interp_type* K_SPLINE_TYPE;
-  gsl_interp_type* M_SPLINE_TYPE;
-  gsl_interp_type* D_SPLINE_TYPE;
-  gsl_interp2d_type* PNL_SPLINE_TYPE;
-  gsl_interp2d_type* PLIN_SPLINE_TYPE;
-  gsl_interp_type* CORR_SPLINE_TYPE;
+  const gsl_interp_type* A_SPLINE_TYPE;
+  const gsl_interp_type* K_SPLINE_TYPE;
+  const gsl_interp_type* M_SPLINE_TYPE;
+  const gsl_interp_type* D_SPLINE_TYPE;
+  const gsl_interp2d_type* PNL_SPLINE_TYPE;
+  const gsl_interp2d_type* PLIN_SPLINE_TYPE;
+  const gsl_interp_type* CORR_SPLINE_TYPE;
 } ccl_spline_params;
 
 extern const ccl_spline_params default_spline_params;

--- a/pyccl/correlation.py
+++ b/pyccl/correlation.py
@@ -26,7 +26,7 @@ correlation_types = {
 }
 
 
-def correlation(cosmo, ell, C_ell, theta, type='nn', corr_type=None,
+def correlation(cosmo, ell, C_ell, theta, type='NN', corr_type=None,
                 method='fftlog'):
     """Compute the angular correlation function.
 

--- a/pyccl/correlation.py
+++ b/pyccl/correlation.py
@@ -61,6 +61,7 @@ def correlation(cosmo, ell, C_ell, theta, type='nn', corr_type=None,
         float or array_like: Value(s) of the correlation function at the \
             input angular separations.
     """
+    from .errors import CCLWarning
     cosmo_in = cosmo
     cosmo = cosmo.cosmo
     status = 0
@@ -78,8 +79,8 @@ def correlation(cosmo, ell, C_ell, theta, type='nn', corr_type=None,
             type = 'GG-'
         else:
             raise ValueError("Unknown corr_type " + corr_type)
-        warnings.warn("corr_type is deprecated. "
-                      "Use type = {}".format(type))
+        warnings.warn("corr_type is deprecated. Use type = {}".format(type),
+                      CCLWarning)
     method = method.lower()
 
     if type not in correlation_types.keys():

--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -412,9 +412,9 @@ def halomod_power_spectrum(cosmo, hmc, k, a, prof,
     # Power spectrum
     if isinstance(p_of_k_a, Pk2D):
         def pkf(sf): return p_of_k_a.eval(k_use, sf, cosmo)
-    elif (p_of_k_a is None) or (p_of_k_a == 'linear'):
+    elif (p_of_k_a is None) or (str(p_of_k_a) == 'linear'):
         def pkf(sf): return linear_matter_power(cosmo, k_use, sf)
-    elif p_of_k_a == 'nonlinear':
+    elif str(p_of_k_a) == 'nonlinear':
         def pkf(sf): return nonlin_matter_power(cosmo, k_use, sf)
     else:
         raise TypeError("p_of_k_a must be `None`, \'linear\', "

--- a/pyccl/pyutils.py
+++ b/pyccl/pyutils.py
@@ -487,7 +487,7 @@ def _check_array_params(f_arg, name=None, arr3=False):
         if ((not isinstance(f_arg, Iterable))
             or (len(f_arg) != (3 if arr3 else 2))
             or (not (isinstance(f_arg[0], Iterable)
-                    and isinstance(f_arg[1], Iterable)))):
+                     and isinstance(f_arg[1], Iterable)))):
             raise ValueError("%s needs to be a tuple of two arrays." % name)
 
         f1 = np.atleast_1d(np.array(f_arg[0], dtype=float))

--- a/pyccl/pyutils.py
+++ b/pyccl/pyutils.py
@@ -6,6 +6,10 @@ from .errors import CCLError, CCLWarning
 import functools
 import warnings
 import numpy as np
+try:
+    from collections.abc import Iterable
+except ImportError:  # pragma: no cover  (for py2.7)
+    from collections import Iterable
 
 NoneArr = np.array([])
 
@@ -467,7 +471,7 @@ def _spline_integrate(x, ys, a, b):
     return result
 
 
-def _check_array_params(f_arg, arr3=False):
+def _check_array_params(f_arg, name=None, arr3=False):
     """Check whether an argument `f_arg` passed into the constructor of
     Tracer() is valid.
 
@@ -480,6 +484,12 @@ def _check_array_params(f_arg, arr3=False):
         f2 = NoneArr
         f3 = NoneArr
     else:
+        if ((not isinstance(f_arg, Iterable))
+            or (len(f_arg) != (3 if arr3 else 2))
+            or (not (isinstance(f_arg[0], Iterable)
+                    and isinstance(f_arg[1], Iterable)))):
+            raise ValueError("%s needs to be a tuple of two arrays." % name)
+
         f1 = np.atleast_1d(np.array(f_arg[0], dtype=float))
         f2 = np.atleast_1d(np.array(f_arg[1], dtype=float))
         if arr3:

--- a/pyccl/pyutils.py
+++ b/pyccl/pyutils.py
@@ -488,3 +488,19 @@ def _check_array_params(f_arg, arr3=False):
         return f1, f2, f3
     else:
         return f1, f2
+
+def assert_warns(wtype, f, *args, **kwargs):
+    """Check that a function call f(*args, **kwargs) raises a warning of type wtype.
+
+    Returns the output of f(*args, **kwargs) unless there was no warning, in which case
+    an AssertionError is raised.
+    """
+    import warnings
+    # Check that f() raises a warning, but not an error.
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        res = f(*args, **kwargs)
+    assert len(w) >= 1, "Expected warning was not raised."
+    assert issubclass(w[0].category, wtype), \
+        "Warning raised was the wrong type (got %s, expected %s)"%(w[0].category, wtype)
+    return res

--- a/pyccl/pyutils.py
+++ b/pyccl/pyutils.py
@@ -489,11 +489,13 @@ def _check_array_params(f_arg, arr3=False):
     else:
         return f1, f2
 
-def assert_warns(wtype, f, *args, **kwargs):
-    """Check that a function call f(*args, **kwargs) raises a warning of type wtype.
 
-    Returns the output of f(*args, **kwargs) unless there was no warning, in which case
-    an AssertionError is raised.
+def assert_warns(wtype, f, *args, **kwargs):
+    """Check that a function call f(*args, **kwargs) raises a warning of type
+    wtype.
+
+    Returns the output of f(*args, **kwargs) unless there was no warning, in
+    which case an AssertionError is raised.
     """
     import warnings
     # Check that f() raises a warning, but not an error.
@@ -502,5 +504,6 @@ def assert_warns(wtype, f, *args, **kwargs):
         res = f(*args, **kwargs)
     assert len(w) >= 1, "Expected warning was not raised."
     assert issubclass(w[0].category, wtype), \
-        "Warning raised was the wrong type (got %s, expected %s)"%(w[0].category, wtype)
+        "Warning raised was the wrong type (got %s, expected %s)" % (
+                w[0].category, wtype)
     return res

--- a/pyccl/tests/test_cclerror.py
+++ b/pyccl/tests/test_cclerror.py
@@ -17,3 +17,19 @@ def test_cclerror_not_equal():
     assert_(e is not e2)
     assert_(e != e2)
     assert_(hash(e) != hash(e2))
+
+def test_cclwarning_repr():
+    """Check that a CCLWarning can be built from its repr"""
+    w = pyccl.CCLWarning("blah")
+    w2 = eval(repr(w))
+    assert_(str(w2) == str(w))
+    assert_(w2 == w)
+
+
+def test_cclwarning_not_equal():
+    """Check that a CCLWarning can be built from its repr"""
+    w = pyccl.CCLWarning("blah")
+    w2 = pyccl.CCLWarning("blahh")
+    assert_(w is not w2)
+    assert_(w != w2)
+    assert_(hash(w) != hash(w2))

--- a/pyccl/tests/test_cclerror.py
+++ b/pyccl/tests/test_cclerror.py
@@ -18,6 +18,7 @@ def test_cclerror_not_equal():
     assert_(e != e2)
     assert_(hash(e) != hash(e2))
 
+
 def test_cclwarning_repr():
     """Check that a CCLWarning can be built from its repr"""
     w = pyccl.CCLWarning("blah")

--- a/pyccl/tests/test_cls.py
+++ b/pyccl/tests/test_cls.py
@@ -3,6 +3,8 @@ import pytest
 
 import pyccl as ccl
 
+from numpy.testing import assert_raises
+
 COSMO = ccl.Cosmology(
     Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
     transfer_function='bbks', matter_power_spectrum='linear')
@@ -45,6 +47,24 @@ def test_cls_smoke(p_of_k_a):
                 corr_rev = ccl.angular_cl(
                     COSMO, tracers[j], tracers[i], ell, p_of_k_a=p_of_k_a)
                 assert np.allclose(corr, corr_rev)
+
+    # Check invalid dndz
+    with assert_raises(ValueError):
+        ccl.NumberCountsTracer(COSMO, False, dndz=z, bias=(z, b))
+    with assert_raises(ValueError):
+        ccl.NumberCountsTracer(COSMO, False, dndz=(z,n,n), bias=(z, b))
+    with assert_raises(ValueError):
+        ccl.NumberCountsTracer(COSMO, False, dndz=(z,), bias=(z, b))
+    with assert_raises(ValueError):
+        ccl.NumberCountsTracer(COSMO, False, dndz=(1,2), bias=(z, b))
+    with assert_raises(ValueError):
+        ccl.WeakLensingTracer(COSMO, dndz=z)
+    with assert_raises(ValueError):
+        ccl.WeakLensingTracer(COSMO, dndz=(z,n,n))
+    with assert_raises(ValueError):
+        ccl.WeakLensingTracer(COSMO, dndz=(z,))
+    with assert_raises(ValueError):
+        ccl.WeakLensingTracer(COSMO, dndz=(1,2))
 
 
 @pytest.mark.parametrize('ells', [[3, 2, 1], [1, 3, 2], [2, 3, 1]])

--- a/pyccl/tests/test_cls.py
+++ b/pyccl/tests/test_cls.py
@@ -52,19 +52,19 @@ def test_cls_smoke(p_of_k_a):
     with assert_raises(ValueError):
         ccl.NumberCountsTracer(COSMO, False, dndz=z, bias=(z, b))
     with assert_raises(ValueError):
-        ccl.NumberCountsTracer(COSMO, False, dndz=(z,n,n), bias=(z, b))
+        ccl.NumberCountsTracer(COSMO, False, dndz=(z, n, n), bias=(z, b))
     with assert_raises(ValueError):
         ccl.NumberCountsTracer(COSMO, False, dndz=(z,), bias=(z, b))
     with assert_raises(ValueError):
-        ccl.NumberCountsTracer(COSMO, False, dndz=(1,2), bias=(z, b))
+        ccl.NumberCountsTracer(COSMO, False, dndz=(1, 2), bias=(z, b))
     with assert_raises(ValueError):
         ccl.WeakLensingTracer(COSMO, dndz=z)
     with assert_raises(ValueError):
-        ccl.WeakLensingTracer(COSMO, dndz=(z,n,n))
+        ccl.WeakLensingTracer(COSMO, dndz=(z, n, n))
     with assert_raises(ValueError):
         ccl.WeakLensingTracer(COSMO, dndz=(z,))
     with assert_raises(ValueError):
-        ccl.WeakLensingTracer(COSMO, dndz=(1,2))
+        ccl.WeakLensingTracer(COSMO, dndz=(1, 2))
 
 
 @pytest.mark.parametrize('ells', [[3, 2, 1], [1, 3, 2], [2, 3, 1]])

--- a/pyccl/tests/test_correlation.py
+++ b/pyccl/tests/test_correlation.py
@@ -2,6 +2,8 @@ import numpy as np
 import pyccl as ccl
 import pytest
 
+from pyccl.pyutils import assert_warns
+
 COSMO = ccl.Cosmology(
     Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
     transfer_function='bbks', matter_power_spectrum='linear')
@@ -41,8 +43,8 @@ def test_correlation_newtypes(typs):
     cl = ccl.angular_cl(COSMO, lens, lens, ell)
 
     theta = np.logspace(-2., np.log10(5.), 5)
-    corr_old = ccl.correlation(COSMO, ell, cl, theta,
-                               corr_type=typs[0])
+    corr_old = assert_warns(ccl.CCLWarning,
+            ccl.correlation, COSMO, ell, cl, theta, corr_type=typs[0])
     corr_new = ccl.correlation(COSMO, ell, cl, theta,
                                type=typs[1])
     assert np.all(corr_new == corr_old)
@@ -125,4 +127,4 @@ def test_correlation_raises():
         ccl.correlation(COSMO, [1], [1e-3], [1], method='blah')
 
     with pytest.raises(ValueError):
-        ccl.correlation(COSMO, [1], [1e-3], [1], corr_type='blah')
+        ccl.correlation(COSMO, [1], [1e-3], [1], type='blah')

--- a/pyccl/tests/test_correlation.py
+++ b/pyccl/tests/test_correlation.py
@@ -42,7 +42,8 @@ def test_correlation_newtypes(typs):
     cl = ccl.angular_cl(COSMO, lens, lens, ell)
 
     theta = np.logspace(-2., np.log10(5.), 5)
-    corr_old = assert_warns(ccl.CCLWarning,
+    corr_old = assert_warns(
+            ccl.CCLWarning,
             ccl.correlation, COSMO, ell, cl, theta, corr_type=typs[0])
     corr_new = ccl.correlation(COSMO, ell, cl, theta,
                                type=typs[1])

--- a/pyccl/tests/test_correlation.py
+++ b/pyccl/tests/test_correlation.py
@@ -125,6 +125,7 @@ def test_correlation_pi_sigma_smoke(sval):
 def test_correlation_raises():
     with pytest.raises(ValueError):
         ccl.correlation(COSMO, [1], [1e-3], [1], method='blah')
-
     with pytest.raises(ValueError):
         ccl.correlation(COSMO, [1], [1e-3], [1], type='blah')
+    with pytest.raises(ValueError):
+        ccl.correlation(COSMO, [1], [1e-3], [1], corr_type='blah')

--- a/pyccl/tests/test_correlation.py
+++ b/pyccl/tests/test_correlation.py
@@ -2,8 +2,6 @@ import numpy as np
 import pyccl as ccl
 import pytest
 
-from pyccl.pyutils import assert_warns
-
 COSMO = ccl.Cosmology(
     Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
     transfer_function='bbks', matter_power_spectrum='linear')
@@ -35,6 +33,7 @@ def test_correlation_smoke(method):
                                   ['l+', 'GG+'],
                                   ['l-', 'GG-']])
 def test_correlation_newtypes(typs):
+    from pyccl.pyutils import assert_warns
     z = np.linspace(0., 1., 200)
     n = np.ones(z.shape)
     lens = ccl.WeakLensingTracer(COSMO, dndz=(z, n))

--- a/pyccl/tests/test_halomodel.py
+++ b/pyccl/tests/test_halomodel.py
@@ -16,6 +16,7 @@ COSMO = ccl.Cosmology(
     np.array([0.3, 0.5, 10])])
 @pytest.mark.parametrize('kind', ['one', 'two', 'total'])
 def test_halomodel_power(k, kind):
+    from pyccl.pyutils import assert_warns
     a = 0.8
 
     if kind == 'one':
@@ -25,7 +26,7 @@ def test_halomodel_power(k, kind):
     else:
         func = ccl.halomodel_matter_power
 
-    pk = func(COSMO, k, a)
+    pk = assert_warns(ccl.CCLWarning, func, COSMO, k, a)
     assert np.all(np.isfinite(pk))
     assert np.shape(k) == np.shape(pk)
 
@@ -36,8 +37,11 @@ def test_halomodel_power(k, kind):
     [1e14, 1e15],
     np.array([1e14, 1e15])])
 def test_halo_concentration(m):
+    from pyccl.pyutils import assert_warns
     a = 0.8
-    c = ccl.halo_concentration(COSMO, m, a)
+    # Deprecated.
+    c = assert_warns(ccl.CCLWarning,
+            ccl.halo_concentration, COSMO, m, a)
     assert np.all(np.isfinite(c))
     assert np.shape(c) == np.shape(m)
 
@@ -76,6 +80,7 @@ def get_pk_new(mf, c, cosmo, a, k, get_1h, get_2h):
                                   ['shethtormen', 'constant_concentration'],
                                   ['tinker10', 'constant_concentration']])
 def test_halomodel_choices_smoke(mf_c):
+    from pyccl.pyutils import assert_warns
     mf, c = mf_c
     cosmo = ccl.Cosmology(
         Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
@@ -83,7 +88,10 @@ def test_halomodel_choices_smoke(mf_c):
         mass_function=mf, halo_concentration=c)
     a = 0.8
     k = np.geomspace(1E-2, 1, 10)
-    p = ccl.twohalo_matter_power(cosmo, k, a)
+    # Deprecated
+    # TODO: Convert this and other places to using the non-deprecated syntax
+    # Or, since this wasn't already done, maybe this is a useful convenience function?
+    p = assert_warns(ccl.CCLWarning, ccl.twohalo_matter_power, cosmo, k, a)
     pb = get_pk_new(mf, c, cosmo, a, k, False, True)
 
     assert np.all(np.isfinite(p))
@@ -91,6 +99,7 @@ def test_halomodel_choices_smoke(mf_c):
 
 
 def test_halomodel_choices_raises():
+    from pyccl.pyutils import assert_warns
     cosmo = ccl.Cosmology(
         Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
         transfer_function='bbks', matter_power_spectrum='linear',
@@ -99,14 +108,19 @@ def test_halomodel_choices_raises():
     k = np.geomspace(1E-2, 1, 10)
 
     with pytest.raises(ValueError):
-        ccl.twohalo_matter_power(cosmo, k, a)
+        assert_warns(ccl.CCLWarning, ccl.twohalo_matter_power, cosmo, k, a)
 
 
 def test_halomodel_power_consistent():
+    from pyccl.pyutils import assert_warns
     a = 0.8
     k = np.logspace(-1, 1, 10)
-    tot = ccl.halomodel_matter_power(COSMO, k, a)
-    one = ccl.onehalo_matter_power(COSMO, k, a)
-    two = ccl.twohalo_matter_power(COSMO, k, a)
+    # These are all deprecated.
+    tot = assert_warns(ccl.CCLWarning,
+            ccl.halomodel_matter_power, COSMO, k, a)
+    one = assert_warns(ccl.CCLWarning,
+            ccl.onehalo_matter_power, COSMO, k, a)
+    two = assert_warns(ccl.CCLWarning,
+            ccl.twohalo_matter_power, COSMO, k, a)
 
     assert np.allclose(one + two, tot)

--- a/pyccl/tests/test_halomodel.py
+++ b/pyccl/tests/test_halomodel.py
@@ -40,7 +40,8 @@ def test_halo_concentration(m):
     from pyccl.pyutils import assert_warns
     a = 0.8
     # Deprecated.
-    c = assert_warns(ccl.CCLWarning,
+    c = assert_warns(
+            ccl.CCLWarning,
             ccl.halo_concentration, COSMO, m, a)
     assert np.all(np.isfinite(c))
     assert np.shape(c) == np.shape(m)
@@ -90,7 +91,8 @@ def test_halomodel_choices_smoke(mf_c):
     k = np.geomspace(1E-2, 1, 10)
     # Deprecated
     # TODO: Convert this and other places to using the non-deprecated syntax
-    # Or, since this wasn't already done, maybe this is a useful convenience function?
+    # Or, since this wasn't already done, maybe this is a useful convenience
+    # function?
     p = assert_warns(ccl.CCLWarning, ccl.twohalo_matter_power, cosmo, k, a)
     pb = get_pk_new(mf, c, cosmo, a, k, False, True)
 
@@ -116,11 +118,14 @@ def test_halomodel_power_consistent():
     a = 0.8
     k = np.logspace(-1, 1, 10)
     # These are all deprecated.
-    tot = assert_warns(ccl.CCLWarning,
+    tot = assert_warns(
+            ccl.CCLWarning,
             ccl.halomodel_matter_power, COSMO, k, a)
-    one = assert_warns(ccl.CCLWarning,
+    one = assert_warns(
+            ccl.CCLWarning,
             ccl.onehalo_matter_power, COSMO, k, a)
-    two = assert_warns(ccl.CCLWarning,
+    two = assert_warns(
+            ccl.CCLWarning,
             ccl.twohalo_matter_power, COSMO, k, a)
 
     assert np.allclose(one + two, tot)

--- a/pyccl/tests/test_haloprofile.py
+++ b/pyccl/tests/test_haloprofile.py
@@ -12,6 +12,7 @@ import pytest
     np.array([1, 2, 3]),
     [1, 2, 3]])
 def test_haloprofile_smoke(func, r):
+    from pyccl.pyutils import assert_warns
     cosmo = ccl.Cosmology(
         Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
         transfer_function='bbks', matter_power_spectrum='linear')
@@ -19,6 +20,7 @@ def test_haloprofile_smoke(func, r):
     c = 5
     mass = 1e14
     odelta = 200
-    prof = getattr(ccl, func)(cosmo, c, mass, odelta, a, r)
+    # These are all deprecated
+    prof = assert_warns(ccl.CCLWarning, getattr(ccl, func), cosmo, c, mass, odelta, a, r)
     assert np.all(np.isfinite(prof))
     assert np.shape(prof) == np.shape(r)

--- a/pyccl/tests/test_haloprofile.py
+++ b/pyccl/tests/test_haloprofile.py
@@ -21,6 +21,8 @@ def test_haloprofile_smoke(func, r):
     mass = 1e14
     odelta = 200
     # These are all deprecated
-    prof = assert_warns(ccl.CCLWarning, getattr(ccl, func), cosmo, c, mass, odelta, a, r)
+    prof = assert_warns(
+            ccl.CCLWarning,
+            getattr(ccl, func), cosmo, c, mass, odelta, a, r)
     assert np.all(np.isfinite(prof))
     assert np.shape(prof) == np.shape(r)

--- a/pyccl/tests/test_massfunction.py
+++ b/pyccl/tests/test_massfunction.py
@@ -17,6 +17,7 @@ MF_TYPES = sorted(list(MF_EQUIV.keys()))
 
 @pytest.mark.parametrize('mf_type', MF_TYPES)
 def test_massfunc_models_smoke(mf_type):
+    from pyccl.pyutils import assert_warns
     cosmo = ccl.Cosmology(
         Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
         transfer_function='bbks', matter_power_spectrum='linear',
@@ -24,7 +25,8 @@ def test_massfunc_models_smoke(mf_type):
     hmf_cls = ccl.halos.mass_function_from_name(MF_EQUIV[mf_type])
     hmf = hmf_cls(cosmo)
     for m in MS:
-        nm_old = ccl.massfunc(cosmo, m, 1.)
+        # Deprecated
+        nm_old = assert_warns(ccl.CCLWarning, ccl.massfunc, cosmo, m, 1.)
         nm_new = hmf.get_mass_function(cosmo, m, 1.)
         assert np.all(np.isfinite(nm_old))
         assert np.shape(nm_old) == np.shape(m)
@@ -34,6 +36,7 @@ def test_massfunc_models_smoke(mf_type):
 
 @pytest.mark.parametrize('mf_type', ['tinker10', 'shethtormen'])
 def test_halo_bias_models_smoke(mf_type):
+    from pyccl.pyutils import assert_warns
     cosmo = ccl.Cosmology(
         Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
         transfer_function='bbks', matter_power_spectrum='linear',
@@ -41,7 +44,8 @@ def test_halo_bias_models_smoke(mf_type):
     hbf_cls = ccl.halos.halo_bias_from_name(MF_EQUIV[mf_type])
     hbf = hbf_cls(cosmo)
     for m in MS:
-        bm_old = ccl.halo_bias(cosmo, m, 1.)
+        # Deprecated
+        bm_old = assert_warns(ccl.CCLWarning, ccl.halo_bias, cosmo, m, 1.)
         bm_new = hbf.get_halo_bias(cosmo, m, 1.)
         assert np.all(np.isfinite(bm_old))
         assert np.shape(bm_old) == np.shape(m)
@@ -56,7 +60,7 @@ def test_halo_bias_models_smoke(mf_type):
     np.array([1e14, 1e15])])
 def test_massfunc_smoke(m):
     a = 0.8
-    mf = ccl.massfunc(COSMO, m, a)
+    mf = ccl.halos.MassFuncTinker10(COSMO).get_mass_function(COSMO, m, a)
     assert np.all(np.isfinite(mf))
     assert np.shape(mf) == np.shape(m)
 
@@ -67,7 +71,10 @@ def test_massfunc_smoke(m):
     [1e14, 1e15],
     np.array([1e14, 1e15])])
 def test_massfunc_m2r_smoke(m):
-    r = ccl.massfunc_m2r(COSMO, m)
+    from pyccl.pyutils import assert_warns
+    # Deprecated
+    # TODO: switch to mass2radius_lagrangian
+    r = assert_warns(ccl.CCLWarning, ccl.massfunc_m2r, COSMO, m)
     assert np.all(np.isfinite(r))
     assert np.shape(r) == np.shape(m)
 
@@ -90,7 +97,10 @@ def test_sigmaM_smoke(m):
     [1e14, 1e15],
     np.array([1e14, 1e15])])
 def test_halo_bias_smoke(m):
+    from pyccl.pyutils import assert_warns
     a = 0.8
-    b = ccl.halo_bias(COSMO, m, a)
+    # Deprecated
+    # TODO: switch to HaloBias
+    b = assert_warns(ccl.CCLWarning, ccl.halo_bias, COSMO, m, a)
     assert np.all(np.isfinite(b))
     assert np.shape(b) == np.shape(m)

--- a/pyccl/tests/test_mg.py
+++ b/pyccl/tests/test_mg.py
@@ -37,6 +37,7 @@ def test_mu_sigma_transfer_err(tf):
 
 @pytest.mark.parametrize('mp', ['emu', 'halofit'])
 def test_mu_sigma_matter_power_err(mp):
+    from pyccl.pyutils import assert_warns
     with pytest.raises(ccl.CCLError):
         cosmo = ccl.Cosmology(
             Omega_c=0.25,
@@ -49,4 +50,5 @@ def test_mu_sigma_matter_power_err(mp):
             transfer_function=None,
             matter_power_spectrum=mp
         )
-        ccl.nonlin_matter_power(cosmo, 1, 1)
+        # Also raises a warning, so catch that.
+        assert_warns(ccl.CCLWarning, ccl.nonlin_matter_power, cosmo, 1, 1)

--- a/pyccl/tests/test_power.py
+++ b/pyccl/tests/test_power.py
@@ -28,7 +28,9 @@ def test_halomod_f2d_copy():
     pk2d = ccl.halos.halomod_Pk2D(COSMO_HM, hmc, prf, normprof1=True)
     psp_new = pk2d.psp
     # This just triggers the internal calculation
-    pk_old = assert_warns(ccl.CCLWarning, ccl.nonlin_matter_power, COSMO_HM, 1., 0.8)
+    pk_old = assert_warns(
+            ccl.CCLWarning,
+            ccl.nonlin_matter_power, COSMO_HM, 1., 0.8)
     pk_new = pk2d.eval(1., 0.8, COSMO_HM)
     psp_old = COSMO_HM.cosmo.data.p_nl
     assert psp_new.lkmin == psp_old.lkmin

--- a/pyccl/tests/test_power.py
+++ b/pyccl/tests/test_power.py
@@ -15,6 +15,7 @@ COSMO_HM = ccl.Cosmology(
 
 
 def test_halomod_f2d_copy():
+    from pyccl.pyutils import assert_warns
     mdef = ccl.halos.MassDef('vir', 'matter')
     hmf = ccl.halos.MassFuncSheth99(COSMO_HM, mdef,
                                     mass_def_strict=False,
@@ -27,7 +28,7 @@ def test_halomod_f2d_copy():
     pk2d = ccl.halos.halomod_Pk2D(COSMO_HM, hmc, prf, normprof1=True)
     psp_new = pk2d.psp
     # This just triggers the internal calculation
-    pk_old = ccl.nonlin_matter_power(COSMO_HM, 1., 0.8)
+    pk_old = assert_warns(ccl.CCLWarning, ccl.nonlin_matter_power, COSMO_HM, 1., 0.8)
     pk_new = pk2d.eval(1., 0.8, COSMO_HM)
     psp_old = COSMO_HM.cosmo.data.p_nl
     assert psp_new.lkmin == psp_old.lkmin

--- a/pyccl/tests/test_power_mu_sigma_sigma8norm.py
+++ b/pyccl/tests/test_power_mu_sigma_sigma8norm.py
@@ -5,6 +5,10 @@ import pyccl as ccl
 import sys
 from numpy.testing import assert_raises
 from pyccl.boltzmann import get_isitgr_pk_lin
+try:
+    from importlib import reload
+except ImportError:
+    pass  # in 2.7, reload is a global function.
 
 
 @pytest.mark.parametrize('tf', [
@@ -35,6 +39,9 @@ def test_power_mu_sigma_sigma8norm(tf):
     with mock.patch.dict(sys.modules, {'isitgr': None}):
         with assert_raises(ImportError):
             get_isitgr_pk_lin(cosmo)
+    # Importing ccl without isitgr is fine.  No ImportError triggered.
+    with mock.patch.dict(sys.modules, {'isitgr': None}):
+        reload(ccl.boltzmann)
 
 
 @pytest.mark.parametrize('tf', [

--- a/pyccl/tests/test_profiles.py
+++ b/pyccl/tests/test_profiles.py
@@ -33,7 +33,8 @@ def smoke_assert_prof_real(profile):
         if sr == 0:
             r = 0.5
         else:
-            r = np.linspace(0., 1., sr)
+            # Don't include 0 to avoid 1/0 at origin.
+            r = np.linspace(0.001, 1., sr)
         if sm == 0:
             m = 1E12
         else:

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -366,7 +366,8 @@ class Tracer(object):
                 raise ValueError("Scale-dependent transfer arrays "
                                  "should have the same shape")
         else:
-            a_s, lk_s, tka_s = _check_array_params(transfer_ka, 'transer_ka', arr3=True)
+            a_s, lk_s, tka_s = _check_array_params(transfer_ka, 'transer_ka',
+                                                   arr3=True)
             if tka_s.shape != (len(a_s), len(lk_s)):
                 raise ValueError("2D transfer array has inconsistent "
                                  "shape. Should be (na,nk)")

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -392,7 +392,10 @@ class Tracer(object):
         self._trc.append(_check_returned_tracer(ret))
 
     def __del__(self):
-        if hasattr(self, '_trc'):
+        # Sometimes lib is freed before some Tracers, in which case, this
+        # doesn't work.
+        # So just check that lib.cl_tracer_t_free is still a real function.
+        if hasattr(self, '_trc') and lib.cl_tracer_t_free is not None:
             for t in self._trc:
                 lib.cl_tracer_t_free(t)
 

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -3,10 +3,6 @@ from .core import check
 from .background import comoving_radial_distance, growth_rate, growth_factor
 from .pyutils import _check_array_params, NoneArr
 import numpy as np
-try:
-    from collections.abc import Iterable
-except ImportError:  # for py2.7
-    from collections import Iterable
 
 
 def get_density_kernel(cosmo, dndz):
@@ -26,12 +22,7 @@ def get_density_kernel(cosmo, dndz):
             The units are arbitrary; N(z) will be normalized
             to unity.
     """
-    if ((not isinstance(dndz, Iterable))
-        or (len(dndz) != 2)
-        or (not (isinstance(dndz[0], Iterable)
-                 and isinstance(dndz[1], Iterable)))):
-        raise ValueError("dndz needs to be a tuple of two arrays.")
-    z_n, n = _check_array_params(dndz)
+    z_n, n = _check_array_params(dndz, 'dndz')
     # this call inits the distance splines neded by the kernel functions
     chi = comoving_radial_distance(cosmo, 1./(1.+z_n))
     status = 0
@@ -62,18 +53,12 @@ def get_lensing_kernel(cosmo, dndz, mag_bias=None):
             giving the magnification bias as a function of redshift. If
             `None`, s=0 will be assumed
     """
-    if ((not isinstance(dndz, Iterable))
-        or (len(dndz) != 2)
-        or (not (isinstance(dndz[0], Iterable)
-                 and isinstance(dndz[1], Iterable)))):
-        raise ValueError("dndz needs to be a tuple of two arrays.")
-
     # we need the distance functions at the C layer
     cosmo.compute_distances()
 
-    z_n, n = _check_array_params(dndz)
+    z_n, n = _check_array_params(dndz, 'dndz')
     has_magbias = mag_bias is not None
-    z_s, s = _check_array_params(mag_bias)
+    z_s, s = _check_array_params(mag_bias, 'mag_bias')
 
     # Calculate number of samples in chi
     nchi = lib.get_nchi_lensing_kernel_wrapper(z_n)
@@ -369,10 +354,10 @@ class Tracer(object):
         is_a_constant = (transfer_ka is None) and (transfer_a is None)
         is_kernel_constant = kernel is None
 
-        chi_s, wchi_s = _check_array_params(kernel)
+        chi_s, wchi_s = _check_array_params(kernel, 'kernel')
         if is_factorizable:
-            a_s, ta_s = _check_array_params(transfer_a)
-            lk_s, tk_s = _check_array_params(transfer_k)
+            a_s, ta_s = _check_array_params(transfer_a, 'transfer_a')
+            lk_s, tk_s = _check_array_params(transfer_k, 'transfer_k')
             tka_s = NoneArr
             if (not is_a_constant) and (a_s.shape != ta_s.shape):
                 raise ValueError("Time-dependent transfer arrays "
@@ -381,7 +366,7 @@ class Tracer(object):
                 raise ValueError("Scale-dependent transfer arrays "
                                  "should have the same shape")
         else:
-            a_s, lk_s, tka_s = _check_array_params(transfer_ka, arr3=True)
+            a_s, lk_s, tka_s = _check_array_params(transfer_ka, 'transer_ka', arr3=True)
             if tka_s.shape != (len(a_s), len(lk_s)):
                 raise ValueError("2D transfer array has inconsistent "
                                  "shape. Should be (na,nk)")
@@ -439,7 +424,7 @@ class NumberCountsTracer(Tracer):
         cosmo.compute_distances()
 
         from scipy.interpolate import interp1d
-        z_n, n = _check_array_params(dndz)
+        z_n, n = _check_array_params(dndz, 'dndz')
         self._dndz = interp1d(z_n, n, bounds_error=False,
                               fill_value=0)
 
@@ -449,7 +434,7 @@ class NumberCountsTracer(Tracer):
             if kernel_d is None:
                 kernel_d = get_density_kernel(cosmo, dndz)
             # Transfer
-            z_b, b = _check_array_params(bias)
+            z_b, b = _check_array_params(bias, 'bias')
             # Reverse order for increasing a
             t_a = (1./(1+z_b[::-1]), b[::-1])
             self.add_tracer(cosmo, kernel=kernel_d, transfer_a=t_a)
@@ -458,7 +443,7 @@ class NumberCountsTracer(Tracer):
             if kernel_d is None:
                 kernel_d = get_density_kernel(cosmo, dndz)
             # Transfer (growth rate)
-            z_b, _ = _check_array_params(dndz)
+            z_b, _ = _check_array_params(dndz, 'dndz')
             a_s = 1./(1+z_b[::-1])
             t_a = (a_s, -growth_rate(cosmo, a_s))
             self.add_tracer(cosmo, kernel=kernel_d,
@@ -500,7 +485,7 @@ class WeakLensingTracer(Tracer):
         cosmo.compute_distances()
 
         from scipy.interpolate import interp1d
-        z_n, n = _check_array_params(dndz)
+        z_n, n = _check_array_params(dndz, 'dndz')
         self._dndz = interp1d(z_n, n, bounds_error=False,
                               fill_value=0)
 
@@ -510,7 +495,7 @@ class WeakLensingTracer(Tracer):
             self.add_tracer(cosmo, kernel=kernel_l,
                             der_bessel=-1, der_angles=2)
         if ia_bias is not None:  # Has intrinsic alignments
-            z_a, tmp_a = _check_array_params(ia_bias)
+            z_a, tmp_a = _check_array_params(ia_bias, 'ia_bias')
             # Kernel
             kernel_i = get_density_kernel(cosmo, dndz)
             if use_A_ia:

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -3,7 +3,10 @@ from .core import check
 from .background import comoving_radial_distance, growth_rate, growth_factor
 from .pyutils import _check_array_params, NoneArr
 import numpy as np
-import collections
+try:
+    from collections.abc import Iterable
+except ImportError:  # for py2.7
+    from collections import Iterable
 
 
 def get_density_kernel(cosmo, dndz):
@@ -23,10 +26,10 @@ def get_density_kernel(cosmo, dndz):
             The units are arbitrary; N(z) will be normalized
             to unity.
     """
-    if ((not isinstance(dndz, collections.Iterable))
+    if ((not isinstance(dndz, Iterable))
         or (len(dndz) != 2)
-        or (not (isinstance(dndz[0], collections.Iterable)
-                 and isinstance(dndz[1], collections.Iterable)))):
+        or (not (isinstance(dndz[0], Iterable)
+                 and isinstance(dndz[1], Iterable)))):
         raise ValueError("dndz needs to be a tuple of two arrays.")
     z_n, n = _check_array_params(dndz)
     # this call inits the distance splines neded by the kernel functions
@@ -59,10 +62,10 @@ def get_lensing_kernel(cosmo, dndz, mag_bias=None):
             giving the magnification bias as a function of redshift. If
             `None`, s=0 will be assumed
     """
-    if ((not isinstance(dndz, collections.Iterable))
+    if ((not isinstance(dndz, Iterable))
         or (len(dndz) != 2)
-        or (not (isinstance(dndz[0], collections.Iterable)
-                 and isinstance(dndz[1], collections.Iterable)))):
+        or (not (isinstance(dndz[0], Iterable)
+                 and isinstance(dndz[1], Iterable)))):
         raise ValueError("dndz needs to be a tuple of two arrays.")
 
     # we need the distance functions at the C layer

--- a/src/ccl_background.c
+++ b/src/ccl_background.c
@@ -269,7 +269,7 @@ static int growth_factor_and_growth_rate(double a, double *gf, double *fg, ccl_c
 
       if(gslstatus != GSL_SUCCESS) {
         ccl_raise_gsl_warning(gslstatus, "ccl_background.c: growth_factor_and_growth_rate():");
-        return NAN;
+        return 0;
       }
 
       *gf = y[0];
@@ -299,7 +299,7 @@ static int growth_factor_and_growth_rate(double a, double *gf, double *fg, ccl_c
 
       if(gslstatus != GSL_SUCCESS) {
         ccl_raise_gsl_warning(gslstatus, "ccl_background.c: growth_factor_and_growth_rate():");
-        return NAN;
+        return 0;
       }
 
       *gf = y[0];

--- a/src/ccl_background.c
+++ b/src/ccl_background.c
@@ -66,7 +66,7 @@ double ccl_omega_x(ccl_cosmology * cosmo, double a, ccl_species_x_label label, i
   if ((cosmo->params.N_nu_mass) > 0.0001) {
     // Call the massive neutrino density function just once at this redshift.
     OmNuh2 = ccl_Omeganuh2(a, cosmo->params.N_nu_mass, cosmo->params.m_nu,
-		       cosmo->params.T_CMB, status);
+                           cosmo->params.T_CMB, status);
   }
   else {
     OmNuh2 = 0.;
@@ -79,7 +79,7 @@ double ccl_omega_x(ccl_cosmology * cosmo, double a, ccl_species_x_label label, i
       return 1.;
     case ccl_species_m_label :
       return (cosmo->params.Omega_c + cosmo->params.Omega_b) / (a*a*a) / hnorm / hnorm +
-	      OmNuh2 / (cosmo->params.h) / (cosmo->params.h) / hnorm / hnorm;
+          OmNuh2 / (cosmo->params.h) / (cosmo->params.h) / hnorm / hnorm;
     case ccl_species_l_label :
       return
         cosmo->params.Omega_l *
@@ -138,9 +138,9 @@ of modifications to GR in the quasistatic approximation.
 
 double ccl_mu_MG(ccl_cosmology * cosmo, double a, int *status)
 {
-	// This function can be extended to include other
-	// z-dependences for mu in the future.
-	return cosmo->params.mu_0 * ccl_omega_x(cosmo, a, ccl_species_l_label, status) / cosmo->params.Omega_l;
+    // This function can be extended to include other
+    // z-dependences for mu in the future.
+    return cosmo->params.mu_0 * ccl_omega_x(cosmo, a, ccl_species_l_label, status) / cosmo->params.Omega_l;
 }
 
 /* --------- ROUTINE: ccl_Sig_MG ---------
@@ -151,9 +151,9 @@ of modifications to GR in the quasistatic approximation.
 
 double ccl_Sig_MG(ccl_cosmology * cosmo, double a, int *status)
 {
-	// This function can be extended to include other
-	// z-dependences for Sigma in the future.
-	return cosmo->params.sigma_0 * ccl_omega_x(cosmo, a, ccl_species_l_label, status) / cosmo->params.Omega_l;
+    // This function can be extended to include other
+    // z-dependences for Sigma in the future.
+    return cosmo->params.sigma_0 * ccl_omega_x(cosmo, a, ccl_species_l_label, status) / cosmo->params.Omega_l;
 }
 
 // Structure to hold parameters of chi_integrand
@@ -788,7 +788,7 @@ void ccl_cosmology_compute_growth(ccl_cosmology* cosmo, int* status)
   double growth0, fgrowth0;
   double *y = NULL;
   double *y2 = NULL;
-	double df, integ;
+  double df, integ;
 
   if (*status == 0) {
     a = ccl_linlog_spacing(
@@ -851,9 +851,9 @@ void ccl_cosmology_compute_growth(ccl_cosmology* cosmo, int* status)
           else if(z>cosmo->params.z_mgrowth[cosmo->params.nz_mgrowth-1])
             df_arr[i]=cosmo->params.df_mgrowth[cosmo->params.nz_mgrowth-1];
           else
-  	       chistatus |= gsl_spline_eval_e(df_z_spline,z,NULL,&df_arr[i]);
+              chistatus |= gsl_spline_eval_e(df_z_spline,z,NULL,&df_arr[i]);
         } else {
-  	     df_arr[i]=0;
+            df_arr[i]=0;
         }
       }
       if(chistatus) {
@@ -933,7 +933,7 @@ void ccl_cosmology_compute_growth(ccl_cosmology* cosmo, int* status)
           gslstatus = gsl_integration_cquad(
             &F, a[i], 1.0, 0.0, cosmo->gsl_params.INTEGRATION_DISTANCE_EPSREL,
             workspace, &integ, NULL, NULL);
-  	      if (gslstatus != GSL_SUCCESS) {
+          if (gslstatus != GSL_SUCCESS) {
             ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_cosmology_compute_growth():");
             status_mg |= gslstatus;
           }
@@ -1109,7 +1109,7 @@ double ccl_sinn(ccl_cosmology *cosmo, double chi, int *status)
   default:
     *status = CCL_ERROR_PARAMETERS;
     ccl_cosmology_set_status_message(cosmo, "ccl_background.c: ccl_sinn: ill-defined cosmo->params.k_sign = %d",
-	    cosmo->params.k_sign);
+                                     cosmo->params.k_sign);
     return NAN;
   }
 }
@@ -1166,26 +1166,26 @@ double ccl_angular_diameter_distance(ccl_cosmology * cosmo, double a1, double a2
     return NAN;
   } else {
       if (!cosmo->computed_distances) {
-	*status = CCL_ERROR_DISTANCES_INIT;
-	ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_angular_diameter_distance(): distance splines have not been precomputed!");
-	return NAN;
+          *status = CCL_ERROR_DISTANCES_INIT;
+          ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_angular_diameter_distance(): distance splines have not been precomputed!");
+          return NAN;
       }
       double chi1,chi2;
       int gslstatus = gsl_spline_eval_e(cosmo->data.chi, a1, NULL, &chi1);
       if(gslstatus != GSL_SUCCESS) {
-	ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_angular_diameter_distance():");
-	*status |= gslstatus;
-	ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_angular_diameter_distance(): Scale factor outside interpolation range.\n");
-	return NAN;
+          ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_angular_diameter_distance():");
+          *status |= gslstatus;
+          ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_angular_diameter_distance(): Scale factor outside interpolation range.\n");
+          return NAN;
       }
       gslstatus = gsl_spline_eval_e(cosmo->data.chi, a2, NULL, &chi2);
       if(gslstatus != GSL_SUCCESS) {
-	ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_angular_diameter_distance():");
-	*status |= gslstatus;
-	ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_angular_diameter_distance(): Scale factor outside interpolation range.\n");
-	return NAN;
+          ccl_raise_gsl_warning(gslstatus, "ccl_background.c: ccl_angular_diameter_distance():");
+          *status |= gslstatus;
+          ccl_cosmology_set_status_message(cosmo,"ccl_background.c: ccl_angular_diameter_distance(): Scale factor outside interpolation range.\n");
+          return NAN;
       }
-	    return a2*ccl_sinn(cosmo,chi2-chi1,status);
+      return a2*ccl_sinn(cosmo,chi2-chi1,status);
   }
 }
 
@@ -1399,8 +1399,8 @@ double ccl_growth_rate(ccl_cosmology * cosmo, double a, int * status)
       }
       return g;
     } else {
-	    return NAN;
-	  }
+        return NAN;
+    }
   }
 }
 

--- a/src/ccl_f2d.c
+++ b/src/ccl_f2d.c
@@ -38,8 +38,8 @@ ccl_f2d_t *ccl_f2d_t_copy(ccl_f2d_t *f2d_o, int *status)
         *status = CCL_ERROR_MEMORY;
 
       if(*status==0) {
-        s2dstatus|=gsl_spline_init(f2d->fk, f2d_o->fk->x,
-                                   f2d_o->fk->y, f2d_o->fk->size);
+        s2dstatus |= gsl_spline_init(f2d->fk, f2d_o->fk->x,
+                                     f2d_o->fk->y, f2d_o->fk->size);
         if(s2dstatus)
           *status = CCL_ERROR_SPLINE;
       }
@@ -56,8 +56,8 @@ ccl_f2d_t *ccl_f2d_t_copy(ccl_f2d_t *f2d_o, int *status)
         *status = CCL_ERROR_MEMORY;
 
       if(*status==0) {
-        s2dstatus|=gsl_spline_init(f2d->fa, f2d_o->fa->x,
-                                   f2d_o->fa->y, f2d_o->fa->size);
+        s2dstatus |= gsl_spline_init(f2d->fa, f2d_o->fa->x,
+                                     f2d_o->fa->y, f2d_o->fa->size);
         if(s2dstatus)
           *status = CCL_ERROR_SPLINE;
       }
@@ -192,7 +192,7 @@ ccl_f2d_t *ccl_f2d_t_new(int na,double *a_arr,
       if (f2d->fk != NULL)
         s2dstatus |= gsl_spline_init(f2d->fk, lk_arr, fk_arr, nk);
       if (f2d->fa != NULL)
-        s2dstatus|=gsl_spline_init(f2d->fa, a_arr, fa_arr, na);
+        s2dstatus |= gsl_spline_init(f2d->fa, a_arr, fa_arr, na);
     }
     else {
       if (f2d->fka != NULL)

--- a/src/ccl_f2d.c
+++ b/src/ccl_f2d.c
@@ -75,10 +75,10 @@ ccl_f2d_t *ccl_f2d_t_copy(ccl_f2d_t *f2d_o, int *status)
         *status = CCL_ERROR_MEMORY;
 
       if(*status==0) {
-        s2dstatus!=gsl_spline2d_init(f2d->fka, f2d_o->fka->xarr,
-                                     f2d_o->fka->yarr, f2d_o->fka->zarr,
-                                     f2d_o->fka->interp_object.xsize,
-                                     f2d_o->fka->interp_object.ysize);
+        s2dstatus |= gsl_spline2d_init(f2d->fka, f2d_o->fka->xarr,
+                                       f2d_o->fka->yarr, f2d_o->fka->zarr,
+                                       f2d_o->fka->interp_object.xsize,
+                                       f2d_o->fka->interp_object.ysize);
         if(s2dstatus)
           *status = CCL_ERROR_SPLINE;
       }


### PR DESCRIPTION
While helping Elisa and Mustapha try to find their problems running the test suite on master, I noticed that you currently have a lot of warnings show up both when compiling and when running the tests.  IMO, it's a good idea to try to remove all these warnings.  So I went ahead and did so for you.

At least 3 of the compiler warnings were actual bugs (related to runtime failures, so didn't affect much in normal operations).  

The python warnings were mostly CCL deprecations, so for these I added a test using assert_warns to check that the deprecation warning was raised, and to catch it from being output to the terminal.

Finally, there were a couple other warnings related to numpy and collections that aren't a problem yet, but might become a problem in the future.  So worth fixing now before they become an error.