### PR TITLE
[WIP] Expose nonlinear power spectra from Boltzmann codes

### DIFF
--- a/benchmarks/ccl_test_angpow.c
+++ b/benchmarks/ccl_test_angpow.c
@@ -63,7 +63,7 @@ static void test_angpow_precision(struct angpow_data * data)
   ccl_parameters ccl_params = ccl_parameters_create(data->Omega_c, data->Omega_b, data->Omega_k,
 						    data->Neff, data->mnu, data->mnu_type,data->w_0,
 						    data->w_a, data->h, data->A_s, data->n_s,
-						    -1,-1,-1,data->mu_0, data->sigma_0,-1,NULL,NULL, &status);
+						    -1,-1,-1,-1,-1,-1,data->mu_0, data->sigma_0,-1,NULL,NULL, &status);
   ccl_params.Omega_g=0.;
   ccl_params.Omega_l=data->Omega_v;
 

--- a/benchmarks/data/codes/angpow_benchmarks.c
+++ b/benchmarks/data/codes/angpow_benchmarks.c
@@ -32,7 +32,7 @@ int main(int argc,char **argv)
   ccl_config.matter_power_spectrum_method=ccl_linear;
   ccl_parameters ccl_params = ccl_parameters_create(Omega_c, Omega_b, Omega_k, Neff,
 						    &mnu, mnu_type,w_0, w_a, h, A_s,
-						    n_s,-1,-1,-1,-1,NULL,NULL, &status);
+						    n_s,-1,-1,-1,-1,-1,-1,-1,-1,-1,NULL,NULL, &status);
   ccl_params.Omega_g=0.;
   ccl_params.Omega_l=Omega_v;
   

