### PR TITLE
Camb dark energy model

### DIFF
--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -129,9 +129,16 @@ def get_camb_pk_lin(cosmo):
         cp.ombh2 * (camb.constants.COBE_CMBTemp / cp.TCMB) ** 3,
         delta_neff)
 
-    cp.set_classes(
+    if (cosmo['DE_model_camb'] == 'ppf' or
+            cosmo['DE_model_camb'] == 'DarkEnergyPPF'):
+        cp.set_classes(
+        dark_energy_model=camb.dark_energy.DarkEnergyPPF
+        )
+    else:
+        cp.set_classes(
         dark_energy_model=camb.dark_energy.DarkEnergyFluid
-    )
+        )
+
     cp.DarkEnergy.set_params(
         w=cosmo['w0'],
         wa=cosmo['wa']

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -132,11 +132,11 @@ def get_camb_pk_lin(cosmo):
     if (cosmo['DE_model_camb'] == 'ppf' or
             cosmo['DE_model_camb'] == 'DarkEnergyPPF'):
         cp.set_classes(
-        dark_energy_model=camb.dark_energy.DarkEnergyPPF
+            dark_energy_model=camb.dark_energy.DarkEnergyPPF
         )
     else:
         cp.set_classes(
-        dark_energy_model=camb.dark_energy.DarkEnergyFluid
+            dark_energy_model=camb.dark_energy.DarkEnergyFluid
         )
 
     cp.DarkEnergy.set_params(

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -140,12 +140,12 @@ def get_camb_pk_lin(cosmo, nonlin=False):
         delta_neff)
 
     camb_de_models = ['DarkEnergyFluid', 'DarkEnergyPPF', 'fluid', 'ppf']
-    camb_de_model = extra_camb_params.get('dark_energy_model','DarkEnergyFluid')
+    camb_de_model = extra_camb_params.get('dark_energy_model', 'fluid')
     if camb_de_model not in camb_de_models:
         raise ValueError("The only dark energy models CCL supports with"
                          " camb are fluid and ppf.")
     cp.set_classes(
-            dark_energy_model=camb_de_model
+        dark_energy_model=camb_de_model
     )
 
     cp.DarkEnergy.set_params(
@@ -365,12 +365,12 @@ def get_isitgr_pk_lin(cosmo):
         delta_neff)
 
     camb_de_models = ['DarkEnergyFluid', 'DarkEnergyPPF', 'fluid', 'ppf']
-    camb_de_model = extra_camb_params.get('dark_energy_model','DarkEnergyFluid')
+    camb_de_model = extra_camb_params.get('dark_energy_model', 'fluid')
     if camb_de_model not in camb_de_models:
         raise ValueError("The only dark energy models CCL supports with"
                          " camb are fluid and ppf.")
     cp.set_classes(
-            dark_energy_model=camb_de_model
+        dark_energy_model=camb_de_model
     )
     cp.DarkEnergy.set_params(
         w=cosmo['w0'],

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -149,7 +149,8 @@ def get_camb_pk_lin(cosmo, nonlin=False):
     )
 
     if camb_de_model not in camb_de_models[:2] and cosmo['wa'] and \
-        (cosmo['w0'] < -1 - 1e-6 or 1 + cosmo['w0'] + cosmo['wa'] < - 1e-6):
+            (cosmo['w0'] < -1 - 1e-6 or
+                1 + cosmo['w0'] + cosmo['wa'] < - 1e-6):
         raise ValueError("If you want to use w crossing -1,"
                          " then please set the dark_energy_model to ppf.")
     cp.DarkEnergy.set_params(
@@ -377,7 +378,8 @@ def get_isitgr_pk_lin(cosmo):
         dark_energy_model=camb_de_model
     )
     if camb_de_model not in camb_de_models[:2] and cosmo['wa'] and \
-        (cosmo['w0'] < -1 - 1e-6 or 1 + cosmo['w0'] + cosmo['wa'] < - 1e-6):
+            (cosmo['w0'] < -1 - 1e-6 or
+                1 + cosmo['w0'] + cosmo['wa'] < - 1e-6):
         raise ValueError("If you want to use w crossing -1,"
                          " then please set the dark_energy_model to ppf.")
     cp.DarkEnergy.set_params(

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -139,15 +139,14 @@ def get_camb_pk_lin(cosmo, nonlin=False):
         cp.ombh2 * (camb.constants.COBE_CMBTemp / cp.TCMB) ** 3,
         delta_neff)
 
-    if (cosmo['DE_model_camb'] == 'ppf' or
-            cosmo['DE_model_camb'] == 'DarkEnergyPPF'):
-        cp.set_classes(
-            dark_energy_model=camb.dark_energy.DarkEnergyPPF
-        )
-    else:
-        cp.set_classes(
-            dark_energy_model=camb.dark_energy.DarkEnergyFluid
-        )
+    camb_de_models = ['DarkEnergyFluid', 'DarkEnergyPPF', 'fluid', 'ppf']
+    camb_de_model = extra_camb_params.get('dark_energy_model','DarkEnergyFluid')
+    if camb_de_model not in camb_de_models:
+        raise ValueError("The only dark energy models CCL supports with"
+                         " camb are fluid and ppf.")
+    cp.set_classes(
+            dark_energy_model=camb_de_model
+    )
 
     cp.DarkEnergy.set_params(
         w=cosmo['w0'],
@@ -263,6 +262,13 @@ def get_isitgr_pk_lin(cosmo):
             *e.args)
         raise
 
+    # Get extra CAMB parameters that were specified
+    extra_camb_params = {}
+    try:
+        extra_camb_params = cosmo["extra_parameters"]["camb"]
+    except (KeyError, TypeError):
+        pass
+
     # z sampling from CCL parameters
     na = lib.get_pk_spline_na(cosmo.cosmo)
     status = 0
@@ -325,7 +331,7 @@ def get_isitgr_pk_lin(cosmo):
 
     delta_neff = cosmo['Neff'] - 3.046  # used for BBN YHe comps
 
-    # ISiTGR built on  CAMB which defines a neutrino degeneracy
+    # ISiTGR built on CAMB which defines a neutrino degeneracy
     # factor as T_i = g^(1/4)*T_nu
     # where T_nu is the standard neutrino temperature from first order
     # computations
@@ -358,8 +364,13 @@ def get_isitgr_pk_lin(cosmo):
         cp.ombh2 * (isitgr.constants.COBE_CMBTemp / cp.TCMB) ** 3,
         delta_neff)
 
