### PR TITLE
Tuning knob param for 1-halo 2-point correlations

### DIFF
--- a/pyccl/halos/__init__.py
+++ b/pyccl/halos/__init__.py
@@ -40,7 +40,7 @@ from .profiles import (  # noqa
 
 # Halo profile 2-point cumulants
 from .profiles_2pt import (  # noqa
-    Profile2pt, Profile2ptHOD, Profile2ptR)
+    Profile2pt, Profile2ptHOD)
 
 # Halo model power spectrum
 from .halo_model import (  # noqa

--- a/pyccl/halos/__init__.py
+++ b/pyccl/halos/__init__.py
@@ -40,7 +40,7 @@ from .profiles import (  # noqa
 
 # Halo profile 2-point cumulants
 from .profiles_2pt import (  # noqa
-    Profile2pt, Profile2ptHOD)
+    Profile2pt, Profile2ptHOD, Profile2ptR)
 
 # Halo model power spectrum
 from .halo_model import (  # noqa

--- a/pyccl/halos/profiles_2pt.py
+++ b/pyccl/halos/profiles_2pt.py
@@ -106,3 +106,72 @@ class Profile2ptHOD(Profile2pt):
                 raise ValueError("prof2 must be the same as prof")
 
         return prof._fourier_variance(cosmo, k, M, a, mass_def)
+
+
+class Profile2ptR(Profile2pt):
+    """ This class inherits from the 1-halo 2-point correlator between two
+    halo profiles. Sometimes we need not assume that the 1-halo terms are
+    fully correlated. We introduce a term `r_corr` which scales the product
+    of the fourier halo profiles by `(1+r_corr)`. In the trivial case where
+    `r_corr=0` this returns the 2-point correlator of the parent class.
+    Example usecases can be found in arXiv:1909.09102 and arXiv:2102.07701.
+    """
+    def __init__(self, r_corr=0.):
+        self.r_corr = r_corr
+
+    def update_parameters(self, r_corr=None):
+        """ Update any of the parameters associated with this 1-halo
+        2-point correlator. Any parameter set to `None` won't be updated.
+        """
+        if r_corr is not None:
+            self.r_corr = r_corr
+
+    def fourier_2pt(self, prof, cosmo, k, M, a, r_corr=None,
+                    prof2=None, mass_def=None):
+        """ Returns the Fourier-space two-point moment between
+        two profiles:
+
+        Args:
+            prof (:class:`~pyccl.halos.profiles.HaloProfileHOD`):
+                halo profile for which the second-order moment
+                is desired.
+            cosmo (:class:`~pyccl.core.Cosmology`): a Cosmology object.
+            k (float or array_like): comoving wavenumber in Mpc^-1.
+            M (float or array_like): halo mass in units of M_sun.
+            a (float): scale factor.
+            r_corr (float): scale the correlation through `1-r_corr`.
+                If `None` it will default to the value passed during
+                instantiation of this class. Note, that if you require
+                to update `r_corr` for the instance created, you need to
+                do it through `update_parameters`.
+            prof2 (:class:`~pyccl.halos.profiles.HaloProfile`):
+                second halo profile for which the second-order moment
+                is desired. If `None`, the assumption is that you want
+                an auto-correlation. Note that only auto-correlations
+                are allowed in this case.
+            mass_def (:obj:`~pyccl.halos.massdef.MassDef`): a mass
+                definition object.
+
+        Returns:
+            float or array_like: second-order Fourier-space
+            moment. The shape of the output will be `(N_M, N_k)`
+            where `N_k` and `N_m` are the sizes of `k` and `M`
+            respectively. If `k` or `M` are scalars, the
+            corresponding dimension will be squeezed out on output.
+        """
+        if not isinstance(prof, HaloProfile):
+            raise TypeError("prof must be of type `HaloProfile`")
+        uk1 = prof.fourier(cosmo, k, M, a, mass_def=mass_def)
+
+        if prof2 is None:
+            uk2 = uk1
+        else:
+            if not isinstance(prof2, HaloProfile):
+                raise TypeError("prof2 must be of type "
+                                "`HaloProfile` or `None`")
+
+            uk2 = prof2.fourier(cosmo, k, M, a, mass_def=mass_def)
+
+        if r_corr is None:
+            r_corr = self.r_corr
+        return uk1 * uk2 * (1 + r_corr)

--- a/pyccl/halos/profiles_2pt.py
+++ b/pyccl/halos/profiles_2pt.py
@@ -69,12 +69,6 @@ class Profile2pt(object):
         """
         if not isinstance(prof, HaloProfile):
             raise TypeError("prof must be of type `HaloProfile`")
-        # If we auto-correlate a profile the covariance term must be zero.
-        # We add the test here because `prof2` might be given but point
-        # to the same memory location as `prof`. In this case, we know
-        # the two profiles are identical.
-        if self.r_corr != 0 and ((prof2 is None) or (prof == prof2)):
-            raise ValueError("prof is the same as prof2 but r_corr != 0")
 
         uk1 = prof.fourier(cosmo, k, M, a, mass_def=mass_def)
 

--- a/pyccl/halos/profiles_2pt.py
+++ b/pyccl/halos/profiles_2pt.py
@@ -2,38 +2,63 @@ from .profiles import HaloProfile, HaloProfileHOD
 
 
 class Profile2pt(object):
-    """ This class implements the 1-halo 2-point correlator between two
-    halo profiles. In the simplest case, this is just
-    the product of both profiles in Fourier space.
-    More complicated cases should be implemented by subclassing
-    this class and overloading the :meth:`~Profile2pt.fourier_2pt`
-    method.
+    """ This class implements the 1-halo 2-point correlator between
+    two halo profiles.
+
+    .. math::
+        \\langle u_1(k) u_2(k) \\rangle.
+
+    In the simplest case the second-order cumulant is just the product
+    of the individual Fourier-space profiles. More complicated cases
+    are implemented via the parameters of this class.
+
+    Args:
+        r_corr (float):
+            Tuning knob for the 1-halo 2-point correlation.
+            Scale the correlation by :math:`(1+\\rho_{u_1, u_2})`.
+            This is useful when the individual 1-halo terms
+            are not fully correlated. Example usecases can be found
+            in ``arXiv:1909.09102`` and ``arXiv:2102.07701``.
+            Defaults to ``r_corr=0``, returning simply the product
+            of the fourier profiles.
+
     """
-    def __init__(self):
-        pass
+    def __init__(self, r_corr=0.):
+        self.r_corr = r_corr
+
+    def update_parameters(self, r_corr=None):
+        """ Update any of the parameters associated with this 1-halo
+        2-point correlator. Any parameter set to `None` won't be updated.
+        """
+        if r_corr is not None:
+            self.r_corr = r_corr
 
     def fourier_2pt(self, prof, cosmo, k, M, a,
                     prof2=None, mass_def=None):
-        """ Returns the Fourier-space two-point moment between
-        two profiles:
+        """ Return the Fourier-space two-point moment between
+        two profiles.
 
         .. math::
-           \\langle\\rho_1(k)\\rho_2(k)\\rangle.
+           (1+\\rho_{u_1,u_2})\\langle u_1(k)\\rangle\\langle u_2(k) \\rangle
 
         Args:
             prof (:class:`~pyccl.halos.profiles.HaloProfile`):
                 halo profile for which the second-order moment
                 is desired.
-            cosmo (:class:`~pyccl.core.Cosmology`): a Cosmology object.
-            k (float or array_like): comoving wavenumber in Mpc^-1.
-            M (float or array_like): halo mass in units of M_sun.
-            a (float): scale factor.
+            cosmo (:class:`~pyccl.core.Cosmology`):
+                a Cosmology object.
+            k (float or array_like):
+                comoving wavenumber in Mpc^-1.
+            M (float or array_like):
+                halo mass in units of M_sun.
+            a (float):
+                scale factor.
             prof2 (:class:`~pyccl.halos.profiles.HaloProfile`):
                 second halo profile for which the second-order moment
                 is desired. If `None`, the assumption is that you want
                 an auto-correlation, and `prof` will be used as `prof2`.
-            mass_def (:obj:`~pyccl.halos.massdef.MassDef`): a mass
-                definition object.
+            mass_def (:obj:`~pyccl.halos.massdef.MassDef`):
+                a mass definition object.
 
         Returns:
             float or array_like: second-order Fourier-space
@@ -44,6 +69,13 @@ class Profile2pt(object):
         """
         if not isinstance(prof, HaloProfile):
             raise TypeError("prof must be of type `HaloProfile`")
+        # If we auto-correlate a profile the covariance term must be zero.
+        # We add the test here because `prof2` might be given but point
+        # to the same memory location as `prof`. In this case, we know
+        # the two profiles are identical.
+        if self.r_corr != 0 and ((prof2 is None) or (prof == prof2)):
+            raise ValueError("prof is the same as prof2 but r_corr != 0")
+
         uk1 = prof.fourier(cosmo, k, M, a, mass_def=mass_def)
 
         if prof2 is None:
@@ -55,7 +87,7 @@ class Profile2pt(object):
 
             uk2 = prof2.fourier(cosmo, k, M, a, mass_def=mass_def)
 
-        return uk1 * uk2
+        return uk1 * uk2 * (1 + self.r_corr)
 
 
 class Profile2ptHOD(Profile2pt):
@@ -106,72 +138,3 @@ class Profile2ptHOD(Profile2pt):
                 raise ValueError("prof2 must be the same as prof")
 
         return prof._fourier_variance(cosmo, k, M, a, mass_def)
-
-
-class Profile2ptR(Profile2pt):
-    """ This class inherits from the 1-halo 2-point correlator between two
-    halo profiles. Sometimes we need not assume that the 1-halo terms are
-    fully correlated. We introduce a term `r_corr` which scales the product
-    of the fourier halo profiles by `(1+r_corr)`. In the trivial case where
-    `r_corr=0` this returns the 2-point correlator of the parent class.
-    Example usecases can be found in arXiv:1909.09102 and arXiv:2102.07701.
-    """
-    def __init__(self, r_corr=0.):
-        self.r_corr = r_corr
-
-    def update_parameters(self, r_corr=None):
-        """ Update any of the parameters associated with this 1-halo
-        2-point correlator. Any parameter set to `None` won't be updated.
-        """
-        if r_corr is not None:
-            self.r_corr = r_corr
-
-    def fourier_2pt(self, prof, cosmo, k, M, a, r_corr=None,
-                    prof2=None, mass_def=None):
-        """ Returns the Fourier-space two-point moment between
-        two profiles:
-
-        Args:
-            prof (:class:`~pyccl.halos.profiles.HaloProfileHOD`):
-                halo profile for which the second-order moment
-                is desired.
-            cosmo (:class:`~pyccl.core.Cosmology`): a Cosmology object.
-            k (float or array_like): comoving wavenumber in Mpc^-1.
-            M (float or array_like): halo mass in units of M_sun.
-            a (float): scale factor.
-            r_corr (float): scale the correlation through `1-r_corr`.
-                If `None` it will default to the value passed during
-                instantiation of this class. Note, that if you require
-                to update `r_corr` for the instance created, you need to
-                do it through `update_parameters`.
-            prof2 (:class:`~pyccl.halos.profiles.HaloProfile`):
-                second halo profile for which the second-order moment
-                is desired. If `None`, the assumption is that you want
-                an auto-correlation. Note that only auto-correlations
-                are allowed in this case.
-            mass_def (:obj:`~pyccl.halos.massdef.MassDef`): a mass
-                definition object.
-
-        Returns:
-            float or array_like: second-order Fourier-space
-            moment. The shape of the output will be `(N_M, N_k)`
-            where `N_k` and `N_m` are the sizes of `k` and `M`
-            respectively. If `k` or `M` are scalars, the
-            corresponding dimension will be squeezed out on output.
-        """
-        if not isinstance(prof, HaloProfile):
-            raise TypeError("prof must be of type `HaloProfile`")
-        uk1 = prof.fourier(cosmo, k, M, a, mass_def=mass_def)
-
-        if prof2 is None:
-            uk2 = uk1
-        else:
-            if not isinstance(prof2, HaloProfile):
-                raise TypeError("prof2 must be of type "
-                                "`HaloProfile` or `None`")
-
-            uk2 = prof2.fourier(cosmo, k, M, a, mass_def=mass_def)
-
-        if r_corr is None:
-            r_corr = self.r_corr
-        return uk1 * uk2 * (1 + r_corr)

--- a/pyccl/tests/test_profiles.py
+++ b/pyccl/tests/test_profiles.py
@@ -174,6 +174,26 @@ def test_hod_2pt_raises():
                    prof2=pgood, mass_def=M200)
 
 
+def test_2pt_rcorr_smoke():
+    c = ccl.halos.ConcentrationDuffy08(M200)
+    p = ccl.halos.HaloProfileNFW(c_M_relation=c)
+    F0 = ccl.halos.Profile2pt().fourier_2pt(p, COSMO, 1., 1e13, 1.,
+                                            mass_def=M200)
+    p2pt = ccl.halos.Profile2ptR(r_corr=0)
+    F1 = p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., mass_def=M200)
+    assert F0 == F1
+    F2 = p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., prof2=p, mass_def=M200)
+    assert F1 == F2
+    p2pt.update_parameters(r_corr=-1.)
+    assert p2pt.r_corr == -1.
+    F3 = p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., mass_def=M200)
+    assert F3 == 0
+    with pytest.raises(TypeError):
+        p2pt.fourier_2pt(None, COSMO, 1., 1e13, 1., mass_def=M200)
+    with pytest.raises(TypeError):
+        p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., prof2=0, mass_def=M200)
+
+
 @pytest.mark.parametrize('prof_class',
                          [ccl.halos.HaloProfileGaussian,
                           ccl.halos.HaloProfilePowerLaw])

--- a/pyccl/tests/test_profiles.py
+++ b/pyccl/tests/test_profiles.py
@@ -177,7 +177,6 @@ def test_hod_2pt_raises():
 def test_2pt_rcorr_smoke():
     c = ccl.halos.ConcentrationDuffy08(M200)
     p = ccl.halos.HaloProfileNFW(c_M_relation=c)
-    p2 = ccl.halos.HaloProfileNFW(c_M_relation=c)  # different memory location
     F0 = ccl.halos.Profile2pt().fourier_2pt(p, COSMO, 1., 1e13, 1.,
                                             mass_def=M200)
     p2pt = ccl.halos.Profile2pt(r_corr=0)
@@ -188,7 +187,7 @@ def test_2pt_rcorr_smoke():
 
     p2pt.update_parameters(r_corr=-1.)
     assert p2pt.r_corr == -1.
-    F3 = p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., prof2=p2, mass_def=M200)
+    F3 = p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., mass_def=M200)
     assert F3 == 0
 
     # Errors
@@ -196,10 +195,6 @@ def test_2pt_rcorr_smoke():
         p2pt.fourier_2pt(None, COSMO, 1., 1e13, 1., mass_def=M200)
     with pytest.raises(TypeError):
         p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., prof2=0, mass_def=M200)
-    with pytest.raises(ValueError):
-        p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., mass_def=M200)
-    with pytest.raises(ValueError):
-        p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., prof2=p, mass_def=M200)
 
 
 @pytest.mark.parametrize('prof_class',

--- a/pyccl/tests/test_profiles.py
+++ b/pyccl/tests/test_profiles.py
@@ -177,21 +177,29 @@ def test_hod_2pt_raises():
 def test_2pt_rcorr_smoke():
     c = ccl.halos.ConcentrationDuffy08(M200)
     p = ccl.halos.HaloProfileNFW(c_M_relation=c)
+    p2 = ccl.halos.HaloProfileNFW(c_M_relation=c)  # different memory location
     F0 = ccl.halos.Profile2pt().fourier_2pt(p, COSMO, 1., 1e13, 1.,
                                             mass_def=M200)
-    p2pt = ccl.halos.Profile2ptR(r_corr=0)
+    p2pt = ccl.halos.Profile2pt(r_corr=0)
     F1 = p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., mass_def=M200)
     assert F0 == F1
     F2 = p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., prof2=p, mass_def=M200)
     assert F1 == F2
+
     p2pt.update_parameters(r_corr=-1.)
     assert p2pt.r_corr == -1.
-    F3 = p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., mass_def=M200)
+    F3 = p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., prof2=p2, mass_def=M200)
     assert F3 == 0
+
+    # Errors
     with pytest.raises(TypeError):
         p2pt.fourier_2pt(None, COSMO, 1., 1e13, 1., mass_def=M200)
     with pytest.raises(TypeError):
         p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., prof2=0, mass_def=M200)
+    with pytest.raises(ValueError):
+        p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., mass_def=M200)
+    with pytest.raises(ValueError):
+        p2pt.fourier_2pt(p, COSMO, 1., 1e13, 1., prof2=p, mass_def=M200)
 
 
 @pytest.mark.parametrize('prof_class',


### PR DESCRIPTION
Cont. work from #874 . Basically, a parameter `r_corr` which controls the sign of the correlation of two profiles, which do not necessarily have to be fully correlated.

In the original implementation I subclassed `Profile2pt` into `Profile2ptR`, because there was an explicit statement to only subclass `Profile2pt` for more complicated 2-point moments, but in hindsight, there is no reason for this prohibition to exist. So I am implementing it directly into the base class.