### PR TITLE
Growth from arrays

### DIFF
--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -186,6 +186,9 @@ class Cosmology(object):
         # This will change to True once the "_set_background_from_arrays"
         # is called.
         self._background_on_input = False
+        # This will change to True once the "_set_growth_from_arrays"
+        # is called.
+        self._growth_on_input = False
         # This will change to True once the "_set_linear_power_from_arrays"
         # is called.
         self._linear_power_on_input = False
@@ -651,20 +654,21 @@ class Cosmology(object):
             check(status, self)
         else:
             # Check that input arrays have the same size.
-            if not (self.a_array.shape == self.chi_array.shape
+            if not (self.a_array_back.shape == self.chi_array.shape
                     == self.hoh0_array.shape):
                 raise ValueError("Input arrays must have the same size.")
-            # Check that a_array is a monotonically increasing array.
-            if not np.array_equal(self.a_array, np.sort(self.a_array)):
+            # Check that a_array_back is a monotonically increasing array.
+            if not np.array_equal(self.a_array_back,
+                                  np.sort(self.a_array_back)):
                 raise ValueError("Input scale factor array is not "
                                  "monotonically increasing.")
-            # Check that the last element of a_array is 1:
-            if np.abs(self.a_array[-1]-1.0) > 1e-5:
+            # Check that the last element of a_array_back is 1:
+            if np.abs(self.a_array_back[-1]-1.0) > 1e-5:
                 raise ValueError("The last element of the input scale factor"
                                  "array must be 1.0.")
             status = 0
             status = lib.cosmology_distances_from_input(self.cosmo,
-                                                        self.a_array,
+                                                        self.a_array_back,
                                                         self.chi_array,
                                                         self.hoh0_array,
                                                         status)
@@ -695,25 +699,27 @@ class Cosmology(object):
                     "with massive neutrinos in CCL!",
                     category=CCLWarning)
 
-        if not self._background_on_input:
+        if not self._growth_on_input:
             status = 0
             status = lib.cosmology_compute_growth(self.cosmo, status)
             check(status, self)
         else:
             # Check that input arrays have the same size.