+    camb_de_models = ['DarkEnergyFluid', 'DarkEnergyPPF', 'fluid', 'ppf']
+    camb_de_model = extra_camb_params.get('dark_energy_model','DarkEnergyFluid')
+    if camb_de_model not in camb_de_models:
+        raise ValueError("The only dark energy models CCL supports with"
+                         " camb are fluid and ppf.")
     cp.set_classes(
-        dark_energy_model=isitgr.dark_energy.DarkEnergyFluid
+            dark_energy_model=camb_de_model
     )
     cp.DarkEnergy.set_params(
         w=cosmo['w0'],

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -139,7 +139,7 @@ def get_camb_pk_lin(cosmo, nonlin=False):
         cp.ombh2 * (camb.constants.COBE_CMBTemp / cp.TCMB) ** 3,
         delta_neff)
 
-    camb_de_models = ['DarkEnergyFluid', 'DarkEnergyPPF', 'fluid', 'ppf']
+    camb_de_models = ['DarkEnergyPPF', 'ppf', 'DarkEnergyFluid', 'fluid']
     camb_de_model = extra_camb_params.get('dark_energy_model', 'fluid')
     if camb_de_model not in camb_de_models:
         raise ValueError("The only dark energy models CCL supports with"
@@ -148,6 +148,10 @@ def get_camb_pk_lin(cosmo, nonlin=False):
         dark_energy_model=camb_de_model
     )
 
+    if camb_de_model not in camb_de_models[:2] and cosmo['wa'] and \
+        (cosmo['w0'] < -1 - 1e-6 or 1 + cosmo['w0'] + cosmo['wa'] < - 1e-6):
+        raise ValueError("If you want to use w crossing -1,"
+                         " then please set the dark_energy_model to ppf.")
     cp.DarkEnergy.set_params(
         w=cosmo['w0'],
         wa=cosmo['wa']
@@ -364,7 +368,7 @@ def get_isitgr_pk_lin(cosmo):
         cp.ombh2 * (isitgr.constants.COBE_CMBTemp / cp.TCMB) ** 3,
         delta_neff)
 
