### PR TITLE
Adding automated travis upload to PyPi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,65 +1,58 @@
 language: generic
-
 matrix:
   include:
-    - os: linux
-      sudo: required
-      env: TOXENV=py36
-      name: linux (Python3.6)
-    - os: osx
-      osx_image: xcode9.4
-      env: TOXENV=py36
-      name: OSX (Python3.6)
-    - os: linux
-      sudo: required
-      env: TOXENV=py27
-      name: linux (Python2.7)
-    - os: osx
-      osx_image: xcode9.4
-      env: TOXENV=py27
-      name: OSX (Python2.7)
-
+  - os: linux
+    sudo: required
+    env: TOXENV=py36
+    name: linux (Python3.6)
+  - os: osx
+    osx_image: xcode9.4
+    env: TOXENV=py36
+    name: OSX (Python3.6)
+  - os: linux
+    sudo: required
+    env: TOXENV=py27
+    name: linux (Python2.7)
+  - os: osx
+    osx_image: xcode9.4
+    env: TOXENV=py27
+    name: OSX (Python2.7)
   allow_failures:
-    - name: linux (Python2.7)
-    - name: OSX (Python2.7)
+  - name: linux (Python2.7)
+  - name: OSX (Python2.7)
   fast_finish: true
-
 install:
-  - "./.travis/install.sh"
-  - export PATH=$HOME/miniconda/bin:$PATH
-  - source activate test-environment
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then conda install -y llvm-openmp; fi
-  # this is a hack for conda osx compilers
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib; fi
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export CONDA_BUILD_SYSROOT=/; fi
-
-  # install CLASS into the env
-  - if [[ $TRAVIS_OS_NAME != 'osx' ]]; then "./.travis/install_class_linux.sh"; fi
-  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then "./.travis/install_class_osx.sh"; fi
-
+- "./.travis/install.sh"
+- export PATH=$HOME/miniconda/bin:$PATH
+- source activate test-environment
+- if [[ $TRAVIS_OS_NAME == 'osx' ]]; then conda install -y llvm-openmp; fi
+- if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib;
+  fi
+- if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export CONDA_BUILD_SYSROOT=/; fi
+- if [[ $TRAVIS_OS_NAME != 'osx' ]]; then "./.travis/install_class_linux.sh"; fi
+- if [[ $TRAVIS_OS_NAME == 'osx' ]]; then "./.travis/install_class_osx.sh"; fi
 script:
-  - flake8 pyccl
-  - flake8 --exclude=data benchmarks
-  - "[[ `grep \"$(printf '\t')\" pyccl/*.py` == \"\" ]]"  # no tabs in python
-  - mkdir -p build && cd build && cmake -DFORCE_OPENMP=YES -DCMAKE_VERBOSE_MAKEFILE=ON .. && make && cd ..
-  - CLASS_PARAM_DIR=./build/extern/share/class/ OMP_NUM_THREADS=2 ./build/check_ccl
-  - rm -rf build
-  - mkdir -p build && cd build && cmake -DFORCE_OPENMP=YES -DCMAKE_VERBOSE_MAKEFILE=ON .. && cd ..
-  - python setup.py build
-  - python setup.py develop
-  - OMP_NUM_THREADS=2 pytest -vv pyccl --cov=pyccl
-  - OMP_NUM_THREADS=2 pytest -vv benchmarks --cov=pyccl --cov-append
-
+- flake8 pyccl
+- flake8 --exclude=data benchmarks
+- "[[ `grep \"$(printf '\t')\" pyccl/*.py` == \"\" ]]"
+- mkdir -p build && cd build && cmake -DFORCE_OPENMP=YES -DCMAKE_VERBOSE_MAKEFILE=ON
+  .. && make && cd ..
+- CLASS_PARAM_DIR=./build/extern/share/class/ OMP_NUM_THREADS=2 ./build/check_ccl
+- rm -rf build
+- mkdir -p build && cd build && cmake -DFORCE_OPENMP=YES -DCMAKE_VERBOSE_MAKEFILE=ON
+  .. && cd ..
+- python setup.py build
+- python setup.py develop
+- OMP_NUM_THREADS=2 pytest -vv pyccl --cov=pyccl
+- OMP_NUM_THREADS=2 pytest -vv benchmarks --cov=pyccl --cov-append
 after_success:
