### PR TITLE
Fix AttributeError in Tk3D.__del__

### DIFF
--- a/pyccl/ccl_tk3d.i
+++ b/pyccl/ccl_tk3d.i
@@ -13,6 +13,7 @@
 %apply (int DIM1, double* ARGOUT_ARRAY1) {(int ndout, double* doutput)};
 
 %include "../include/ccl_f2d.h"
+%include "../include/ccl_f3d.h"
 %include "../include/ccl_core.h"
 
 %inline %{

--- a/pyccl/tests/test_tk3d.py
+++ b/pyccl/tests/test_tk3d.py
@@ -101,6 +101,15 @@ def test_tk3d_eval_errors():
     assert_raises(TypeError, tsp.eval, 1E-2, np.array([0.1]))
 
 
+def test_tk3d_delete():
+    """Check that ccl.Tk3D.__del__ works."""
+    (a_arr, lk_arr, fka1_arr, fka2_arr, tkka_arr) = get_arrays()
+    tsp = ccl.Tk3D(a_arr, lk_arr, pk1_arr=fka1_arr,
+                   pk2_arr=fka2_arr)
+    # This should not cause an ignored exception
+    del tsp
+
+
 @pytest.mark.parametrize('is_product', [True, False])
 def test_tk3d_eval(is_product):
     (a_arr, lk_arr, fka1_arr, fka2_arr, tkka_arr) = get_arrays()


### PR DESCRIPTION
`Tk3D.__del__` calls `lib.f3d_t_free`, which however isn't exposed. In other, words a memory leak. Since this happens in `__del__` the `AttributeError` exception that is raised is usually ignored. It's not entirely clear to me why this isn't at least reported as a warning when pytest runs though. Maybe something funny about when `__del__` is called when going out of scope.

This should be fixed by including the relevant header file in `ccl_tk3d.i`. 