-            if not (self.a_array.shape == self.growth_array.shape
+            if not (self.a_array_grth.shape == self.growth_array.shape
                     == self.fgrowth_array.shape):
                 raise ValueError("Input arrays must have the same size.")
-            # Check that a_array is a monotonically increasing array.
-            if not np.array_equal(self.a_array, np.sort(self.a_array)):
+            # Check that a_array_grth is a monotonically increasing array.
+            if not np.array_equal(self.a_array_grth,
+                                  np.sort(self.a_array_grth)):
                 raise ValueError("Input scale factor array is not "
                                  "monotonically increasing.")
-            # Check that the last element of a_array is 1:
-            if np.abs(self.a_array[-1]-1.0) > 1e-5:
+            # Check that the last element of a_array_grth is 1:
+            if np.abs(self.a_array_grth[-1]-1.0) > 1e-5:
                 raise ValueError("The last element of the input scale factor"
                                  "array must be 1.0.")
             status = 0
-            status = lib.cosmology_growth_from_input(self.cosmo, self.a_array,
+            status = lib.cosmology_growth_from_input(self.cosmo,
+                                                     self.a_array_grth,
                                                      self.growth_array,
                                                      self.fgrowth_array,
                                                      status)
@@ -782,9 +788,9 @@ class Cosmology(object):
             raise ValueError("Cannot compute linear power spectrum from"
                              " input without input arrays initialized.")
         pk_lin = Pk2D(pkfunc=None,
-                      a_arr=self.a_array,
-                      lk_arr=np.log(self.k_array),
-                      pk_arr=self.pk_array,
+                      a_arr=self.a_array_pkln,
+                      lk_arr=np.log(self.k_array_pkln),
+                      pk_arr=self.pk_array_pkln,
                       is_logp=False,
                       extrap_order_lok=1,
                       extrap_order_hik=2,
@@ -891,16 +897,16 @@ class Cosmology(object):
         if not self._nonlinear_power_on_input:
             raise ValueError("Cannot compute non-linear power spectrum from"
                              "input without input arrays initialized.")
-        pk_lin = Pk2D(pkfunc=None,
-                      a_arr=self.a_array,
-                      lk_arr=np.log(self.k_array),
-                      pk_arr=self.pk_array,
+        pk_nln = Pk2D(pkfunc=None,
+                      a_arr=self.a_array_pknl,
+                      lk_arr=np.log(self.k_array_pknl),
+                      pk_arr=self.pk_array_pknl,
                       is_logp=False,
                       extrap_order_lok=1,
                       extrap_order_hik=2,
                       cosmo=None)
 
-        psp = pk_lin.psp
+        psp = pk_nln.psp
 
         status = 0
         status = lib.cosmology_compute_nonlin_power(self.cosmo, psp, status)
@@ -980,8 +986,7 @@ class Cosmology(object):
         return "status(%s): %s" % (status, msg)
 
     def _set_background_from_arrays(self, a_array=None, chi_array=None,
-                                    hoh0_array=None, growth_array=None,
-                                    fgrowth_array=None):
+                                    hoh0_array=None):
         """
         Function to store distances and growth splines from input arrays.
 
@@ -993,25 +998,45 @@ class Cosmology(object):
                 at points indicated by the a_array.
             hoh0_array (array_like, optional): Hubble parameter divided by the
                 value of H0.
+        """
+        if self.has_distances:
+            raise ValueError("Background cosmology has already been"
+                             " initialized and cannot be reset.")
+        else:
+            self._background_on_input = True
+            self.a_array_back = a_array
+            self.chi_array = chi_array
+            self.hoh0_array = hoh0_array
+            # Check if the input arrays are all parsed
+            if ((a_array is None) or (chi_array is None)
+                    or (hoh0_array is None)):
+                raise ValueError("Input arrays not parsed.")
+
+    def _set_growth_from_arrays(self, a_array=None, growth_array=None,
+                                fgrowth_array=None):
+        """
+        Function to store distances and growth splines from input arrays.
+
+        Args:
+            a_array (array_like, optional): Scale factor array with values on
+                which the input arrays are computed. The array must end on the
+                value of 1.0.
             growth_array (array_like, optional): Growth factor array, defined
                 as D(a)=P(k,a)/P(k,a=1), assuming no scale dependence. It is
                 assumed that D(a<<1)~a so that D(1.0) will be used for
                 normalization.
             fgrowth_array (array_like, optional): Growth rate array.
         """
-        if self.has_distances or self.has_growth:
-            raise ValueError("Background cosmology has already been"
+        if self.has_growth:
+            raise ValueError("Linear growth has already been"
                              " initialized and cannot be reset.")
         else:
-            self._background_on_input = True
-            self.a_array = a_array
-            self.chi_array = chi_array
-            self.hoh0_array = hoh0_array
+            self._growth_on_input = True
+            self.a_array_grth = a_array
             self.growth_array = growth_array
             self.fgrowth_array = fgrowth_array
             # Check if the input arrays are all parsed
-            if ((a_array is None) or (chi_array is None)
-                    or (hoh0_array is None) or (growth_array is None)
+            if ((a_array is None) or (growth_array is None)
                     or (fgrowth_array is None)):
                 raise ValueError("Input arrays not parsed.")
 
@@ -1050,9 +1075,9 @@ class Cosmology(object):
             self.cosmo.config.transfer_function_method = lib.pklin_from_input
             self._config_init_kwargs['transfer_function'] = 'pklin_from_input'
             self._linear_power_on_input = True
-            self.a_array = a_array
-            self.k_array = k_array
-            self.pk_array = pk_array
+            self.a_array_pkln = a_array
+            self.k_array_pkln = k_array
+            self.pk_array_pkln = pk_array
 
     def _set_nonlin_power_from_arrays(self, a_array=None, k_array=None,
                                       pk_array=None):
@@ -1091,9 +1116,9 @@ class Cosmology(object):
             self._config_init_kwargs['matter_power_spectrum']\
                 = 'pknl_from_input'
             self._nonlinear_power_on_input = True
-            self.a_array = a_array
-            self.k_array = k_array
-            self.pk_array = pk_array
+            self.a_array_pknl = a_array
+            self.k_array_pknl = k_array
+            self.pk_array_pknl = pk_array
 
 
 class CosmologyVanillaLCDM(Cosmology):

--- a/pyccl/tests/test_background.py
+++ b/pyccl/tests/test_background.py
@@ -135,9 +135,10 @@ def test_input_arrays():
                                 A_s=2e-9)
     cosmo_input._set_background_from_arrays(a_array=a_arr,
                                             chi_array=chi_from_ccl,
-                                            hoh0_array=hoh0_from_ccl,
-                                            growth_array=growth_from_ccl,
-                                            fgrowth_array=fgrowth_from_ccl)
+                                            hoh0_array=hoh0_from_ccl)
+    cosmo_input._set_growth_from_arrays(a_array=a_arr,
+                                        growth_array=growth_from_ccl,
+                                        fgrowth_array=fgrowth_from_ccl)
 
     # Where to compare chi(a) from CCL and from CCL with input quantities.
     a_arr = np.linspace(0.102, 0.987, 158)
@@ -168,9 +169,10 @@ def test_input_arrays_raises():
                                     n_s=0.965, A_s=2e-9)
         cosmo_input._set_background_from_arrays(a_array=input_a,
                                                 chi_array=input_chi,
-                                                hoh0_array=input_hoh0,
-                                                growth_array=input_growth,
-                                                fgrowth_array=input_fgrowth)
+                                                hoh0_array=input_hoh0)
+        cosmo_input._set_growth_from_arrays(a_array=input_a,
+                                            growth_array=input_growth,
+                                            fgrowth_array=input_fgrowth)
         with pytest.raises(ValueError):
             cosmo_input.compute_distances()
             cosmo_input.compute_growth()
@@ -178,17 +180,20 @@ def test_input_arrays_raises():
     with pytest.raises(ValueError):
         cosmo_input._set_background_from_arrays(a_array=input_a_array,
                                                 chi_array=input_chi,
-                                                hoh0_array=input_hoh0,
-                                                growth_array=input_growth,
-                                                fgrowth_array=input_fgrowth)
+                                                hoh0_array=input_hoh0)
+        cosmo_input._set_growth_from_arrays(a_array=input_a_array,
+                                            growth_array=input_growth,
+                                            fgrowth_array=input_fgrowth)
         cosmo_input.compute_growth()
         cosmo_input._set_background_from_arrays(a_array=input_a,
                                                 chi_array=input_chi,
-                                                hoh0_array=input_hoh0,
-                                                growth_array=input_growth,
-                                                fgrowth_array=input_fgrowth)
+                                                hoh0_array=input_hoh0)
+        cosmo_input._set_growth_from_arrays(a_array=input_a,
+                                            growth_array=input_growth,
+                                            fgrowth_array=input_fgrowth)
     # Test trying to set background without input arrays
     with pytest.raises(ValueError):
         cosmo_input = ccl.Cosmology(Omega_c=0.27, Omega_b=0.05, h=0.7,
                                     n_s=0.965, A_s=2e-9)
         cosmo_input._set_background_from_arrays()