-  - coveralls
-
-## Uncommenting this section will let travis upload releases to PyPi automatcally
-## everytime a new version is tagged. No modifications required.
-# deploy:
-#   provider: pypi
-#   user: __token__
-#   password:
-#     secure: lX2d0KINZUDSWf/PJvkWUPIUxJfih7dZgK7gAbkorTG6EzGohxxRO2RX2BLQ+An6wYttit1syGwyEH8ZIINHivE6gOyc02aw8TOVZa6UsQPLg7mVy0/Ds//9hAzB0dIZg5XRN4ATxCUh2WhvbxgP/NKMkABgdr8kEKr/zs7OzAiHYAOTXTpjtzAtPnR7ilwHLLk0f1kjDfxJEBUz9mi2dDwO9Psgx2VS4WDE7G09DNwEYwfW5p8v22mKCVZS5BkUwrNX+DQ8v2wT+b4C+UWQcQtuT8qNFaAO7I4ud6dLZQa/yjROoCb7T2mprJZLqBh8gR8t5XridtJuGrFSFeQV8r4OOOPM1cPVN6FtsxeJNmJ3egeZLF+fchhPUMEIyck8kLpuh4ub8HfDsJj9Bf033MoAioXVSQM1F9M5TR9Uq+XLTW6n5uub2aoVG/Jfvrg0qJpIkor4n9JUOJw7F3UDKWNUEs7+ca/HZ2VCvp8Z4d4liLbUT3XL+46jwtW72rILysbjUh+KsJkl30fYDBKaZ260oGDV+hL1EorD5E1rXw2Nk6e7g+RaTlXEAosZxtmd/qpE8seK0J734svoTZjR8gH9SlNQDW4xaoUcZNeru/FkSgQOYk3z5bKspuv+7uPVPI/D172x7IizQEyz33S7eJSUsAh9k8oJeq19Okc99Ac=
-#   on:
-#     tags: true
-#     branch: master
+- coveralls
+deploy:
+  provider: pypi
+  user: __token__
+  password:
+    secure: NsqcEdDZJDAbs4YuBzVlQ5a25fY1f1Rdoq8WSFPN97zEXOeJzi6kDJmdQbOwoOPQwvTqlG5YP52zQtmU+SlIgEfJZeFr2q7YCGAT5xhAMEIBKzpX7es4w1HZXqer2hWByOr1Q/8yqMXrJChyAV/gzb6DFvcBc1+n8rzBMP/9OfwU/jxk8SY586T7BKnAuOlOHty/QQ1riBY8U61qOFQ3//dui1Jt698Tb4zT9hpYykV53T4qb0sPnl+rr4R95et+Jom1FOMUVRAcYnKriV7pVkA9LwUf1uRkkOiMXN/spNO3KyTJ2q9US1SxdyPPpAse4YNin7qlBT+FVZneTI+rZjk6AdehjLCAOU3IiGfUmlrtofauEDwEJ5nWeE5Mtd9p8jPuIil8AYqT6hT4DBMlp8Tj4AAZFFqKxdvVB5uMUuVkniyBbdcSulp+vRCMUm6NGYtSoAmJIjbG562yCzJAtxFQF+0nVXa3WCMd4+2Oc+ipYlUAUt4xQ1pxIVBSDE5zqEc3QrNY3e7LuFWo7E7ZvuWpkAc2OO7DaePe+CQ/B3D2vFWollmIFcdr24xtEB1sSHIKDRSOip9lmqfdPs5Nayc7qtKBPXViwN1VZncvUqYtyJiEc2feKeZIwzV5c1ELAIUoAW8UOt1cwUfdL/pdCRSBOHIST4QBeMSZxzOuEtE=
+  distributions: sdist
+  on:
+    tags: true
+    branch: master

--- a/readthedocs/source/development_workflow.rst
+++ b/readthedocs/source/development_workflow.rst
@@ -157,7 +157,8 @@ When cutting a new release, the procedure is as follows:
 
       $ python setup.py sdist
 
-   This command will create a ``.tar.gz`` file in the ``dist`` folder.
+   This command will create a ``.tar.gz`` file in the ``dist`` folder. CAREFUL!!! Only build and upload the source distribution,
+   not a binary wheel!
 #. Upload source distribution to PyPi using ``twine`` (can be installed using ``pip`` or ``conda``):
 
    .. code-block:: bash


### PR DESCRIPTION
This PR aims to have travis automatically upload the source distribution for CCL to PyPi on new releases without manual intervention. I have encoded an access token for pypi, and this should work, but can't really test it until the next release.
This should fix #774 