### PR TITLE
Make tracer spline errors more verbose

### DIFF
--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -57,7 +57,7 @@ def get_camb_pk_lin(cosmo, nonlin=False):
     na = lib.get_pk_spline_na(cosmo.cosmo)
     status = 0
     a_arr, status = lib.get_pk_spline_a(cosmo.cosmo, na, status)
-    check(status)
+    check(status, cosmo=cosmo)
     a_arr = np.sort(a_arr)
     zs = 1.0 / a_arr - 1
     zs = np.clip(zs, 0, np.inf)
@@ -278,7 +278,7 @@ def get_isitgr_pk_lin(cosmo):
     na = lib.get_pk_spline_na(cosmo.cosmo)
     status = 0
     a_arr, status = lib.get_pk_spline_a(cosmo.cosmo, na, status)
-    check(status)
+    check(status, cosmo=cosmo)
     a_arr = np.sort(a_arr)
     zs = 1.0 / a_arr - 1
     zs = np.clip(zs, 0, np.inf)
@@ -508,7 +508,7 @@ def get_class_pk_lin(cosmo):
         na = lib.get_pk_spline_na(cosmo.cosmo)
         status = 0
         a_arr, status = lib.get_pk_spline_a(cosmo.cosmo, na, status)
-        check(status)
+        check(status, cosmo=cosmo)
 
         # FIXME - getting the lowest CLASS k value from the python interface
         # appears to be broken - setting to 1e-5 which is close to the

--- a/pyccl/covariances.py
+++ b/pyccl/covariances.py
@@ -161,7 +161,7 @@ def sigma2_B_disc(cosmo, a=None, fsky=1., p_of_k_a=None):
     if a is None:
         na = lib.get_pk_spline_na(cosmo.cosmo)
         a_arr, status = lib.get_pk_spline_a(cosmo.cosmo, na, status)
-        check(status)
+        check(status, cosmo=cosmo)
     else:
         a_arr = np.atleast_1d(a)
         na = len(a_arr)

--- a/pyccl/halos/concentration.py
+++ b/pyccl/halos/concentration.py
@@ -482,7 +482,7 @@ class ConcentrationIshiyama21(Concentration):
         status = 0
         dlns_dlogM, status = lib.dlnsigM_dlogM_vec(cosmo.cosmo, a, logM,
                                                    len(logM), status)
-        check(status)
+        check(status, cosmo=cosmo)
         return -3/np.log(10) * dlns_dlogM
 
     def _G(self, x, n_eff):

