### PR TITLE
Fix WL functions in pyccl.halos.profiles

### DIFF
--- a/benchmarks/test_haloprofile.py
+++ b/benchmarks/test_haloprofile.py
@@ -146,6 +146,8 @@ def test_weak_lensing_functions():
         np.log(rmax/rmin) * np.arange(data.shape[0]) / (data.shape[0]-1))
 
     r_al = r / a_lens
+    len_r = len(r)
+    a_source = [a_source]*len_r
 
     mdef = ccl.halos.MassDef(mDelta, 'matter')
     c = ccl.halos.ConcentrationConstant(c=concentration, mdef=mdef)

--- a/pyccl/halos/profiles.py
+++ b/pyccl/halos/profiles.py
@@ -292,7 +292,7 @@ class HaloProfile(object):
             M (float or array_like): halo mass in units of M_sun.
             a_lens (float): scale factor of lens.
             a_source (float or array_like): scale factor of source.
-                If array_like, it must have the same shape as r.
+                If array_like, it must have the same shape as `r`.
             mass_def (:class:`~pyccl.halos.massdef.MassDef`):
                 a mass definition object.
 
@@ -326,7 +326,7 @@ class HaloProfile(object):
             M (float or array_like): halo mass in units of M_sun.
             a_lens (float): scale factor of lens.
             a_source (float or array_like): source's scale factor.
-                If array_like, it must have the same shape as r.
+                If array_like, it must have the same shape as `r`.
             mass_def (:class:`~pyccl.halos.massdef.MassDef`):
                 a mass definition object.
 
@@ -359,7 +359,7 @@ class HaloProfile(object):
             M (float or array_like): halo mass in units of M_sun.
             a_lens (float): scale factor of lens.
             a_source (float or array_like): source's scale factor.
-                If array_like, it must have the same shape as r.
+                If array_like, it must have the same shape as `r`.
             mass_def (:class:`~pyccl.halos.massdef.MassDef`):
                 a mass definition object.
 
@@ -387,7 +387,7 @@ class HaloProfile(object):
             M (float or array_like): halo mass in units of M_sun.
             a_lens (float): scale factor of lens.
             a_source (float or array_like): source's scale factor.
-                If array_like, it must have the same shape as r.
+                If array_like, it must have the same shape as `r`.
             mass_def (:class:`~pyccl.halos.massdef.MassDef`):
                 a mass definition object.
 

--- a/pyccl/halos/profiles.py
+++ b/pyccl/halos/profiles.py
@@ -290,7 +290,7 @@ class HaloProfile(object):
             cosmo (:class:`~pyccl.core.Cosmology`): A Cosmology object.
             r (float or array_like): comoving radius in Mpc.
             M (float or array_like): halo mass in units of M_sun.
-            a_lens (float or array_like): scale factor of lens.
+            a_lens (float): scale factor of lens.
             a_source (float or array_like): scale factor of source.
             mass_def (:class:`~pyccl.halos.massdef.MassDef`):
                 a mass definition object.
@@ -323,7 +323,7 @@ class HaloProfile(object):
             cosmo (:class:`~pyccl.core.Cosmology`): A Cosmology object.
             r (float or array_like): comoving radius in Mpc.
             M (float or array_like): halo mass in units of M_sun.
-            a_lens (float or array_like): lens' scale factor.
+            a_lens (float): scale factor of lens.
             a_source (float or array_like): source's scale factor.
             mass_def (:class:`~pyccl.halos.massdef.MassDef`):
                 a mass definition object.
@@ -355,7 +355,7 @@ class HaloProfile(object):
             cosmo (:class:`~pyccl.core.Cosmology`): A Cosmology object.
             r (float or array_like): comoving radius in Mpc.
             M (float or array_like): halo mass in units of M_sun.
-            a_lens (float or array_like): lens' scale factor.
+            a_lens (float): scale factor of lens.
             a_source (float or array_like): source's scale factor.
             mass_def (:class:`~pyccl.halos.massdef.MassDef`):
                 a mass definition object.
@@ -382,7 +382,7 @@ class HaloProfile(object):
             cosmo (:class:`~pyccl.core.Cosmology`): A Cosmology object.
             r (float or array_like): comoving radius in Mpc.
             M (float or array_like): halo mass in units of M_sun.
-            a_lens (float or array_like): lens' scale factor.
+            a_lens (float): scale factor of lens.
             a_source (float or array_like): source's scale factor.
             mass_def (:class:`~pyccl.halos.massdef.MassDef`):
                 a mass definition object.