-    camb_de_models = ['DarkEnergyFluid', 'DarkEnergyPPF', 'fluid', 'ppf']
+    camb_de_models = ['DarkEnergyPPF', 'ppf', 'DarkEnergyFluid', 'fluid']
     camb_de_model = extra_camb_params.get('dark_energy_model', 'fluid')
     if camb_de_model not in camb_de_models:
         raise ValueError("The only dark energy models CCL supports with"
@@ -372,6 +376,10 @@ def get_isitgr_pk_lin(cosmo):
     cp.set_classes(
         dark_energy_model=camb_de_model
     )
+    if camb_de_model not in camb_de_models[:2] and cosmo['wa'] and \
+        (cosmo['w0'] < -1 - 1e-6 or 1 + cosmo['w0'] + cosmo['wa'] < - 1e-6):
+        raise ValueError("If you want to use w crossing -1,"
+                         " then please set the dark_energy_model to ppf.")
     cp.DarkEnergy.set_params(
         w=cosmo['w0'],
         wa=cosmo['wa']

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -572,7 +572,8 @@ class Cosmology(object):
         # Check if the user has defined a dark energy model for camb to use,
         # and if they have not, then default to 'fluid'.
         self._params.DE_model_camb = DE_model_camb
-        DE_model_camb_types = ['fluid','ppf','DarkEnergyFluid','DarkEnergyPPF']
+        DE_model_camb_types = ['fluid', 'ppf',
+                               'DarkEnergyFluid', 'DarkEnergyPPF']
         if DE_model_camb is None:
             DE_model_camb = 'fluid'
         elif DE_model_camb not in DE_model_camb_types:
@@ -652,7 +653,7 @@ class Cosmology(object):
         string += ", ".join(
             "%s=%s" % (k, v)
             for k, v in self._params_init_kwargs.items()
-            if k not in ['m_nu', 'm_nu_type', 'z_mg', 'df_mg', 'DE_model_camb'])
+            if k not in ['m_nu', 'm_nu_type', 'z_mg', 'df_mg'])
 
         if hasattr(self._params_init_kwargs['m_nu'], '__len__'):
             string += ", m_nu=[%s, %s, %s]" % tuple(

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -185,6 +185,7 @@ class Cosmology(object):
         * `HMCode_logT_AGN`
         * `kmax`
         * `lmax`
+        * `dark_energy_model`
 
     Consult the CAMB documentation for their usage. These parameters are passed
     in a :obj:`dict` to `extra_parameters` as::
@@ -201,7 +202,6 @@ class Cosmology(object):
             bcm_log10Mc=np.log10(1.2e14), bcm_etab=0.5,
             bcm_ks=55., mu_0=0., sigma_0=0.,
             c1_mg=1., c2_mg=1., lambda_mg=0., z_mg=None, df_mg=None,
-            DE_model_camb=None,
             transfer_function='boltzmann_camb',
             matter_power_spectrum='halofit',
             baryons_power_spectrum='nobaryons',
@@ -591,17 +591,6 @@ class Cosmology(object):
             total = self._params.Omega_g + self._params.Omega_l
             self._params.Omega_g = Omega_g
             self._params.Omega_l = total - Omega_g
-
-        # Check if the user has defined a dark energy model for camb to use,
-        # and if they have not, then default to 'fluid'.
-        self._params.DE_model_camb = DE_model_camb
-        DE_model_camb_types = ['fluid', 'ppf',
-                               'DarkEnergyFluid', 'DarkEnergyPPF']
-        if DE_model_camb is None:
-            DE_model_camb = 'fluid'
-        elif DE_model_camb not in DE_model_camb_types:
-            raise ValueError("The only dark energy models CCL supports with"
-                             " camb are fluid and ppf.")
 
     def __getitem__(self, key):
         """Access parameter values by name."""

--- a/pyccl/tests/test_power.py
+++ b/pyccl/tests/test_power.py
@@ -581,3 +581,12 @@ def test_camb_de_model():
         extra_parameters={"camb": {"dark_energy_model": "pf"}})
     with pytest.raises(ValueError):
         ccl.linear_matter_power(cosmo, 1, 1)
+
+
+def test_camb_correct_de_model():
+    """Check that w is not less than -1, if the chosen dark energy model for
+    CAMB is fluid."""
+    cosmo = ccl.CosmologyVanillaLCDM(
+        transfer_function='boltzmann_camb', w0=-1, wa=-1)
+    with pytest.raises(ValueError):
+        ccl.linear_matter_power(cosmo, 1, 1)

--- a/pyccl/tests/test_power.py
+++ b/pyccl/tests/test_power.py
@@ -577,7 +577,7 @@ def test_input_nonlin_raises():
 def test_camb_de_model():
     """Check that the dark energy model for CAMB has been properly defined."""
     cosmo = ccl.CosmologyVanillaLCDM(
-                transfer_function='boltzmann_camb',
-                extra_parameters={"camb": {"dark_energy_model": "pf"}})
+        transfer_function='boltzmann_camb',
+        extra_parameters={"camb": {"dark_energy_model": "pf"}})
     with pytest.raises(ValueError):
         ccl.linear_matter_power(cosmo, 1, 1)

