### PR TITLE
Added the option to choose the type of dark energy to be used with camb.

### DIFF
--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -129,9 +129,16 @@ def get_camb_pk_lin(cosmo):
         cp.ombh2 * (camb.constants.COBE_CMBTemp / cp.TCMB) ** 3,
         delta_neff)
 
-    cp.set_classes(
+    if (cosmo['DE_model_camb'] == 'ppf' or
+            cosmo['DE_model_camb'] == 'DarkEnergyPPF'):
+        cp.set_classes(
+        dark_energy_model=camb.dark_energy.DarkEnergyPPF
+        )
+    else:
+        cp.set_classes(
         dark_energy_model=camb.dark_energy.DarkEnergyFluid
-    )
+        )
+
     cp.DarkEnergy.set_params(
         w=cosmo['w0'],
         wa=cosmo['wa']

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -132,11 +132,11 @@ def get_camb_pk_lin(cosmo):
     if (cosmo['DE_model_camb'] == 'ppf' or
             cosmo['DE_model_camb'] == 'DarkEnergyPPF'):
         cp.set_classes(
-        dark_energy_model=camb.dark_energy.DarkEnergyPPF
+            dark_energy_model=camb.dark_energy.DarkEnergyPPF
         )
     else:
         cp.set_classes(
-        dark_energy_model=camb.dark_energy.DarkEnergyFluid
+            dark_energy_model=camb.dark_energy.DarkEnergyFluid
         )
 
     cp.DarkEnergy.set_params(

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -572,7 +572,8 @@ class Cosmology(object):
         # Check if the user has defined a dark energy model for camb to use,
         # and if they have not, then default to 'fluid'.
         self._params.DE_model_camb = DE_model_camb
-        DE_model_camb_types = ['fluid','ppf','DarkEnergyFluid','DarkEnergyPPF']
+        DE_model_camb_types = ['fluid', 'ppf',
+                               'DarkEnergyFluid', 'DarkEnergyPPF']
         if DE_model_camb is None:
             DE_model_camb = 'fluid'
         elif DE_model_camb not in DE_model_camb_types:
@@ -652,7 +653,7 @@ class Cosmology(object):
         string += ", ".join(
             "%s=%s" % (k, v)
             for k, v in self._params_init_kwargs.items()
-            if k not in ['m_nu', 'm_nu_type', 'z_mg', 'df_mg', 'DE_model_camb'])
+            if k not in ['m_nu', 'm_nu_type', 'z_mg', 'df_mg'])
 
         if hasattr(self._params_init_kwargs['m_nu'], '__len__'):
             string += ", m_nu=[%s, %s, %s]" % tuple(


### PR DESCRIPTION
I included an option to choose which type of dark energy you want when using camb. It defaults to "fluid", now one can easily set it to "ppf".

I simply set "self._params.DE_model_camb = DE_model_camb" because I was having a difficult time with the C files.