### PR TITLE
10x speed increase in CIB profile

### DIFF
--- a/pyccl/halos/profiles_cib.py
+++ b/pyccl/halos/profiles_cib.py
@@ -200,7 +200,7 @@ class HaloProfileCIBShang12(HaloProfile):
         dnsubdlnm = self.dNsub_dlnM_TinkerWetzel10(10**msub, M_use)
         integ = dnsubdlnm * Lum
         Lumsat = simps(integ, x=np.log(10)*msub)
-        res[-len(Lumsat): ] = Lumsat
+        res[-len(Lumsat):] = Lumsat
         return res
 
     def _real(self, cosmo, r, M, a, mass_def):

--- a/pyccl/halos/profiles_cib.py
+++ b/pyccl/halos/profiles_cib.py
@@ -189,18 +189,19 @@ class HaloProfileCIBShang12(HaloProfile):
         return Lumcen
 
     def _Lumsat(self, M, a):
-        logM = np.log10(M[None, :])
-        # log-spaced integration points (10 per dex)
+        res = np.zeros_like(M)
+        M_use = M[M >= self.Mmin, None]
+        logM = np.log10(M_use)
         LOGM_MIN = 10
         nm = max(2, 10*int(np.max(logM) - LOGM_MIN))
-        msub = np.linspace(LOGM_MIN, np.max(logM), nm+1)[:, None]
+        msub = np.linspace(LOGM_MIN, np.max(logM), nm+1)[None, :]
 
-        dnsubdlnm = self.dNsub_dlnM_TinkerWetzel10(10**msub, M)
         Lum = self._Lum(msub, a)
+        dnsubdlnm = self.dNsub_dlnM_TinkerWetzel10(10**msub, M_use)
         integ = dnsubdlnm * Lum
-        Lumsat = simps(integ, x=np.log(10)*msub, axis=0)
-        Lumsat[M < self.Mmin] = 0.
-        return Lumsat
+        Lumsat = simps(integ, x=np.log(10)*msub)
+        res[-len(Lumsat): ] = Lumsat
+        return res
 
     def _real(self, cosmo, r, M, a, mass_def):
         M_use = np.atleast_1d(M)

--- a/pyccl/halos/profiles_cib.py
+++ b/pyccl/halos/profiles_cib.py
@@ -189,20 +189,17 @@ class HaloProfileCIBShang12(HaloProfile):
         return Lumcen
 
     def _Lumsat(self, M, a):
-        Lumsat = np.zeros_like(M)
-        # Loop over Mparent
-        # TODO: if this is too slow we could move it to C
-        # and parallelize
-        for iM, Mparent in enumerate(M):
-            if Mparent > self.Mmin:
-                # Array of Msubs (log-spaced with 10 samples per dex)
-                nm = max(2, int(np.log10(Mparent/1E10)*10))
-                msub = np.geomspace(1E10, Mparent, nm+1)
-                # Sample integrand
-                dnsubdlnm = self.dNsub_dlnM_TinkerWetzel10(msub, Mparent)
-                Lum = self._Lum(np.log10(msub), a)
-                integ = dnsubdlnm*Lum
-                Lumsat[iM] = simps(integ, x=np.log(msub))
+        logM = np.log10(M[None, :])
+        # log-spaced integration points (10 per dex)
+        LOGM_MIN = 10
+        nm = max(2, 10*int(np.max(logM) - LOGM_MIN))
+        msub = np.linspace(LOGM_MIN, np.max(logM), nm+1)[:, None]
+
+        dnsubdlnm = self.dNsub_dlnM_TinkerWetzel10(10**msub, M)
+        Lum = self._Lum(msub, a)
+        integ = dnsubdlnm * Lum
+        Lumsat = simps(integ, x=np.log(10)*msub, axis=0)
+        Lumsat[M < self.Mmin] = 0.
         return Lumsat
 
     def _real(self, cosmo, r, M, a, mass_def):

--- a/pyccl/halos/profiles_cib.py
+++ b/pyccl/halos/profiles_cib.py
@@ -189,6 +189,9 @@ class HaloProfileCIBShang12(HaloProfile):
         return Lumcen
 
     def _Lumsat(self, M, a):
+        if not np.max(M) > self.Mmin:
+            return np.zeros_like(M)
+
         res = np.zeros_like(M)
         M_use = M[M >= self.Mmin, None]
         logM = np.log10(M_use)

--- a/pyccl/halos/profiles_cib.py
+++ b/pyccl/halos/profiles_cib.py
@@ -195,7 +195,7 @@ class HaloProfileCIBShang12(HaloProfile):
         res = np.zeros_like(M)
         M_use = M[M >= self.Mmin, None]
         logM = np.log10(M_use)
-        LOGM_MIN = 10
+        LOGM_MIN = np.log10(self.Mmin)
         nm = max(2, 10*int(np.max(logM) - LOGM_MIN))
         msub = np.linspace(LOGM_MIN, np.max(logM), nm+1)[None, :]
 


### PR DESCRIPTION
Using `numpy` broadcasting rules we can get at least a 10-fold speed increase (and up to 100x) in the computation of `_Lumsat` in `HaloProfileCIBShang12`, thus avoiding having to write this in C.