### PR TITLE
Update docs and tests to use mead2020_feedback.

### DIFF
--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -191,7 +191,7 @@ class Cosmology(object):
     Consult the CAMB documentation for their usage. These parameters are passed
     in a :obj:`dict` to `extra_parameters` as::
 
-        extra_parameters = {"camb": {"halofit_version": "mead2020",
+        extra_parameters = {"camb": {"halofit_version": "mead2020_feedback",
                                      "HMCode_logT_AGN": 7.8}}
 
     """

--- a/pyccl/tests/test_nonlin_camb_power.py
+++ b/pyccl/tests/test_nonlin_camb_power.py
@@ -13,16 +13,25 @@ def test_nonlin_camb_power():
     A_s = 2.1e-9
     n_s = 0.97
     h = 0.7
+    # Needs to be set for good agreements between CCL and CAMB
+    T_CMB = 2.725
 
     p = camb.CAMBparams(WantTransfer=True,
                         NonLinearModel=camb.nonlinear.Halofit(
-                            halofit_version="mead2020",
+                            halofit_version="mead2020_feedback",
                             HMCode_logT_AGN=logT_AGN))
-    p.set_cosmology(H0=h*100, omch2=Omega_c*h**2, ombh2=Omega_b*h**2, mnu=0.0)
+    # This affects k_min
+    p.WantCls = False
+    p.DoLensing = False
+    p.Want_CMB = False
+    p.Want_CMB_lensing = False
+    p.Want_cl_2D_array = False
+    p.set_cosmology(H0=h*100, omch2=Omega_c*h**2, ombh2=Omega_b*h**2,
+                    mnu=0.0, TCMB=T_CMB)
     p.share_delta_neff = False
     p.InitPower.set_params(As=A_s, ns=n_s)
 
-    z = [0.0, 0.5, 1.0]
+    z = [0.0, 0.5, 1.0, 1.5]
     p.set_matter_power(redshifts=z, kmax=10.0, nonlinear=True)
     p.set_for_lmax(5000)
 
@@ -31,18 +40,18 @@ def test_nonlin_camb_power():
     k, z, pk_nonlin_camb = r.get_nonlinear_matter_power_spectrum(
         hubble_units=False, k_hunit=False)
 
-    ccl_cosmo = ccl.Cosmology(Omega_c=Omega_c, Omega_b=Omega_b, h=h, m_nu=0.0,
-                              A_s=A_s, n_s=n_s,
-                              transfer_function="boltzmann_camb",
-                              matter_power_spectrum="camb",
-                              extra_parameters={"camb":
-                                                {"halofit_version": "mead2020",
-                                                 "HMCode_logT_AGN": logT_AGN}})
+    ccl_cosmo = ccl.Cosmology(
+        Omega_c=Omega_c, Omega_b=Omega_b, h=h, m_nu=0.0,
+        A_s=A_s, n_s=n_s,
+        transfer_function="boltzmann_camb",
+        matter_power_spectrum="camb",
+        extra_parameters={"camb": {"halofit_version": "mead2020_feedback",
+                                   "HMCode_logT_AGN": logT_AGN}})
 
     for z_, pk_camb in zip(z, pk_nonlin_camb):
         pk_nonlin_ccl = ccl.nonlin_matter_power(ccl_cosmo, k, 1/(1+z_))
 
-        assert np.allclose(pk_camb, pk_nonlin_ccl, rtol=3e-3)
+        assert np.allclose(pk_camb, pk_nonlin_ccl, rtol=3e-5)
 
 
 def test_nonlin_camb_power_with_sigma8():


### PR DESCRIPTION
The docs suggest that `halofit_version=mead2020` accounts for baryon feedback, but that should be `mead2020_feedback`.
This also fixes the tests to get the agreement with CAMB to O(1e-5) by using the same setup as in `boltzmann.py` (namely setting T_CMB and using the same k-range).