--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -742,12 +742,12 @@ def halomod_Pk2D(cosmo, hmc, prof,
         status = 0
         nk = lib.get_pk_spline_nk(cosmo.cosmo)
         lk_arr, status = lib.get_pk_spline_lk(cosmo.cosmo, nk, status)
-        check(status)
+        check(status, cosmo=cosmo)
     if a_arr is None:
         status = 0
         na = lib.get_pk_spline_na(cosmo.cosmo)
         a_arr, status = lib.get_pk_spline_a(cosmo.cosmo, na, status)
-        check(status)
+        check(status, cosmo=cosmo)
 
     pk_arr = halomod_power_spectrum(cosmo, hmc, np.exp(lk_arr), a_arr,
                                     prof, prof_2pt=prof_2pt,
@@ -958,12 +958,12 @@ def halomod_Tk3D_1h(cosmo, hmc,
         status = 0
         nk = lib.get_pk_spline_nk(cosmo.cosmo)
         lk_arr, status = lib.get_pk_spline_lk(cosmo.cosmo, nk, status)
-        check(status)
+        check(status, cosmo=cosmo)
     if a_arr is None:
         status = 0
         na = lib.get_pk_spline_na(cosmo.cosmo)
         a_arr, status = lib.get_pk_spline_a(cosmo.cosmo, na, status)
-        check(status)
+        check(status, cosmo=cosmo)
 
     tkk = halomod_trispectrum_1h(cosmo, hmc, np.exp(lk_arr), a_arr,
                                  prof1, prof2=prof2,
@@ -1067,12 +1067,12 @@ def halomod_Tk3D_SSC(cosmo, hmc,
         status = 0
         nk = lib.get_pk_spline_nk(cosmo.cosmo)
         lk_arr, status = lib.get_pk_spline_lk(cosmo.cosmo, nk, status)
-        check(status)
+        check(status, cosmo=cosmo)
     if a_arr is None:
         status = 0
         na = lib.get_pk_spline_na(cosmo.cosmo)
         a_arr, status = lib.get_pk_spline_a(cosmo.cosmo, na, status)
-        check(status)
+        check(status, cosmo=cosmo)
 
     k_use = np.exp(lk_arr)
 

--- a/pyccl/halos/hbias.py
+++ b/pyccl/halos/hbias.py
@@ -134,7 +134,7 @@ class HaloBias(object):
         status = 0
         sigM, status = lib.sigM_vec(cosmo.cosmo, a, logM,
                                     len(logM), status)
-        check(status)
+        check(status, cosmo=cosmo)
 
         b = self._get_bsigma(cosmo, sigM, a)
         if np.ndim(M) == 0:
@@ -200,7 +200,7 @@ class HaloBiasSheth99(HaloBias):
         if self.use_delta_c_fit:
             status = 0
             delta_c, status = lib.dc_NakamuraSuto(cosmo.cosmo, a, status)
-            check(status)
+            check(status, cosmo=cosmo)
         else:
             delta_c = 1.68647
 

--- a/pyccl/halos/hmfunc.py
+++ b/pyccl/halos/hmfunc.py
@@ -142,11 +142,11 @@ class MassFunc(object):
         status = 0
         sigM, status = lib.sigM_vec(cosmo.cosmo, a, logM,
                                     len(logM), status)
-        check(status)
+        check(status, cosmo=cosmo)
         # dlogsigma(M)/dlog10(M)
         dlns_dlogM, status = lib.dlnsigM_dlogM_vec(cosmo.cosmo, a, logM,
                                                    len(logM), status)
-        check(status)
+        check(status, cosmo=cosmo)
 
         rho = (lib.cvar.constants.RHO_CRITICAL *
                cosmo['Omega_m'] * cosmo['h']**2)
@@ -257,7 +257,7 @@ class MassFuncSheth99(MassFunc):
         if self.use_delta_c_fit:
             status = 0
             delta_c, status = lib.dc_NakamuraSuto(cosmo.cosmo, a, status)
-            check(status)
+            check(status, cosmo=cosmo)
         else:
             delta_c = 1.68647
 
@@ -396,10 +396,10 @@ class MassFuncDespali16(MassFunc):
     def _get_fsigma(self, cosmo, sigM, a, lnM):
         status = 0
         delta_c, status = lib.dc_NakamuraSuto(cosmo.cosmo, a, status)
-        check(status)
+        check(status, cosmo=cosmo)
 
         Dv, status = lib.Dv_BryanNorman(cosmo.cosmo, a, status)
-        check(status)
+        check(status, cosmo=cosmo)
 
         x = np.log10(self.mdef.get_Delta(cosmo, a) *
                      omega_x(cosmo, a, self.mdef.rho_type) / Dv)

--- a/pyccl/halos/massdef.py
+++ b/pyccl/halos/massdef.py
@@ -57,7 +57,7 @@ def convert_concentration(cosmo, c_old, Delta_old, Delta_new):
     if np.isscalar(c_old):
         c_new = c_new[0]
 
-    check(status)
+    check(status, cosmo=cosmo)
     return c_new
 
 

--- a/pyccl/halos/profiles.py
+++ b/pyccl/halos/profiles.py
@@ -875,7 +875,7 @@ class HaloProfileEinasto(HaloProfile):
 
         status = 0
         norm, status = lib.einasto_norm(R_s, R_M, alpha, M_use.size, status)
-        check(status)
+        check(status, cosmo=cosmo)
         norm = M_use / norm
 
         x = r_use[None, :] / R_s[:, None]
@@ -945,7 +945,7 @@ class HaloProfileHernquist(HaloProfile):
 
         status = 0
         norm, status = lib.hernquist_norm(R_s, R_M, M_use.size, status)
-        check(status)
+        check(status, cosmo=cosmo)
         norm = M_use / norm
 
         x = r_use[None, :] / R_s[:, None]

--- a/pyccl/nl_pt/power.py
+++ b/pyccl/nl_pt/power.py
@@ -521,7 +521,7 @@ def get_pt_pk2d(cosmo, tracer1, tracer2=None, ptc=None,
         status = 0
         na = lib.get_pk_spline_na(cosmo.cosmo)
         a_arr, status = lib.get_pk_spline_a(cosmo.cosmo, na, status)
-        check(status)
+        check(status, cosmo=cosmo)
 
     if tracer2 is None:
         tracer2 = tracer1

--- a/pyccl/pk2d.py
+++ b/pyccl/pk2d.py
@@ -101,9 +101,9 @@ class Pk2D(object):
             nk = lib.get_pk_spline_nk(cosmo.cosmo)
             na = lib.get_pk_spline_na(cosmo.cosmo)
             a_arr, status = lib.get_pk_spline_a(cosmo.cosmo, na, status)
-            check(status)
+            check(status, cosmo=cosmo)
             lk_arr, status = lib.get_pk_spline_lk(cosmo.cosmo, nk, status)
-            check(status)
+            check(status, cosmo=cosmo)
 
             # Compute power spectrum on 2D grid
             pkflat = np.zeros([na, nk])
@@ -118,7 +118,7 @@ class Pk2D(object):
                                                         int(extrap_order_lok),
                                                         int(extrap_order_hik),
                                                         int(is_logp), status)
-        check(status)
+        check(status, cosmo=cosmo)
         self.has_psp = True
 
     @classmethod

--- a/pyccl/power.py
+++ b/pyccl/power.py
@@ -95,7 +95,7 @@ def sigmaM(cosmo, M, a):
     status = 0
     sigM, status = lib.sigM_vec(cosmo.cosmo, a, logM,
                                 len(logM), status)
-    check(status)
+    check(status, cosmo=cosmo)
     if np.ndim(M) == 0:
         sigM = sigM[0]
     return sigM

--- a/pyccl/tests/test_tracers.py
+++ b/pyccl/tests/test_tracers.py
@@ -124,3 +124,30 @@ def test_tracer_transfer_smoke(tracer_type):
             else:
                 shap = (0, )
             assert tf.shape == shap
+
+
+def test_tracer_nz_support():
+    z_max = 1.0
+    a = np.linspace(1/(1+z_max), 1.0, 100)
+
+    background_def = {"a": a,
+                      "chi": ccl.comoving_radial_distance(COSMO, a),
+                      "h_over_h0": ccl.h_over_h0(COSMO, a)}
+
+    calculator_cosmo = ccl.CosmologyCalculator(
+        Omega_c=0.27, Omega_b=0.045, h=0.67,
+        sigma8=0.8, n_s=0.96,
+        background=background_def)
+
+    z = np.linspace(0., 2., 2000)
+    n = dndz(z)
+
+    with pytest.raises(ValueError):
+        _ = ccl.WeakLensingTracer(calculator_cosmo, (z, n))
+
+    with pytest.raises(ValueError):
+        _ = ccl.NumberCountsTracer(calculator_cosmo, has_rsd=False,
+                                   dndz=(z, n), bias=(z, np.ones_like(z)))
+
+    with pytest.raises(ValueError):
+        _ = ccl.CMBLensingTracer(calculator_cosmo, z_source=2.0)


### PR DESCRIPTION
This catches the case where the tracer redshift support is wider than the interal background spline. This is mostly useful to prevent opaque error in calculator mode. A similar check should probably be made for the power spectrum as well.