### PR TITLE
Option to compile CCL with debugging symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,17 +55,26 @@ include(BuildGSL)
 # option to use a pre-installed version of angpow
 #include(BuildAngpow)
 
+# Check if OpemMP is installed (only matters for macOS clang)
+find_package(OpenMP)
+
 # Compilation flags
 set(CMAKE_C_FLAGS_RELEASE "-O3 -fomit-frame-pointer -fno-common -fPIC -std=gnu99 -DHAVE_ANGPOW")
 set(CMAKE_C_FLAGS_DEBUG   "-Og -g -fomit-frame-pointer -fno-common -fPIC -std=gnu99 -DHAVE_ANGPOW")
-if ((NOT "${CMAKE_C_COMPILER_ID}" MATCHES "^(Apple)?Clang$") OR FORCE_OPENMP)
-    # When not using Clang and in Release mode, enabling OpenMP support
+
+if (("${CMAKE_C_COMPILER_ID}" MATCHES "^(Apple)?Clang$") AND OpenMP_C_FOUND) 
+    # OpenMP flags for macOS clang
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Xpreprocessor -fopenmp")
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Xpreprocessor -fopenmp")
+else()
+    # OpenMP flags for all other compilers clang
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fopenmp")
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fopenmp")
-    if(DEFINED ENV{CONDA_PREFIX})
-        include_directories("$ENV{CONDA_PREFIX}/include")
-        add_link_options("LINKER:-rpath,$ENV{CONDA_PREFIX}/lib")
-    endif()
+endif()
+
+if(DEFINED ENV{CONDA_PREFIX})
+    include_directories("$ENV{CONDA_PREFIX}/include")
+    add_link_options("LINKER:-rpath,$ENV{CONDA_PREFIX}/lib")
 endif()
 
 # Define include and library directories for external dependencies
@@ -97,7 +106,7 @@ endif()
 # The reason for building ccl as a shared library is that we can link it to
 # class directly, and it's not a dependency anymore
 add_library(ccl SHARED $<TARGET_OBJECTS:objlib>)