+        cosmo_input._set_growth_from_arrays()

--- a/pyccl/tests/test_power.py
+++ b/pyccl/tests/test_power.py
@@ -204,9 +204,10 @@ def test_input_lin_power_spectrum():
                                 A_s=2e-9)
     cosmo_input._set_background_from_arrays(a_array=a_arr,
                                             chi_array=chi_from_ccl,
-                                            hoh0_array=hoh0_from_ccl,
-                                            growth_array=growth_from_ccl,
-                                            fgrowth_array=fgrowth_from_ccl)
+                                            hoh0_array=hoh0_from_ccl)
+    cosmo_input._set_growth_from_arrays(a_array=a_arr,
+                                        growth_array=growth_from_ccl,
+                                        fgrowth_array=fgrowth_from_ccl)
     cosmo_input._set_linear_power_from_arrays(a_arr, k_arr, pk_arr)
 
     pk_CCL_input = ccl.power.linear_matter_power(cosmo_input, k_arr, 0.5)
@@ -248,9 +249,10 @@ def test_input_nonlin_power_spectrum():
                                 A_s=2e-9,)
     cosmo_input._set_background_from_arrays(a_array=a_arr,
                                             chi_array=chi_from_ccl,
-                                            hoh0_array=hoh0_from_ccl,
-                                            growth_array=growth_from_ccl,
-                                            fgrowth_array=fgrowth_from_ccl)
+                                            hoh0_array=hoh0_from_ccl)
+    cosmo_input._set_growth_from_arrays(a_array=a_arr,
+                                        growth_array=growth_from_ccl,
+                                        fgrowth_array=fgrowth_from_ccl)
     cosmo_input._set_nonlin_power_from_arrays(a_arr, k_arr, pk_arr)
 
     pk_CCL_input = ccl.power.nonlin_matter_power(cosmo_input, k_arr, 0.5)


### PR DESCRIPTION
This PR allows CCL to take in growth from input arrays independently from the background. This is convenient because CAMB/CLASS actually do not provide those quantities in a nice manner (because they are actually not well defined in general).

In doing this I've also fixed a bug with how the linear and non-linear power spectra were being taken from input arrays.