### PR TITLE
Allow user defined biases for SSC trispectrum

### DIFF
--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -1006,10 +1006,13 @@ def halomod_Tk3D_SSC(cosmo, hmc,
     .. math::
         \\frac{\\partial P_{u,v}(k)}{\\partial\\delta_L} =
         \\left(\\frac{68}{21}-\\frac{d\\log k^3P_L(k)}{d\\log k}\\right)
-        P_L(k)I^1_1(k,|u)I^1_1(k,|v)+I^1_2(k|u,v)
+        P_L(k)I^1_1(k,|u)I^1_1(k,|v)+I^1_2(k|u,v) - (b_{uu} + b_{vv})
+        P_{u,v}(k)
 
     where the :math:`I^a_b` are defined in the documentation
-    of :meth:`~HMCalculator.I_1_1` and  :meth:`~HMCalculator.I_1_2`.
+    of :meth:`~HMCalculator.I_1_1` and  :meth:`~HMCalculator.I_1_2` and
+    :math:`b_{uu}` and :math:`b_{vv}` are the linear halo biases for quantities
+    :math:`u` and :math:`v`, respectively (zero if they are not clustering).
 
     Args:
         cosmo (:class:`~pyccl.core.Cosmology`): a Cosmology object.

--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -995,7 +995,8 @@ def halomod_Tk3D_SSC(cosmo, hmc,
                      normprof3=False, normprof4=False,
                      p_of_k_a=None, lk_arr=None, a_arr=None,
                      extrap_order_lok=1, extrap_order_hik=1,
-                     use_log=False):
+                     use_log=False, bias1=None, bias2=None,
+                     bias3=None, bias4=None):
     """ Returns a :class:`~pyccl.tk3d.Tk3D` object containing
     the super-sample covariance trispectrum, given by the tensor
     product of the power spectrum responses associated with the
@@ -1059,6 +1060,12 @@ def halomod_Tk3D_SSC(cosmo, hmc,
         use_log (bool): if `True`, the trispectrum will be
             interpolated in log-space (unless negative or
             zero values are found).
+        bias1 (float or array): bias for the halo profile 1. It can be a float
+        or an array of length lk_arr. If given, use this bias instead the one
+        computed from the halo model.
+        bias2 (float or array): as bias1 but for prof2
+        bias3 (float or array): as bias1 but for prof3
+        bias4 (float or array): as bias1 but for prof4
 
     Returns:
         :class:`~pyccl.tk3d.Tk3D`: SSC effective trispectrum.
@@ -1187,12 +1194,12 @@ def halomod_Tk3D_SSC(cosmo, hmc,
             P_12 = norm12 * (pk * i11_1 * i11_2 + i02_12)
 
             if prof1.is_number_counts:
-                b1 = i11_1 * norm1
+                b1 = i11_1 * norm1 if bias1 is None else bias1
 
             if prof2 is None:
-                b2 = b1
+                b2 = b1 if bias2 is None else bias2
             elif prof2.is_number_counts:
-                b2 = i11_2 * norm2
+                b2 = i11_2 * norm2 if bias2 is None else bias2
 
             dpk12[ia, :] -= (b1 + b2) * P_12
 
@@ -1208,14 +1215,14 @@ def halomod_Tk3D_SSC(cosmo, hmc,
             P_34 = norm34 * (pk * i11_3 * i11_4 + i02_34)
 
             if prof3 is None:
-                b3 = b1
+                b3 = b1 if bias3 is None else bias3
             elif prof3.is_number_counts:
-                b3 = i11_3 * norm3
+                b3 = i11_3 * norm3 if bias3 is None else bias3
 
             if prof4 is None:
-                b4 = b3
+                b4 = b3 if bias4 is None else bias4
             elif prof4.is_number_counts:
-                b4 = i11_4 * norm4
+                b4 = i11_4 * norm4 if bias4 is None else bias4
 
             dpk34[ia, :] -= (b3 + b4) * P_34
 

--- a/pyccl/tests/test_tkkssc.py
+++ b/pyccl/tests/test_tkkssc.py
@@ -28,7 +28,7 @@ AA = 1.0
 
 
 def get_ssc_counterterm_gc(k, a, hmc, prof1, prof2, prof12_2pt,
-                           normalize=False):
+                           normalize=False, bias1=None, bias2=None):
 
     P_12 = b1 = b2 = np.zeros_like(k)
     if prof1.is_number_counts or prof2.is_number_counts:
@@ -48,9 +48,15 @@ def get_ssc_counterterm_gc(k, a, hmc, prof1, prof2, prof12_2pt,
         P_12 = norm12 * (pk * i11_1 * i11_2 + i02_12)
 
         if prof1.is_number_counts:
-            b1 = halomod_bias_1pt(COSMO, hmc, k, a, prof1) * norm1
+            if bias1 is None:
+                b1 = halomod_bias_1pt(COSMO, hmc, k, a, prof1) * norm1
+            else:
+                b1 = bias1
         if prof2.is_number_counts:
-            b2 = halomod_bias_1pt(COSMO, hmc, k, a, prof2) * norm2
+            if bias2 is None:
+                b2 = halomod_bias_1pt(COSMO, hmc, k, a, prof2) * norm2
+            else:
+                b2 = bias2
 
     return (b1 + b2) * P_12
 
@@ -195,7 +201,26 @@ def test_tkkssc_errors():
                          # All is_number_counts = True
                          {'prof1': P2, 'prof2': P2,
                           'prof3': P2, 'prof4': P2},
-
+                         # Input biases
+                         {'prof1': P2, 'prof2': P2,
+                          'prof3': P2, 'prof4': P2,
+                          'bias1': 1, 'bias2': 2},
+                         # Input biases
+                         {'prof1': P2, 'prof2': P2,
+                          'prof3': P2, 'prof4': P2,
+                          'bias3': 3, 'bias4': 2},
+                         # Input biases
+                         {'prof1': P2, 'prof2': P2,
+                          'prof3': P2, 'prof4': P2,
+                          'bias1': 1, 'bias2': 2, 'bias3': 3},
+                         # Input biases
+                         {'prof1': P2, 'prof2': P2,
+                          'prof3': P2, 'prof4': P2,
+                          'bias1': 1, 'bias2': 2, 'bias3': 3, 'bias4':4},
+                         # Input biases as arr
+                         {'prof1': P2, 'prof2': P2,
+                          'prof3': P2, 'prof4': P2,
+                          'bias1': np.ones_like(KK)}
                          ]
                          )
 def test_tkkssc_counterterms_gc(kwargs):
@@ -241,9 +266,13 @@ def test_tkkssc_counterterms_gc(kwargs):
     tkc34 = []
     for aa in a_arr:
         tkc12.append(get_ssc_counterterm_gc(k_arr, aa, hmc, kwargs['prof1'],
-                                            kwargs['prof2'], PKC))
+                                            kwargs['prof2'], PKC,
+                                            bias1=kwargs.get('bias1', None),
+                                            bias2=kwargs.get('bias2', None)))
         tkc34.append(get_ssc_counterterm_gc(k_arr, aa, hmc, kwargs['prof3'],
-                                            kwargs['prof4'], PKC))
+                                            kwargs['prof4'], PKC,
+                                            bias1=kwargs.get('bias3', None),
+                                            bias2=kwargs.get('bias4', None)))
     tkc12 = np.array(tkc12)
     tkc34 = np.array(tkc34)
 


### PR DESCRIPTION
As a first step towards the SSC implementation in TJPCov I think it would be useful to avoid having to input many halo model parameters, that will be sample specific, to compute the SSC. Instead, the user could compute the SSC using the galaxy biases that one gets fitting the power spectrum.

I have also fixed the docstring.