### PR TITLE
typo in param naming

### DIFF
--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -502,7 +502,7 @@ def halomod_power_spectrum(cosmo, hmc, k, a, prof,
                            prof_2pt=None, prof2=None, p_of_k_a=None,
                            normprof1=False, normprof2=False,
                            get_1h=True, get_2h=True,
-                           smooth_transition=None, supress_1h=None):
+                           smooth_transition=None, suppress_1h=None):
     """ Computes the halo model power spectrum for two
     quantities defined by their respective halo profiles.
     The halo model power spectrum for two profiles
@@ -554,8 +554,8 @@ def halomod_power_spectrum(cosmo, hmc, k, a, prof,
             defined as in HMCODE-2020 (``arXiv:2009.01858``): :math:`P(k,a)=
             (P_{1h}^{\\alpha(a)}(k)+P_{2h}^{\\alpha(a)}(k))^{1/\\alpha}`.
             If `None` the extra factor is just 1.
-        supress_1h (function or None):
-            Supress the 1-halo large scale contribution by a
+        suppress_1h (function or None):
+            Suppress the 1-halo large scale contribution by a
             time- and scale-dependent function :math:`k_*(a)`,
             defined as in HMCODE-2020 (``arXiv:2009.01858``):
             :math:`\\frac{(k/k_*(a))^4}{1+(k/k_*(a))^4}`.
@@ -588,12 +588,12 @@ def halomod_power_spectrum(cosmo, hmc, k, a, prof,
         if not hasattr(smooth_transition, "__call__"):
             raise TypeError("smooth_transition must be "
                             "a function of `a` or None")
-    if supress_1h is not None:
+    if suppress_1h is not None:
         if not get_1h:
-            raise ValueError("can't supress the 1-halo term "
+            raise ValueError("can't suppress the 1-halo term "
                              "when get_1h is False")
-        if not hasattr(supress_1h, "__call__"):
-            raise TypeError("supress_1h must be "
+        if not hasattr(suppress_1h, "__call__"):
+            raise TypeError("suppress_1h must be "
                             "a function of `a` or None")
 
     # Power spectrum
@@ -646,8 +646,8 @@ def halomod_power_spectrum(cosmo, hmc, k, a, prof,
 
         if get_1h:
             pk_1h = hmc.I_0_2(cosmo, k_use, aa, prof, prof_2pt, prof2)
-            if supress_1h is not None:
-                ks = supress_1h(aa)
+            if suppress_1h is not None:
+                ks = suppress_1h(aa)
                 pk_1h *= (k_use / ks)**4 / (1 + (k_use / ks)**4)
         else:
             pk_1h = 0.
@@ -672,7 +672,7 @@ def halomod_Pk2D(cosmo, hmc, prof,
                  get_1h=True, get_2h=True,
                  lk_arr=None, a_arr=None,
                  extrap_order_lok=1, extrap_order_hik=2,
-                 smooth_transition=None, supress_1h=None):
+                 smooth_transition=None, suppress_1h=None):
     """ Returns a :class:`~pyccl.pk2d.Pk2D` object containing
     the halo-model power spectrum for two quantities defined by
     their respective halo profiles. See :meth:`halomod_power_spectrum`
@@ -728,8 +728,8 @@ def halomod_Pk2D(cosmo, hmc, prof,
             defined as in HMCODE-2020 (``arXiv:2009.01858``): :math:`P(k,a)=
             (P_{1h}^{\\alpha(a)}(k)+P_{2h}^{\\alpha(a)}(k))^{1/\\alpha}`.
             If `None` the extra factor is just 1.
-        supress_1h (function or None):
-            Supress the 1-halo large scale contribution by a
+        suppress_1h (function or None):
+            Suppress the 1-halo large scale contribution by a
             time- and scale-dependent function :math:`k_*(a)`,
             defined as in HMCODE-2020 (``arXiv:2009.01858``):
             :math:`\\frac{(k/k_*(a))^4}{1+(k/k_*(a))^4}`.
@@ -755,7 +755,7 @@ def halomod_Pk2D(cosmo, hmc, prof,
                                     normprof1=normprof1, normprof2=normprof2,
                                     get_1h=get_1h, get_2h=get_2h,
                                     smooth_transition=smooth_transition,
-                                    supress_1h=supress_1h)
+                                    suppress_1h=suppress_1h)
 
     pk2d = Pk2D(a_arr=a_arr, lk_arr=lk_arr, pk_arr=pk_arr,
                 extrap_order_lok=extrap_order_lok,

--- a/pyccl/tests/test_pkhm.py
+++ b/pyccl/tests/test_pkhm.py
@@ -209,7 +209,7 @@ def test_pkhm_pk2d():
     def ks0(a):  # no damping
         return 1e-16
 
-    def ks1(a):  # fully supressed
+    def ks1(a):  # fully suppressed
         return 1e16
 
     def ks2(a):  # reasonable
@@ -217,18 +217,18 @@ def test_pkhm_pk2d():
 
     pk0 = ccl.halos.halomod_power_spectrum(COSMO, hmc, k_arr, a_arr, P1,
                                            normprof1=True, normprof2=True,
-                                           supress_1h=None, get_2h=False)
+                                           suppress_1h=None, get_2h=False)
     pk1 = ccl.halos.halomod_power_spectrum(COSMO, hmc, k_arr, a_arr, P1,
                                            normprof1=True, normprof2=True,
-                                           supress_1h=ks0, get_2h=False)
+                                           suppress_1h=ks0, get_2h=False)
     assert np.allclose(pk0, pk1, rtol=0)
     pk2 = ccl.halos.halomod_power_spectrum(COSMO, hmc, k_arr, a_arr, P1,
                                            normprof1=True, normprof2=True,
-                                           supress_1h=ks1, get_2h=False)
+                                           suppress_1h=ks1, get_2h=False)
     assert np.allclose(pk2, 0, rtol=0)
     pk3 = ccl.halos.halomod_power_spectrum(COSMO, hmc, k_arr, a_arr, P1,
                                            normprof1=True, normprof2=True,
-                                           supress_1h=ks2, get_2h=False)
+                                           suppress_1h=ks2, get_2h=False)
     fact = (k_arr/0.04)**4 / (1 + (k_arr/0.04)**4)
     assert np.allclose(pk3, pk0*fact, rtol=0)
 
@@ -286,8 +286,8 @@ def test_pkhm_errors():
     # Wrong 1h damping
     with pytest.raises(TypeError):
         ccl.halos.halomod_power_spectrum(COSMO, hmc, KK, AA, P1,
-                                         supress_1h=True)
+                                         suppress_1h=True)
 
     with pytest.raises(ValueError):
         ccl.halos.halomod_power_spectrum(COSMO, hmc, KK, AA, P1,
-                                         supress_1h=func, get_1h=False)
+                                         suppress_1h=func, get_1h=False)


### PR DESCRIPTION
In `halomod_power_spectrum` I had written `k_1h_supress` for the HM-Code 1-halo suppression factor, instead of "suppress".
This breaks API but since no one has complained so far about my bad english, I assume no one has used it, so we can merge it, break API, and still get away with it.