### PR TITLE
Expose nonlinear CAMB power spectra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+## Python library
+- Allow access to CAMB nonlinear power spectra (#854)
+- Write and read configuration settings to yaml (#852)
+
+## C library
+- Deprecate C-level yaml reader and writer (#852)
+
 # v2.2.0 Changes
 
 ## Python library

--- a/include/ccl_config.h
+++ b/include/ccl_config.h
@@ -33,12 +33,13 @@ typedef enum transfer_function_t
  */
 typedef enum matter_power_spectrum_t
 {
-    ccl_pknl_none        = 0,
-    ccl_linear           = 1,
-    ccl_halofit          = 2,
-    ccl_halo_model       = 3,
-    ccl_emu              = 4,
-    ccl_pknl_from_input  = 5
+    ccl_pknl_none          = 0,
+    ccl_linear             = 1,
+    ccl_halofit            = 2,
+    ccl_halo_model         = 3,
+    ccl_emu                = 4,
+    ccl_pknl_from_input    = 5,
+    ccl_pknl_from_boltzman = 6
 } matter_power_spectrum_t;
 
 /**

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -35,9 +35,9 @@ def get_camb_pk_lin(cosmo, nonlin=False):
             non-linear power spectrum as well.
 
     Returns:
-        :class:`~pyccl.pk2d.Pk2D`: Power spectrum \
-            object. The linear power spectrum. If `nonlin=True`, returns a
-            tuple (pk_lin, pk_nonlin).
+        :class:`~pyccl.pk2d.Pk2D`: Power spectrum object. The linear power \
+            spectrum. If ``nonlin=True``, returns a tuple \
+            ``(pk_lin, pk_nonlin)``.
     """
 
     # Comment from Jarvis: TODO clean up this and other assert

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -49,8 +49,7 @@ def get_camb_pk_lin(cosmo, nonlin=False):
     # Get extra CAMB parameters that were specified
     extra_camb_params = {}
     try:
-        extra_camb_params = \
-            cosmo._params_init_kwargs["extra_parameters"]["camb"]
+        extra_camb_params = cosmo["extra_parameters"]["camb"]
     except (KeyError, TypeError):
         pass
 

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -24,7 +24,7 @@ from .pk2d import Pk2D
 from .errors import CCLError
 
 
-def get_camb_pk_lin(cosmo):
+def get_camb_pk_lin(cosmo, nonlin=False):
     """Run CAMB and return the linear power spectrum.
 
     Args:
@@ -42,6 +42,14 @@ def get_camb_pk_lin(cosmo):
     assert HAVE_CAMB, (
         "You must have the `camb` python package "
         "installed to run CCL with CAMB!")
+
+    # Get extra CAMB parameters that were specified
+    extra_camb_params = {}
+    try:
+        extra_camb_params = \
+            cosmo._params_init_kwargs["extra_parameters"]["camb"]
+    except (KeyError, TypeError):
+        pass
 
     # z sampling from CCL parameters
     na = lib.get_pk_spline_na(cosmo.cosmo)
@@ -136,14 +144,25 @@ def get_camb_pk_lin(cosmo):
         w=cosmo['w0'],
         wa=cosmo['wa']
     )
-    # cp.set_cosmology()
+
+    if nonlin:
+        cp.NonLinearModel = camb.nonlinear.Halofit()
+        halofit_version = extra_camb_params.get("halofit_version", "mead")
+        options = {k: extra_camb_params[k] for k in
+                   ["HMCode_A_baryon",
+                    "HMCode_eta_baryon",
+                    "HMCode_logT_AGN"] if k in extra_camb_params}
+        cp.NonLinearModel.set_params(halofit_version=halofit_version,
+                                     **options)
+
     cp.set_matter_power(
         redshifts=[_z for _z in zs],
-        kmax=10,
-        nonlinear=False)
-    assert cp.NonLinear == camb.model.NonLinear_none
+        kmax=extra_camb_params.get("kmax", 10.0),
+        nonlinear=nonlin)
+    if not nonlin:
+        assert cp.NonLinear == camb.model.NonLinear_none
 
-    cp.set_for_lmax(5000)
+    cp.set_for_lmax(extra_camb_params.get("lmax", 5000))
     cp.InitPower.set_params(
         As=A_s_fid,
         ns=cosmo['n_s'])
@@ -178,7 +197,38 @@ def get_camb_pk_lin(cosmo):
         extrap_order_hik=2,
         cosmo=cosmo)
 
-    return pk_lin
+    if not nonlin:
+        return pk_lin
+    else:
+        k, z, pk = camb_res.get_linear_matter_power_spectrum(
+            hubble_units=True, nonlinear=True)
+
+        # convert to non-h inverse units
+        k *= cosmo['h']
+        pk /= (h2 * cosmo['h'])
+
+        # now build interpolant
+        nk = k.shape[0]
+        lk_arr = np.log(k)
+        a_arr = 1.0 / (1.0 + z)
+        na = a_arr.shape[0]
+        sinds = np.argsort(a_arr)
+        a_arr = a_arr[sinds]
+        ln_p_k_and_z = np.zeros((na, nk), dtype=np.float64)
+        for i, sind in enumerate(sinds):
+            ln_p_k_and_z[i, :] = np.log(pk[sind, :])
+
+        pk_nonlin = Pk2D(
+            pkfunc=None,
+            a_arr=a_arr,
+            lk_arr=lk_arr,
+            pk_arr=ln_p_k_and_z,
+            is_logp=True,
+            extrap_order_lok=1,
+            extrap_order_hik=2,
+            cosmo=cosmo)
+        
+        return pk_lin, pk_nonlin
 
 
 def get_isitgr_pk_lin(cosmo):

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -227,7 +227,7 @@ def get_camb_pk_lin(cosmo, nonlin=False):
             extrap_order_lok=1,
             extrap_order_hik=2,
             cosmo=cosmo)
-        
+
         return pk_lin, pk_nonlin
 
 

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -31,10 +31,13 @@ def get_camb_pk_lin(cosmo, nonlin=False):
         cosmo (:class:`~pyccl.core.Cosmology`): Cosmological
             parameters. The cosmological parameters with
             which to run CAMB.
+        nonlin (:obj:`bool`, optional): Whether to compute and return the
+            non-linear power spectrum as well.
 
     Returns:
         :class:`~pyccl.pk2d.Pk2D`: Power spectrum \
-            object. The linear power spectrum.
+            object. The linear power spectrum. If `nonlin=True`, returns a
+            tuple (pk_lin, pk_nonlin).
     """
 
     # Comment from Jarvis: TODO clean up this and other assert

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -167,13 +167,15 @@ class Cosmology(object):
             Defaults to 'tinker10' (2010).
         halo_concentration (:obj:`str`, optional): The halo concentration
             relation to use. Defaults to Duffy et al. (2008) 'duffy2008'.
-        emulator_neutrinos: `str`, optional): If using the emulator for
+        emulator_neutrinos (:obj: `str`, optional): If using the emulator for
             the power spectrum, specified treatment of unequal neutrinos.
             Options are 'strict', which will raise an error and quit if the
             user fails to pass either a set of three equal masses or a sum with
             m_nu_type = 'equal', and 'equalize', which will redistribute
             masses to be equal right before calling the emulator but results in
             internal inconsistencies. Defaults to 'strict'.
+        extra_parameters (:obj:`dict`, optional): Dictionary holding extra
+            parameters. Defaults to None.
     """
     def __init__(
             self, Omega_c=None, Omega_b=None, h=None, n_s=None,
@@ -248,7 +250,7 @@ class Cosmology(object):
                 elif isinstance(v, dict):
                     make_yaml_friendly(v)
 
-        params = {**self._params_init_kwargs.copy(),
+        params = {**self._params_init_kwargs,
                   **self._config_init_kwargs}
         make_yaml_friendly(params)
 

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -14,7 +14,6 @@ from .boltzmann import get_class_pk_lin, get_camb_pk_lin, get_isitgr_pk_lin
 from .pyutils import check
 from .pk2d import Pk2D
 from .bcm import bcm_correct_pk2d
-from .power import sigma8
 
 # Configuration types
 transfer_function_types = {
@@ -775,14 +774,10 @@ class Cosmology(object):
                                   category=CCLWarning)
                 if np.isfinite(self["sigma8"]) \
                         and not np.isfinite(self["A_s"]):
-                    if abs(self["sigma8"] - sigma8(self, pk)) > 1e-6:
-                        warnings.warn("You want to compute the non-linear "
-                                      "power spectrum using CAMB and specified"
-                                      " sigma8. The value of sigma8 computed "
-                                      "from the linear power spectrum differs "
-                                      "from the specified one and cannot be "
-                                      "consistenty rescaled.",
-                                      category=CCLWarning)
+                    raise CCLError("You want to compute the non-linear "
+                                   "power spectrum using CAMB and specified"
+                                   " sigma8 but the non-linear power spectrum "
+                                   "cannot be consistenty rescaled.")
         elif trf in ['bbks', 'eisenstein_hu']:
             rescale_s8 = False
             rescale_mg = False

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -166,7 +166,7 @@ class Cosmology(object):
             Defaults to 'tinker10' (2010).
         halo_concentration (:obj:`str`, optional): The halo concentration
             relation to use. Defaults to Duffy et al. (2008) 'duffy2008'.
-        emulator_neutrinos (:obj: `str`, optional): If using the emulator for
+        emulator_neutrinos (:obj:`str`, optional): If using the emulator for
             the power spectrum, specified treatment of unequal neutrinos.
             Options are 'strict', which will raise an error and quit if the
             user fails to pass either a set of three equal masses or a sum with
@@ -174,7 +174,24 @@ class Cosmology(object):
             masses to be equal right before calling the emulator but results in
             internal inconsistencies. Defaults to 'strict'.
         extra_parameters (:obj:`dict`, optional): Dictionary holding extra
-            parameters. Defaults to None.
+            parameters. Currently supports extra parameters for CAMB, with
+            details described below. Defaults to None.
+
+    Currently supported extra parameters for CAMB are:
+
+        * `halofit_version`
+        * `HMCode_A_baryon`
+        * `HMCode_eta_baryon`
+        * `HMCode_logT_AGN`
+        * `kmax`
+        * `lmax`
+
+    Consult the CAMB documentation for their usage. These parameters are passed 
+    in a :obj:`dict` to `extra_parameters` as::
+
+        extra_parameters = {"camb": {"halofit_version": "mead2020",
+                                     "HMCode_logT_AGN": 7.8}}
+
     """
     def __init__(
             self, Omega_c=None, Omega_b=None, h=None, n_s=None,

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -579,6 +579,8 @@ class Cosmology(object):
         try:
             if key == 'm_nu':
                 val = lib.parameters_get_nu_masses(self._params, 3)
+            elif key == 'extra_parameters':
+                val = self._params_init_kwargs["extra_parameters"]
             else:
                 val = getattr(self._params, key)
         except AttributeError:

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -186,7 +186,7 @@ class Cosmology(object):
         * `kmax`
         * `lmax`
 
-    Consult the CAMB documentation for their usage. These parameters are passed 
+    Consult the CAMB documentation for their usage. These parameters are passed
     in a :obj:`dict` to `extra_parameters` as::
 
         extra_parameters = {"camb": {"halofit_version": "mead2020",

--- a/pyccl/tests/test_nonlin_camb_power.py
+++ b/pyccl/tests/test_nonlin_camb_power.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+import pyccl as ccl
+
+
+def test_nonlin_camb_power():
+    import camb
+
+    logT_AGN = 7.93
+    Omega_c = 0.25
+    Omega_b = 0.05
+    A_s = 2.1e-9
+    n_s = 0.97
+    h = 0.7
+
+    p = camb.CAMBparams(WantTransfer=True,
+                        NonLinearModel=camb.nonlinear.Halofit(
+                            halofit_version="mead2020",
+                            HMCode_logT_AGN=logT_AGN))
+    p.set_cosmology(H0=h*100, omch2=Omega_c*h**2, ombh2=Omega_b*h**2, mnu=0.0)
+    p.share_delta_neff = False
+    p.InitPower.set_params(
+        As=A_s,
+        ns=n_s)
+    z = [0.0]
+    p.set_matter_power(redshifts=z, kmax=10.0, nonlinear=True)
+    p.set_for_lmax(5000)
+
+    r = camb.get_results(p)
+
+    k, z, pk_nonlin_camb = r.get_nonlinear_matter_power_spectrum(
+        hubble_units=False, k_hunit=False)
+
+    ccl_cosmo = ccl.Cosmology(Omega_c=Omega_c, Omega_b=Omega_b, h=h, m_nu=0.0,
+                              A_s=A_s, n_s=n_s,
+                              transfer_function="boltzmann_camb",
+                              matter_power_spectrum="camb",
+                              extra_parameters={"camb":
+                                                {"halofit_version": "mead2020",
+                                                 "HMCode_logT_AGN": logT_AGN}})
+    pk_nonlin_ccl = ccl.nonlin_matter_power(ccl_cosmo, k, 1.0)
+
+    # import matplotlib.pyplot as plt
+
+    # plt.loglog(k, pk_nonlin_camb[0])
+    # plt.loglog(k, pk_nonlin_ccl)
+    # plt.semilogx(k, pk_nonlin_ccl/pk_nonlin_camb[0]-1)
+    # plt.show()
+    assert np.allclose(pk_nonlin_camb, pk_nonlin_ccl, rtol=3e-3)
+
+
+# if __name__ == "__main__":
+#     test_nonlin_camb_power()

--- a/pyccl/tests/test_nonlin_camb_power.py
+++ b/pyccl/tests/test_nonlin_camb_power.py
@@ -46,7 +46,6 @@ def test_nonlin_camb_power():
 
 
 def test_nonlin_camb_power_with_sigma8():
-    logT_AGN = 7.93
     Omega_c = 0.25
     Omega_b = 0.05
     n_s = 0.97
@@ -55,10 +54,7 @@ def test_nonlin_camb_power_with_sigma8():
     ccl_cosmo = ccl.Cosmology(Omega_c=Omega_c, Omega_b=Omega_b, h=h, m_nu=0.0,
                               sigma8=0.8, n_s=n_s,
                               transfer_function="boltzmann_camb",
-                              matter_power_spectrum="camb",
-                              extra_parameters={"camb":
-                                                {"halofit_version": "mead2020",
-                                                 "HMCode_logT_AGN": logT_AGN}})
+                              matter_power_spectrum="camb")
 
     k = np.logspace(-3, 1, 10)
 


### PR DESCRIPTION
Redo of PR #837. Much simpler thanks to David's calculator mode and yaml handling in python.

Currently CCL only uses the linear power spectrum prediction from Boltzmann codes, with limited options for nonlinear power spectra. Boltzmann codes provide a range of fast nonlinear models that can be used. For example, CAMB provides an extensive list of codes, among them HMCode.

This PR uses the HMCode implementations in CAMB to provide nonlinear predictions for the matter power spectrum, including modelling of baryons, for CCL. It addresses issue #819.  

The nonlinear power spectra are accessed by setting `matter_power_spectrum="camb"`. To specify parameters, I added a generic `extra_parameters` kwarg to `Cosmology.__init__`. This is meant to take a dictionary and act as a catch-all for more specialised parameters, in order to avoid further bloating of the call signature of `Cosmology.__init__`.

Serialisation seems to work out of the box. 

I added a test comparing an HMCode power spectrum from CAMB to that of CCL. I get agreement at the 2e-3 level, which might be due to interpolation effects and subtleties in how CCL calls CAMB (there's a lot of fiddling with the neutrinos going on in `get_camb_pk_lin`).

Example:
```python
ccl_cosmo = ccl.Cosmology(
    Omega_c=Omega_c, Omega_b=Omega_b, h=h, m_nu=0.0,
    A_s=A_s, n_s=n_s,
    transfer_function="boltzmann_camb",
    matter_power_spectrum="camb",
    extra_parameters={"camb":
         {"halofit_version": "mead2020",
          "HMCode_logT_AGN": logT_AGN, # Feedback strength
          "lmax" : 2600 # Also allow access to some other CAMB parameters for good measure
         }})

pk_nonlin_ccl = ccl.nonlin_matter_power(ccl_cosmo, k, 1.0)
```