-target_link_libraries(ccl ${GSL_LIBRARIES} ${FFTW_LIBRARIES} ${CLASS_LIBRARIES} ${ANGPOW_LIBRARIES} m)
+target_link_libraries(ccl ${GSL_LIBRARIES} ${FFTW_LIBRARIES} ${CLASS_LIBRARIES} ${ANGPOW_LIBRARIES} m $<$<BOOL:OpenMP_C_FOUND>:OpenMP::OpenMP_C>)
 
 # Builds the test suite
 add_executable(check_ccl ${TEST_SRC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,10 +62,12 @@ find_package(OpenMP)
 set(CMAKE_C_FLAGS_RELEASE "-O3 -fomit-frame-pointer -fno-common -fPIC -std=gnu99 -DHAVE_ANGPOW")
 set(CMAKE_C_FLAGS_DEBUG   "-Og -g -fomit-frame-pointer -fno-common -fPIC -std=gnu99 -DHAVE_ANGPOW")
 
-if (("${CMAKE_C_COMPILER_ID}" MATCHES "^(Apple)?Clang$") AND OpenMP_C_FOUND) 
-    # OpenMP flags for macOS clang
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Xpreprocessor -fopenmp")
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Xpreprocessor -fopenmp")
+if ("${CMAKE_C_COMPILER_ID}" MATCHES "^(Apple)?Clang$") 
+    if(FORCE_OPENMP OR OpenMP_C_FOUND)
+        # OpenMP flags for macOS clang
+        set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Xpreprocessor -fopenmp")
+        set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Xpreprocessor -fopenmp")
+    endif()
 else()
     # OpenMP flags for all other compilers clang
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fopenmp")
@@ -106,7 +108,7 @@ endif()
 # The reason for building ccl as a shared library is that we can link it to
 # class directly, and it's not a dependency anymore
 add_library(ccl SHARED $<TARGET_OBJECTS:objlib>)
-target_link_libraries(ccl ${GSL_LIBRARIES} ${FFTW_LIBRARIES} ${CLASS_LIBRARIES} ${ANGPOW_LIBRARIES} m $<$<BOOL:OpenMP_C_FOUND>:OpenMP::OpenMP_C>)
+target_link_libraries(ccl ${GSL_LIBRARIES} ${FFTW_LIBRARIES} ${CLASS_LIBRARIES} ${ANGPOW_LIBRARIES} m $<$<BOOL:${OpenMP_C_FOUND}>:OpenMP::OpenMP_C>)
 
 # Builds the test suite
 add_executable(check_ccl ${TEST_SRC})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ include(BuildGSL)
 
 # Compilation flags
 set(CMAKE_C_FLAGS_RELEASE "-O3 -fomit-frame-pointer -fno-common -fPIC -std=gnu99 -DHAVE_ANGPOW")
-set(CMAKE_C_FLAGS_DEBUG   "-Og -fomit-frame-pointer -fno-common -fPIC -std=gnu99 -DHAVE_ANGPOW")
+set(CMAKE_C_FLAGS_DEBUG   "-Og -g -fomit-frame-pointer -fno-common -fPIC -std=gnu99 -DHAVE_ANGPOW")
 if ((NOT "${CMAKE_C_COMPILER_ID}" MATCHES "^(Apple)?Clang$") OR FORCE_OPENMP)
     # When not using Clang and in Release mode, enabling OpenMP support
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -fopenmp")

--- a/readthedocs/source/developer_installation.rst
+++ b/readthedocs/source/developer_installation.rst
@@ -24,6 +24,25 @@ order to install CCL in this way. See :ref:`getting-cmake` for help installing
 you will need ``CAMB``, ``CLASS``, and ``FAST-PT`` installed. See the instructions for
 :ref:`boltzmann-codes` and :ref:`getting-fast-pt` for details.
 
+To compile the ``C`` code with debugging symbols, add the ``--debug`` option
+when calling ``setup.py``:
+
+.. code-block:: bash
+
+   $ python setup.py --debug develop
+
+Or with ``pip``:
+
+.. code-block:: bash
+
+   $ pip install --no-deps -e . --global-option=--debug
+
+To remove old build products that might conflict when re-compiling CCL, run
+
+.. code-block:: bash
+
+   $ python setup.py clean
+
 
 C-layer Dependencies and Requirements
 =====================================

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from setuptools.command.build_py import build_py as _build
 from setuptools.command.develop import develop as _develop
+from distutils.command.clean import clean as _clean
+from setuptools import Distribution as _distribution
 from setuptools import setup, find_packages
 from subprocess import call
 from io import open
@@ -8,12 +10,14 @@ import os
 import sys
 
 
-def _compile_ccl():
+def _compile_ccl(debug=False):
     call(["mkdir", "-p", "build"])
     v = sys.version_info
-    if call(["cmake", "-H.", "-Bbuild",
-             "-DPYTHON_VERSION=%d.%d.%d" % (
-                v.major, v.minor, v.micro)]) != 0:
+    cmd = ["cmake", "-H.", "-Bbuild",
+           "-DPYTHON_VERSION=%d.%d.%d" % (v.major, v.minor, v.micro)]
+    if debug:
+        cmd += ["-DCMAKE_BUILD_TYPE=Debug"]
+    if call(cmd) != 0:
         raise Exception(
             "Could not run CMake configuration. Make sure "
             "CMake is installed !")
@@ -32,18 +36,40 @@ def _compile_ccl():
                         "SWIG must have failed.")
 
 
-class build(_build):
+class Distribution(_distribution):
+    global_options = _distribution.global_options
+
+    global_options += [
+        ("debug", None, "Debug build"),
+    ]
+
+    def __init__(self, attr=None):
+        self.debug = False
+        super().__init__(attr)
+
+
+class Build(_build):
     """Specialized Python source builder."""
+
     def run(self):
-        _compile_ccl()
+        _compile_ccl(debug=self.distribution.debug)
         _build.run(self)
 
 
-class develop(_develop):
+class Develop(_develop):
     """Specialized Python develop mode."""
     def run(self):
-        _compile_ccl()
+        _compile_ccl(debug=self.distribution.debug)
         _develop.run(self)
+
+
+class Clean(_clean):
+    """Remove the copied _ccllib.so"""
+    def run(self):
+        if os.path.isfile("pyccl/_ccllib.so"):
+            os.remove("pyccl/_ccllib.so")
+            print("Removed pyccl/_ccllib.so")
+        _clean.run(self)
 
 
 # read the contents of the README file
@@ -62,9 +88,10 @@ setup(
     package_data={'pyccl': ['_ccllib.so']},
     include_package_data=True,
     use_scm_version=True,
+    distclass=Distribution,
     setup_requires=['setuptools_scm'],
     install_requires=['numpy', 'pyyaml'],
-    cmdclass={'build_py': build, 'develop': develop},
+    cmdclass={'build_py': Build, 'develop': Develop, 'clean': Clean},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from setuptools import setup, find_packages
 from subprocess import call
 from io import open
 import os
+import shutil
 import sys
 
 
@@ -70,6 +71,8 @@ class Clean(_clean):
             os.remove("pyccl/_ccllib.so")
             print("Removed pyccl/_ccllib.so")
         _clean.run(self)
+        shutil.rmtree("build")
+        print("Removed build.")
 
 
 # read the contents of the README file
@@ -103,5 +106,5 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Scientific/Engineering :: Physics'
-      ]
-    )
+    ]
+)


### PR DESCRIPTION
This adds the `--debug` option to enable debug builds. Also adds the `clean` command to remove `pyccl/_ccllib.so` (not removing that can cause very obscure crashes) and `build`.

Also enables openmp on macOS clang.