### PR TITLE
Initialize growth in cosmology calculator

### DIFF
--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -1222,6 +1222,10 @@ class CosmologyCalculator(Cosmology):
             raise ValueError("`pk_linear` must contain keys 'a', 'k' "
                              "and 'delta_matter:delta_matter' "
                              "(at least)")
+
+        # needed for high-z extrapolation
+        self.compute_growth()
+
         na = len(pk_linear['a'])
         nk = len(pk_linear['k'])
         lk = np.log(pk_linear['k'])


### PR DESCRIPTION
The linear growth needs to be initialized with the linear power spectrum, since it is needed when extrapolating it at high redshifts.

Closes #859 