--- a/include/ccl_config.h
+++ b/include/ccl_config.h
@@ -33,11 +33,12 @@ typedef enum transfer_function_t
  */
 typedef enum matter_power_spectrum_t
 {
-    ccl_linear           = 0,
-    ccl_halofit          = 1,
-    ccl_halo_model       = 3,
-    ccl_emu              = 4,
-    ccl_pknl_from_input  = 5
+    ccl_linear              = 0,
+    ccl_halofit             = 1,
+    ccl_halo_model          = 3,
+    ccl_emu                 = 4,
+    ccl_pknl_from_input     = 5,
+    ccl_pknl_from_boltzmann = 6,
 } matter_power_spectrum_t;
 
 /**

--- a/include/ccl_core.h
+++ b/include/ccl_core.h
@@ -234,6 +234,11 @@ typedef struct ccl_parameters {
   double bcm_etab;
   double bcm_ks;
 
+  // HMCode parameters
+  double hmcode_A;
+  double hmcode_eta;
+  double hmcode_logT;
+
   // mu / Sigma quasistatica parameterisation of modified gravity params
   double mu_0;
   double sigma_0;
@@ -324,6 +329,9 @@ void ccl_cosmology_set_status_message(ccl_cosmology * cosmo, const char * status
  * @param bcm_log10Mc log10 cluster mass, one of the parameters of the BCM model
  * @param bcm_etab ejection radius parameter, one of the parameters of the BCM model
  * @param bcm_ks wavenumber for the stellar profile, one of the parameters of the BCM model
+ * @param hmcode_A HMCode 2016 halo concentration parameter
+ * @param hmcode_eta HMCode 2016 halo bloating parameter
+ * @param hmcode_logT HMCode 2020 AGN feedback parameter
  * @param nz_mgrowth the number of redshifts where the modified growth is provided
  * @param zarr_mgrowth the array of redshifts where the modified growth is provided
  * @param dfarr_mgrowth the modified growth function vector provided
@@ -335,6 +343,7 @@ ccl_parameters ccl_parameters_create(double Omega_c, double Omega_b, double Omeg
 				     double Neff, double* mnu, int n_mnu,
 				     double w0, double wa, double h, double norm_pk,
 				     double n_s, double bcm_log10Mc, double bcm_etab, double bcm_ks,
+             double hmcode_A, double hmcode_eta, double hmcode_logT,
 				     double mu_0, double sigma_0, int nz_mgrowth, double *zarr_mgrowth,
 				     double *dfarr_mgrowth, int *status);
 

--- a/pyccl/ccl_core.i
+++ b/pyccl/ccl_core.i
@@ -39,13 +39,16 @@ ccl_parameters parameters_create_nu(
                         double Omega_c, double Omega_b, double Omega_k,
                         double Neff, double w0, double wa, double h,
                         double norm_pk, double n_s, double bcm_log10Mc,
-                        double bcm_etab, double bcm_ks, double mu_0,
-                        double sigma_0, double* m_nu, int n_m, int* status)
+                        double bcm_etab, double bcm_ks, 
+                        double hmcode_A, double hmcode_eta, double hmcode_logT,
+                        double mu_0, double sigma_0,
+                        double* m_nu, int n_m, int* status)
 {
     return ccl_parameters_create(
                         Omega_c, Omega_b, Omega_k, Neff, m_nu, n_m,
                         w0, wa, h, norm_pk, n_s, bcm_log10Mc, bcm_etab,
-                        bcm_ks, mu_0, sigma_0, -1, NULL, NULL, status );
+                        bcm_ks, hmcode_A, hmcode_eta, hmcode_logT,
+                        mu_0, sigma_0, -1, NULL, NULL, status);
 }
 
 %}
@@ -60,8 +63,9 @@ ccl_parameters parameters_create_nu_vec(
                         double Omega_c, double Omega_b, double Omega_k,
                         double Neff, double w0, double wa, double h,
                         double norm_pk, double n_s, double bcm_log10Mc,
-                        double bcm_etab, double bcm_ks, double mu_0,
-                        double sigma_0, double* zarr, int nz,
+                        double bcm_etab, double bcm_ks, 
+                        double hmcode_A, double hmcode_eta, double hmcode_logT,
+                        double mu_0, double sigma_0, double* zarr, int nz,
                         double* dfarr, int nf, double* m_nu,
                         int n_m, int* status)
 {
@@ -69,6 +73,7 @@ ccl_parameters parameters_create_nu_vec(
     return ccl_parameters_create(
                         Omega_c, Omega_b, Omega_k, Neff, m_nu, n_m,
                         w0, wa, h, norm_pk, n_s, bcm_log10Mc, bcm_etab, bcm_ks,
+                        hmcode_A, hmcode_eta, hmcode_logT,
                         mu_0, sigma_0, nz, zarr, dfarr, status);
 }
 

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -260,9 +260,6 @@ class Cosmology(object):
             bcm_log10Mc=params['bcm_log10Mc'],
             bcm_etab=params['bcm_etab'],
             bcm_ks=params['bcm_ks'],
-            hmcode_A=params.get('hmcode_A', default=3.13),
-            hmcode_eta=params.get('hmcode_eta', default=0.603),
-            hmcode_logT=params.get('hmcode_logT', default=7.8),
             mu_0=params['mu_0'],
             sigma_0=params['sigma_0'])
         if 'z_mg' in params:
@@ -272,6 +269,11 @@ class Cosmology(object):
         if 'm_nu' in params:
             inits['m_nu'] = params['m_nu']
             inits['m_nu_type'] = 'list'
+
+        # Add HMCode parameters to inits if they are in params
+        inits.update({k : params[k] 
+                        for k in ["hmcode_A", "hmcode_eta", "hmcode_logT"] 
+                        if k in params})
 
         return cls(**inits)
 

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -260,9 +260,9 @@ class Cosmology(object):
             bcm_log10Mc=params['bcm_log10Mc'],
             bcm_etab=params['bcm_etab'],
             bcm_ks=params['bcm_ks'],
-            hmcode_A=params['hmcode_A'],
-            hmcode_eta=params['hmcode_eta'],
-            hmcode_logT=params['hmcode_logT'],
+            hmcode_A=params.get('hmcode_A', default=3.13),
+            hmcode_eta=params.get('hmcode_eta', default=0.603),
+            hmcode_logT=params.get('hmcode_logT', default=7.8),
             mu_0=params['mu_0'],
             sigma_0=params['sigma_0'])
         if 'z_mg' in params:

--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -383,8 +383,9 @@ ccl_parameters ccl_parameters_create(
                      double Omega_c, double Omega_b, double Omega_k,
 				     double Neff, double* mnu, int n_mnu,
 				     double w0, double wa, double h, double norm_pk,
-				     double n_s, double bcm_log10Mc, double bcm_etab,
-				     double bcm_ks, double mu_0, double sigma_0,
+				     double n_s, double bcm_log10Mc, double bcm_etab, double bcm_ks, 
+             double hmcode_A, double hmcode_eta, double hmcode_logT,
+             double mu_0, double sigma_0,
 				     int nz_mgrowth, double *zarr_mgrowth,
 				     double *dfarr_mgrowth, int *status)
 {
@@ -445,6 +446,11 @@ ccl_parameters ccl_parameters_create(
   else
     params.bcm_ks=bcm_ks;
 
+  //HMCode params
+  params.hmcode_A = (hmcode_A > 0) ? hmcode_A : 3.13;
+  params.hmcode_eta = (hmcode_eta > 0) ? hmcode_eta : 0.603;
+  params.hmcode_logT = (hmcode_logT > 0) ? hmcode_logT : 7.8;
+
   // Params of the mu / Sigma parameterisation of MG
   params.mu_0 = mu_0;
   params.sigma_0 = sigma_0;
@@ -490,7 +496,7 @@ ccl_parameters ccl_parameters_create_flat_lcdm(double Omega_c, double Omega_b, d
   double sigma_0 = 0.;
 
   ccl_parameters params = ccl_parameters_create(Omega_c, Omega_b, Omega_k, Neff,
-						mnu, 0, w0, wa, h, norm_pk, n_s, -1, -1, -1, mu_0, sigma_0, -1, NULL, NULL, status);
+						mnu, 0, w0, wa, h, norm_pk, n_s, -1, -1, -1, -1, -1, -1, mu_0, sigma_0, -1, NULL, NULL, status);
   return params;
 
 }
@@ -558,6 +564,11 @@ void ccl_parameters_write_yaml(ccl_parameters * params, const char * filename, i
   WRITE_DOUBLE(bcm_log10Mc);
   WRITE_DOUBLE(bcm_etab);
   WRITE_DOUBLE(bcm_ks);
+
+  // HMCode parameters
+  WRITE_DOUBLE(hmcode_A);
+  WRITE_DOUBLE(hmcode_eta);
+  WRITE_DOUBLE(hmcode_logT);
 
   // Modified gravity parameters
   WRITE_DOUBLE(mu_0);
@@ -657,6 +668,11 @@ ccl_parameters ccl_parameters_read_yaml(const char * filename, int *status) {
   READ_DOUBLE(bcm_etab);
   READ_DOUBLE(bcm_ks);
 
+  // HMCode parameters
+  READ_DOUBLE(hmcode_A);
+  READ_DOUBLE(hmcode_eta);
+  READ_DOUBLE(hmcode_logT);
+
   // Modified gravity parameters
   READ_DOUBLE(mu_0);
   READ_DOUBLE(sigma_0);
@@ -719,7 +735,8 @@ ccl_parameters ccl_parameters_read_yaml(const char * filename, int *status) {
     Neff, mnu, N_nu_mass,
     w0, wa, h, norm_pk,
     n_s, bcm_log10Mc, bcm_etab,
-    bcm_ks, mu_0, sigma_0, nz_mgrowth, z_mgrowth,
+    bcm_ks, hmcode_A, hmcode_eta, hmcode_logT,
+    mu_0, sigma_0, nz_mgrowth, z_mgrowth,
     df_mgrowth, status);
 
   if(z_mgrowth) free(z_mgrowth);

--- a/src/ccl_halofit.c
+++ b/src/ccl_halofit.c
@@ -61,7 +61,9 @@ static ccl_cosmology *create_w0eff_cosmo(double w0eff, ccl_cosmology *cosmo, int
     cosmo->params.Neff, mnu, cosmo->params.N_nu_mass,
     w0eff, 0, cosmo->params.h, norm_pk,
     cosmo->params.n_s, cosmo->params.bcm_log10Mc, cosmo->params.bcm_etab,
-    cosmo->params.bcm_ks, cosmo->params.mu_0, cosmo->params.sigma_0, cosmo->params.nz_mgrowth,
+    cosmo->params.bcm_ks, 
+    cosmo->params.hmcode_A, cosmo->params.hmcode_eta, cosmo->params.hmcode_logT,
+    cosmo->params.mu_0, cosmo->params.sigma_0, cosmo->params.nz_mgrowth,
     cosmo->params.z_mgrowth, cosmo->params.df_mgrowth, status);
 
     if(*status != 0)

--- a/src/ccl_musigma.c
+++ b/src/ccl_musigma.c
@@ -138,9 +138,10 @@ void ccl_cosmology_spline_linpower_musigma(ccl_cosmology* cosmo, ccl_f2d_t *psp,
           cosmo->params.Neff, mnu_list, cosmo->params.N_nu_mass,
           cosmo->params.w0, cosmo->params.wa, cosmo->params.h,
           norm_pk, cosmo->params.n_s,
-          cosmo->params.bcm_log10Mc, cosmo->params.bcm_etab,
-          cosmo->params.bcm_ks, 0., 0., cosmo->params.nz_mgrowth,
-          cosmo->params.z_mgrowth, cosmo->params.df_mgrowth, status);
+          cosmo->params.bcm_log10Mc, cosmo->params.bcm_etab, cosmo->params.bcm_ks, 
+          cosmo->params.hmcode_A, cosmo->params.hmcode_eta, cosmo->params.hmcode_logT,
+          0., 0., cosmo->params.nz_mgrowth, cosmo->params.z_mgrowth, cosmo->params.df_mgrowth,
+          status);
 
         if (*status) {
           *status = CCL_ERROR_PARAMETERS;

--- a/src/ccl_power.c
+++ b/src/ccl_power.c
@@ -550,6 +550,10 @@ void ccl_cosmology_compute_nonlin_power(ccl_cosmology* cosmo, ccl_f2d_t *psp_o,
         ccl_cosmology_compute_power_emu(cosmo, status);}
         break;
 
+      case ccl_pknl_from_boltzmann: {
+        ccl_cosmology_compute_nonlin_power_from_f2d(cosmo, psp_o, status);}
+        break;
+
       case ccl_pknl_from_input: {
         ccl_cosmology_compute_nonlin_power_from_f2d(cosmo, psp_o, status);}
         break;

--- a/src/ccl_power.c
+++ b/src/ccl_power.c
@@ -485,12 +485,24 @@ void ccl_cosmology_compute_linear_power(ccl_cosmology* cosmo, ccl_f2d_t *psp, in
 void ccl_cosmology_compute_nonlin_power_from_f2d(ccl_cosmology *cosmo,
                                                  ccl_f2d_t *psp, int *status)
 {
+  if(psp == NULL)
+  {
+    *status = CCL_ERROR_NONLIN_POWER_INIT;
+    ccl_raise_warning(CCL_ERROR_NONLIN_POWER_INIT, "Not a valid F2D pointer!");
+    return;
+  }
   cosmo->data.p_nl = ccl_f2d_t_copy(psp, status);
 }
 
 void ccl_compute_linear_power_from_f2d(ccl_cosmology *cosmo,
                                                  ccl_f2d_t *psp, int *status)
 {
+  if(psp == NULL)
+  {
+    *status = CCL_ERROR_LINEAR_POWER_INIT;
+    ccl_raise_warning(CCL_ERROR_LINEAR_POWER_INIT, "Not a valid F2D pointer!");
+    return;
+  }
   cosmo->data.p_lin = ccl_f2d_t_copy(psp, status);
 }
 


### PR DESCRIPTION
Currently CCL only uses the linear power spectrum prediction from Boltzmann codes, with limited options for nonlinear power spectra. Boltzmann codes provide a range of fast nonlinear models that can be used. For example, CAMB provides an extensive list of codes, among them HMCode.

This PR uses the HMCode implementation in CAMB to provide nonlinear predictions for the matter power spectrum, including modelling of baryons, for CCL. It addresses issue #819.  

To make the baryon modelling accessible, the HMCode parameters A and eta (for the 2016 model), and the AGN feedback strength logT (for the 2020 model) are exposed. To get this to work consistently and for the yaml output, these are also added to the C layer.
This kinda changes the Python API (by adding new but optional parameters to `Cosmology.__init__`) and clearly changes the C API (by changing `ccl_parameters_create`). 
I'd rather have avoided that but right now everything needs to go through the C layer. For example, the `write_yaml` method uses the C-layer dumper function. NB, `read_yaml` doesn't use the C-layer reader. 
While there is a `read_yaml` function in the C-layer, it is not being used. I've added the new parameters to it but this breaks loading old yaml files due to the super simple implementation of the C `read_yaml` function.

If not for the yaml functionality, the HMCode parameters could probably live in the Python layer in a structure adjacent to `_params`.

## To discuss
Should the HMCode parameters get added to the `ccl_parameter` struct or better live exclusively in the Python layer? This would require some refactor of the yaml functionality. Which might be a good thing. Currently it is quite painful to add any new functionality since everything is still tightly bound to the C layer.

## Todo
- [ ] Add tests
- [ ] Fix existing tests
- [ ] Expose nonlinear power spectra in CLASS

