### PR TITLE
Methods of Cosmology

### DIFF
--- a/pyccl/__init__.py
+++ b/pyccl/__init__.py
@@ -24,6 +24,9 @@ from .background import growth_factor, growth_factor_unnorm, \
     h_over_h0, luminosity_distance, distance_modulus, scale_factor_of_chi, \
     omega_x, rho_x
 
+# Boltzmann solvers
+from .boltzmann import get_camb_pk_lin, get_isitgr_pk_lin, get_class_pk_lin
+
 # Generalized power spectra
 from .pk2d import Pk2D, parse_pk2d
 

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -197,10 +197,10 @@ class Cosmology(object):
     # Go through all functions in the main package and the subpackages
     # and make every function that takes `cosmo` as its first argument
     # an attribute of this class.
-    from . import background, bcm, \
+    from . import background, boltzmann, bcm, \
         cls, correlations, covariances, \
         pk2d, power, tracers, halos, nl_pt
-    subs = [background, bcm, cls, correlations, covariances,
+    subs = [background, boltzmann, bcm, cls, correlations, covariances,
             pk2d, power, tracers, halos, nl_pt]
     funcs = [getmembers(sub, isfunction) for sub in subs]
     funcs = [func for sub in funcs for func in sub]
@@ -208,7 +208,7 @@ class Cosmology(object):
         pars = signature(func).parameters
         if list(pars)[0] == "cosmo":
             vars()[name] = func
-    del background, bcm, cls, correlations, covariances, \
+    del background, boltzmann, bcm, cls, correlations, covariances, \
         pk2d, power, tracers, halos, nl_pt
 
     def __init__(

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -7,7 +7,6 @@ import numpy as np
 import yaml
 from inspect import getmembers, isfunction, signature
 
-import pyccl
 from . import ccllib as lib
 from .errors import CCLError, CCLWarning
 from ._types import error_types
@@ -198,13 +197,19 @@ class Cosmology(object):
     # Go through all functions in the main package and the subpackages
     # and make every function that takes `cosmo` as its first argument
     # an attribute of this class.
-    subs = [pyccl, pyccl.halos, pyccl.nl_pt]
+    from . import background, bcm, \
+        cls, correlations, covariances, \
+        pk2d, power, tracers, halos, nl_pt
+    subs = [background, bcm, cls, correlations, covariances,
+            pk2d, power, tracers, halos, nl_pt]
     funcs = [getmembers(sub, isfunction) for sub in subs]
     funcs = [func for sub in funcs for func in sub]
     for name, func in funcs:
         pars = signature(func).parameters
         if list(pars)[0] == "cosmo":
             vars()[name] = func
+    del background, bcm, cls, correlations, covariances, \
+        pk2d, power, tracers, halos, nl_pt
 
     def __init__(
             self, Omega_c=None, Omega_b=None, h=None, n_s=None,

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -197,11 +197,11 @@ class Cosmology(object):
     # Go through all functions in the main package and the subpackages
     # and make every function that takes `cosmo` as its first argument
     # an attribute of this class.
-    from . import background, boltzmann, bcm, \
-        cls, correlations, covariances, \
-        pk2d, power, tracers, halos, nl_pt
+    from . import background, bcm, boltzmann, \
+        cls, correlations, covariances, neutrinos, \
+        pk2d, power, tk3d, tracers, halos, nl_pt
     subs = [background, boltzmann, bcm, cls, correlations, covariances,
-            pk2d, power, tracers, halos, nl_pt]
+            neutrinos, pk2d, power, tk3d, tracers, halos, nl_pt]
     funcs = [getmembers(sub, isfunction) for sub in subs]
     funcs = [func for sub in funcs for func in sub]
     for name, func in funcs:

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -209,7 +209,7 @@ class Cosmology(object):
         if list(pars)[0] == "cosmo":
             vars()[name] = func
     del background, boltzmann, bcm, cls, correlations, covariances, \
-        pk2d, power, tracers, halos, nl_pt
+        neutrinos, pk2d, power, tk3d, tracers, halos, nl_pt
 
     def __init__(
             self, Omega_c=None, Omega_b=None, h=None, n_s=None,

--- a/pyccl/halos/__init__.py
+++ b/pyccl/halos/__init__.py
@@ -2,7 +2,7 @@
 from .massdef import (  # noqa
     mass2radius_lagrangian, MassDef,
     MassDef200m, MassDef200c,
-    MassDefVir)
+    MassDefVir, convert_concentration)
 
 # Halo concentration
 from .concentration import (  # noqa

--- a/pyccl/tests/test_cosmology.py
+++ b/pyccl/tests/test_cosmology.py
@@ -39,7 +39,7 @@ def test_cosmo_methods():
     hmd = ccl.halos.MassDef200m()
     hmf = ccl.halos.MassFuncTinker08(cosmo)
     hbf = ccl.halos.HaloBiasTinker10(cosmo)
-    hmc = ccl.halos.HMCalculator(massfunc=hmf, hbias=hbf, mass_def=hmd)
+    hmc = ccl.halos.HMCalculator(cosmo, massfunc=hmf, hbias=hbf, mass_def=hmd)
     assert ccl.halos.halomod_power_spectrum(cosmo, hmc, 1., 1., prof) == \
         cosmo.halomod_power_spectrum(hmc, 1., 1., prof)
 

--- a/pyccl/tests/test_cosmology.py
+++ b/pyccl/tests/test_cosmology.py
@@ -10,6 +10,26 @@ from numpy.testing import assert_raises, assert_, assert_no_warnings
 import pyccl as ccl
 
 
+def test_cosmo_methods():
+    """ Check that all pyccl functions that take cosmo
+    as their first argument are methods of the Cosmology object.
+    """
+    from inspect import getmembers, isfunction, signature
+    from .. import background, bcm, \
+        cls, correlations, covariances, \
+        pk2d, power, tracers, halos, nl_pt
+    from ..core import CosmologyVanillaLCDM
+    cosmo = CosmologyVanillaLCDM()
+    subs = [background, bcm, cls, correlations, covariances,
+            pk2d, power, tracers, halos, nl_pt]
+    funcs = [getmembers(sub, isfunction) for sub in subs]
+    funcs = [func for sub in funcs for func in sub]
+    for name, func in funcs:
+        pars = signature(func).parameters
+        if list(pars)[0] == "cosmo":
+            _ = getattr(cosmo, name)
+
+
 def test_cosmology_critical_init():
     cosmo = ccl.Cosmology(
         Omega_c=0.25,

--- a/pyccl/tests/test_cosmology.py
+++ b/pyccl/tests/test_cosmology.py
@@ -15,10 +15,10 @@ def test_cosmo_methods():
     as their first argument are methods of the Cosmology object.
     """
     from inspect import getmembers, isfunction, signature
-    from .. import background, bcm, \
+    from pyccl import background, bcm, \
         cls, correlations, covariances, \
         pk2d, power, tracers, halos, nl_pt
-    from ..core import CosmologyVanillaLCDM
+    from pyccl.core import CosmologyVanillaLCDM
     cosmo = CosmologyVanillaLCDM()
     subs = [background, bcm, cls, correlations, covariances,
             pk2d, power, tracers, halos, nl_pt]
@@ -28,6 +28,20 @@ def test_cosmo_methods():
         pars = signature(func).parameters
         if list(pars)[0] == "cosmo":
             _ = getattr(cosmo, name)
+
+    # quantitative
+    assert ccl.sigma8(cosmo) == cosmo.sigma8()
+    assert ccl.rho_x(cosmo, 1., "matter", is_comoving=False) == \
+        cosmo.rho_x(1., "matter", is_comoving=False)
+    assert ccl.get_camb_pk_lin(cosmo).eval(1., 1., cosmo) == \
+        cosmo.get_camb_pk_lin().eval(1., 1., cosmo)
+    prof = ccl.halos.HaloProfilePressureGNFW()
+    hmd = ccl.halos.MassDef200m()
+    hmf = ccl.halos.MassFuncTinker08(cosmo)
+    hbf = ccl.halos.HaloBiasTinker10(cosmo)
+    hmc = ccl.halos.HMCalculator(massfunc=hmf, hbias=hbf, mass_def=hmd)
+    assert ccl.halos.halomod_power_spectrum(cosmo, hmc, 1., 1., prof) == \
+        cosmo.halomod_power_spectrum(hmc, 1., 1., prof)
 
 
 def test_cosmology_critical_init():

--- a/pyccl/tests/test_cosmology.py
+++ b/pyccl/tests/test_cosmology.py
@@ -15,13 +15,13 @@ def test_cosmo_methods():
     as their first argument are methods of the Cosmology object.
     """
     from inspect import getmembers, isfunction, signature
-    from pyccl import background, bcm, \
-        cls, correlations, covariances, \
-        pk2d, power, tracers, halos, nl_pt
+    from pyccl import background, bcm, boltzmann, \
+        cls, correlations, covariances, neutrinos, \
+        pk2d, power, tk3d, tracers, halos, nl_pt
     from pyccl.core import CosmologyVanillaLCDM
     cosmo = CosmologyVanillaLCDM()
-    subs = [background, bcm, cls, correlations, covariances,
-            pk2d, power, tracers, halos, nl_pt]
+    subs = [background, boltzmann, bcm, cls, correlations, covariances,
+            neutrinos, pk2d, power, tk3d, tracers, halos, nl_pt]
     funcs = [getmembers(sub, isfunction) for sub in subs]
     funcs = [func for sub in funcs for func in sub]
     for name, func in funcs:


### PR DESCRIPTION
I have added few lines of code to `core.py` to make (almost) all of the `pyccl` functions which accept `cosmo` as their first argument, methods of the `Cosmology` class.

### New methods, organized by module

1. **pyccl.background**
  - growth_factor
  - growth_factor_unnorm
  - growth_rate
  - comoving_radial_distance
  - comoving_angular_distance
  - angular_diameter_distance
  - luminosity_distance
  - h_over_h0
  - distance_modulus
  - scale_factor_of_chi
  - omega_x
  - rho_x

2. **pyccl.bcm**
  - bcm_model_fka
  - bcm_correct_pk2d

3. **pyccl.boltzmann**
 - get_camb_pk_lin
 - get_isitgr_pk_lin
 - get_class_pk_lin

4. **pyccl.cls**
  - angular_cl

5. **pyccl.correlations**
  - correlation
  - correlation_3d
  - correlation_multipole
  - correlation_3dRsd
  - correlation_3dRsd_avgmu
  - correlation_pi_sigma

6. **pyccl.covariances**
  - angular_cl_cov_cNG

7. **pyccl.pk2d**
  - parse_pk2d

8. **pyccl.power**
  - linear_power
  - nonlin_power
  - linear_matter_power
  - nonlin_matter_power
  - sigmaM
  - sigmaR
  - sigmaV
  - sigma8
  - kNL

9. **pyccl.tracers**
  - get_density_kernel
  - get_lensing_kernel
  - get_kappa_kernel

10. **pyccl.halos.halo_model**
  - halomod_mean_profile_1pt
  - halomod_bias_1pt
  - halomod_power_spectrum
  - halomod_Pk2D
  - halomod_trispectrum_1h
  - halomod_Tk3D_1h

11. **pyccl.halos.massdef**
  - mass2radius_lagrangian
  - convert_concentration   ==> I added this one in `__init__.py` because it's useful

12. **pyccl.nl_pt.power**
  - get_pt_pk2d

13. **pyccl.nl_pt.tracers**
  - translate_IA_norm

### These functions take `cosmo` as their first argument but were not added (because they are not in `__init__.py`)
- _get_concentration
- _get_mf_hb
- _Sig_MG

### These functions take `cosmo` as their first argument but were not added (because they are deprecated)
  - einasto_profile_3d
  - halo_bias
  - halo_concentration
  - halomodel_matter_power
  - hernquist_profile_3d
  - massfunc
  - massfunc_m2r
  - nfw_profile_2d
  - nfw_profile_3d
  - onehalo_matter_power
  - twohalo_matter_power

### Advantages of this method
1. New functions do not have to be manually added in `Cosmology`
2. It is backwards-compatible! (I think)