--- a/pyccl/halos/profiles.py
+++ b/pyccl/halos/profiles.py
@@ -292,6 +292,7 @@ class HaloProfile(object):
             M (float or array_like): halo mass in units of M_sun.
             a_lens (float): scale factor of lens.
             a_source (float or array_like): scale factor of source.
+                If array_like, it must have the same shape as r.
             mass_def (:class:`~pyccl.halos.massdef.MassDef`):
                 a mass definition object.
 
@@ -325,6 +326,7 @@ class HaloProfile(object):
             M (float or array_like): halo mass in units of M_sun.
             a_lens (float): scale factor of lens.
             a_source (float or array_like): source's scale factor.
+                If array_like, it must have the same shape as r.
             mass_def (:class:`~pyccl.halos.massdef.MassDef`):
                 a mass definition object.
 
@@ -357,6 +359,7 @@ class HaloProfile(object):
             M (float or array_like): halo mass in units of M_sun.
             a_lens (float): scale factor of lens.
             a_source (float or array_like): source's scale factor.
+                If array_like, it must have the same shape as r.
             mass_def (:class:`~pyccl.halos.massdef.MassDef`):
                 a mass definition object.
 
@@ -384,6 +387,7 @@ class HaloProfile(object):
             M (float or array_like): halo mass in units of M_sun.
             a_lens (float): scale factor of lens.
             a_source (float or array_like): source's scale factor.
+                If array_like, it must have the same shape as r.
             mass_def (:class:`~pyccl.halos.massdef.MassDef`):
                 a mass definition object.
 

--- a/pyccl/halos/profiles.py
+++ b/pyccl/halos/profiles.py
@@ -300,6 +300,9 @@ class HaloProfile(object):
                 :math:`\\kappa`
         """
         Sigma = self.projected(cosmo, r, M, a_lens, mass_def) / a_lens**2
+        if np.iterable(a_source):
+            a_source = np.array(a_source)
+            a_lens = np.full_like(a_source, a_lens)
         Sigma_crit = sigma_critical(cosmo, a_lens, a_source)
         return Sigma / Sigma_crit
 
@@ -331,6 +334,9 @@ class HaloProfile(object):
         """
         Sigma = self.projected(cosmo, r, M, a_lens, mass_def)
         Sigma_bar = self.cumul2d(cosmo, r, M, a_lens, mass_def)
+        if np.iterable(a_source):
+            a_source = np.array(a_source)
+            a_lens = np.full_like(a_source, a_lens)
         Sigma_crit = sigma_critical(cosmo, a_lens, a_source)
         return (Sigma_bar - Sigma) / (Sigma_crit * a_lens**2)
 

--- a/pyccl/halos/profiles.py
+++ b/pyccl/halos/profiles.py
@@ -335,6 +335,7 @@ class HaloProfile(object):
         Sigma = self.projected(cosmo, r, M, a_lens, mass_def)
         Sigma_bar = self.cumul2d(cosmo, r, M, a_lens, mass_def)
         if hasattr(a_source, "__iter__"):
+            a_source = np.array(a_source)
             a_lens = np.full_like(a_source, a_lens)
         Sigma_crit = sigma_critical(cosmo, a_lens, a_source)
         return (Sigma_bar - Sigma) / (Sigma_crit * a_lens**2)

--- a/pyccl/halos/profiles.py
+++ b/pyccl/halos/profiles.py
@@ -300,7 +300,7 @@ class HaloProfile(object):
                 :math:`\\kappa`
         """
         Sigma = self.projected(cosmo, r, M, a_lens, mass_def) / a_lens**2
-        if np.iterable(a_source):
+        if hasattr(a_source, "__iter__"):
             a_source = np.array(a_source)
             a_lens = np.full_like(a_source, a_lens)
         Sigma_crit = sigma_critical(cosmo, a_lens, a_source)
@@ -334,8 +334,7 @@ class HaloProfile(object):
         """
         Sigma = self.projected(cosmo, r, M, a_lens, mass_def)
         Sigma_bar = self.cumul2d(cosmo, r, M, a_lens, mass_def)
-        if np.iterable(a_source):
-            a_source = np.array(a_source)
+        if hasattr(a_source, "__iter__"):
             a_lens = np.full_like(a_source, a_lens)
         Sigma_crit = sigma_critical(cosmo, a_lens, a_source)
         return (Sigma_bar - Sigma) / (Sigma_crit * a_lens**2)


### PR DESCRIPTION
In pyccl.halos.profiles, convergence, shear, reduced_shear and magnification can now handle array_like a_source.