--- a/pyccl/tests/test_power.py
+++ b/pyccl/tests/test_power.py
@@ -576,17 +576,21 @@ def test_input_nonlin_raises():
 
 def test_camb_de_model():
     """Check that the dark energy model for CAMB has been properly defined."""
-    cosmo = ccl.CosmologyVanillaLCDM(
-        transfer_function='boltzmann_camb',
-        extra_parameters={"camb": {"dark_energy_model": "pf"}})
     with pytest.raises(ValueError):
+        cosmo = ccl.CosmologyVanillaLCDM(
+            transfer_function='boltzmann_camb',
+            extra_parameters={"camb": {"dark_energy_model": "pf"}})
         ccl.linear_matter_power(cosmo, 1, 1)
 
-
-def test_camb_correct_de_model():
     """Check that w is not less than -1, if the chosen dark energy model for
     CAMB is fluid."""
-    cosmo = ccl.CosmologyVanillaLCDM(
-        transfer_function='boltzmann_camb', w0=-1, wa=-1)
     with pytest.raises(ValueError):
+        cosmo = ccl.CosmologyVanillaLCDM(
+            transfer_function='boltzmann_camb', w0=-1, wa=-1)
         ccl.linear_matter_power(cosmo, 1, 1)
+
+    """Check that ppf is running smoothly."""
+    cosmo = ccl.CosmologyVanillaLCDM(
+        transfer_function='boltzmann_camb', w0=-1, wa=-1,
+        extra_parameters={"camb": {"dark_energy_model": "ppf"}})
+    assert np.isfinite(ccl.linear_matter_power(cosmo, 1, 1))

--- a/pyccl/tests/test_power.py
+++ b/pyccl/tests/test_power.py
@@ -573,9 +573,10 @@ def test_input_nonlin_raises():
     assert 'a:b' in cosmo_input._pk_nl
     assert cosmo_input.has_nonlin_power
 
+
 def test_camb_de_model():
-    """ Check that the dark energy model for camb has been properly defined. """
+    """Check that the dark energy model for CAMB has been properly defined."""
     cosmo = ccl.CosmologyVanillaLCDM(transfer_function='boltzmann_camb',
-                extra_parameters={"camb":{"dark_energy_model": "pf"}})
+                    extra_parameters={"camb": {"dark_energy_model": "pf"}})
     with pytest.raises(ValueError):
         ccl.linear_matter_power(cosmo, 1, 1)

--- a/pyccl/tests/test_power.py
+++ b/pyccl/tests/test_power.py
@@ -576,7 +576,8 @@ def test_input_nonlin_raises():
 
 def test_camb_de_model():
     """Check that the dark energy model for CAMB has been properly defined."""
-    cosmo = ccl.CosmologyVanillaLCDM(transfer_function='boltzmann_camb',
-                    extra_parameters={"camb": {"dark_energy_model": "pf"}})
+    cosmo = ccl.CosmologyVanillaLCDM(
+                transfer_function='boltzmann_camb',
+                extra_parameters={"camb": {"dark_energy_model": "pf"}})
     with pytest.raises(ValueError):
         ccl.linear_matter_power(cosmo, 1, 1)

--- a/pyccl/tests/test_power.py
+++ b/pyccl/tests/test_power.py
@@ -572,3 +572,10 @@ def test_input_nonlin_raises():
         nonlinear_model='halofit')
     assert 'a:b' in cosmo_input._pk_nl
     assert cosmo_input.has_nonlin_power
+
+def test_camb_de_model():
+    """ Check that the dark energy model for camb has been properly defined. """
+    cosmo = ccl.CosmologyVanillaLCDM(transfer_function='boltzmann_camb',
+                extra_parameters={"camb":{"dark_energy_model": "pf"}})
+    with pytest.raises(ValueError):
+        ccl.linear_matter_power(cosmo, 1, 1)


### PR DESCRIPTION
I included an option to choose which type of dark energy you want when using camb. It defaults to "fluid", now one can easily set it to "ppf".

I simply set "self._params.DE_model_camb = DE_model_camb" because I was having a difficult time with the C files.