### PR TITLE
Super Sample Covariance with linear galaxy bias approximation

### DIFF
--- a/pyccl/halos/__init__.py
+++ b/pyccl/halos/__init__.py
@@ -52,7 +52,8 @@ from .halo_model import (  # noqa
     halomod_Pk2D,
     halomod_trispectrum_1h,
     halomod_Tk3D_1h,
-    halomod_Tk3D_SSC)
+    halomod_Tk3D_SSC,
+    halomod_Tk3D_SSC_linear_bias)
 
 # CIB profiles
 from .profiles_cib import (  # noqa

--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -2,7 +2,7 @@ import warnings
 from .. import ccllib as lib
 from .hmfunc import MassFunc
 from .hbias import HaloBias
-from .profiles import HaloProfile
+from .profiles import HaloProfile, HaloProfileNFW
 from .profiles_2pt import Profile2pt
 from ..core import check
 from ..pk2d import Pk2D
@@ -330,7 +330,7 @@ class HMCalculator(object):
              value of `k`.
         """
         # Compute mass function
-        self._get_ingredients(a, cosmo, False)
+        self._get_ingredients(a, cosmo, True)
         uk = prof_2pt.fourier_2pt(prof1, cosmo, k, self._mass, a,
                                   prof2=prof2,
                                   mass_def=self._mdef).T
@@ -988,6 +988,163 @@ def halomod_Tk3D_1h(cosmo, hmc,
     return tk3d
 
 
+def halomod_Tk3D_SSC_linear_bias(cosmo, hmc, prof, bias1=1, bias2=1, bias3=1,
+                                 bias4=1,
+                                 is_number_counts1=False,
+                                 is_number_counts2=False,
+                                 is_number_counts3=False,
+                                 is_number_counts4=False,
+                                 p_of_k_a=None, lk_arr=None,
+                                 a_arr=None, extrap_order_lok=1,
+                                 extrap_order_hik=1, use_log=False):
+    """ Returns a :class:`~pyccl.tk3d.Tk3D` object containing
+    the super-sample covariance trispectrum, given by the tensor
+    product of the power spectrum responses associated with the
+    two pairs of quantities being correlated. Each response is
+    calculated as:
+
+    .. math::
+        \\frac{\\partial P_{u,v}(k)}{\\partial\\delta_L} =
+        \\left(\\frac{68}{21}-\\frac{d\\log k^3P_L(k)}{d\\log k}\\right)
+        b_u b_v P_L(k)+I^1_2(k|u,v) - (b_{u} + b_{v})
+        P_{u,v}(k)
+
+    where the :math:`I^1_2` is defined in the documentation
+    :meth:`~HMCalculator.I_1_2` and :math:`b_{}` and :math:`b_{vv}` are the
+    linear halo biases for quantities :math:`u` and :math:`v`, respectively
+    (zero if they are not clustering).
+
+    Args:
+        cosmo (:class:`~pyccl.core.Cosmology`): a Cosmology object.
+        hmc (:class:`HMCalculator`): a halo model calculator.
+        prof (:class:`~pyccl.halos.profiles.HaloProfile`): halo NFW
+            profile.
+        bias1 (float or array): linear galaxy bias for quantity 1. If an array,
+        it has to have the shape (a_arr, lk_arr).
+        bias2 (float or array): linear galaxy bias for quantity 2.
+        bias3 (float or array): linear galaxy bias for quantity 3.
+        bias4 (float or array): linear galaxy bias for quantity 4.
+        is_number_counts1 (bool): If True, quantity 1 will be considered
+        number counts and the clustering counter terms computed. Default False.
+        is_number_counts2 (bool): as is_number_counts1 but for quantity 2.
+        is_number_counts3 (bool): as is_number_counts1 but for quantity 3.
+        is_number_counts4 (bool): as is_number_counts1 but for quantity 4.
+        p_of_k_a (:class:`~pyccl.pk2d.Pk2D`): a `Pk2D` object to
+            be used as the linear matter power spectrum. If `None`,
+            the power spectrum stored within `cosmo` will be used.
+        a_arr (array): an array holding values of the scale factor
+            at which the trispectrum should be calculated for
+            interpolation. If `None`, the internal values used
+            by `cosmo` will be used.
+        lk_arr (array): an array holding values of the natural
+            logarithm of the wavenumber (in units of Mpc^-1) at
+            which the trispectrum should be calculated for
+            interpolation. If `None`, the internal values used
+            by `cosmo` will be used.
+        extrap_order_lok (int): extrapolation order to be used on
+            k-values below the minimum of the splines. See
+            :class:`~pyccl.tk3d.Tk3D`.
+        extrap_order_hik (int): extrapolation order to be used on
+            k-values above the maximum of the splines. See
+            :class:`~pyccl.tk3d.Tk3D`.
+        use_log (bool): if `True`, the trispectrum will be
+            interpolated in log-space (unless negative or
+            zero values are found).
+
+    Returns:
+        :class:`~pyccl.tk3d.Tk3D`: SSC effective trispectrum.
+    """
+    if lk_arr is None:
+        status = 0
+        nk = lib.get_pk_spline_nk(cosmo.cosmo)
+        lk_arr, status = lib.get_pk_spline_lk(cosmo.cosmo, nk, status)
+        check(status, cosmo=cosmo)
+    if a_arr is None:
+        status = 0
+        na = lib.get_pk_spline_na(cosmo.cosmo)
+        a_arr, status = lib.get_pk_spline_a(cosmo.cosmo, na, status)
+        check(status, cosmo=cosmo)
+
+    # Make sure biases are of the form number of a x number of k
+    ones = np.ones((a_arr.size, lk_arr.size))
+    bias1 *= ones
+    bias2 *= ones
+    bias3 *= ones
+    bias4 *= ones
+
+    k_use = np.exp(lk_arr)
+
+    # Check inputs
+    if not isinstance(prof, HaloProfileNFW):
+        raise TypeError("prof must be of type `HaloProfileNFW`")
+    prof_2pt = Profile2pt()
+
+    # Power spectrum
+    if isinstance(p_of_k_a, Pk2D):
+        pk2d = p_of_k_a
+    elif (p_of_k_a is None) or (str(p_of_k_a) == 'linear'):
+        pk2d = cosmo.get_linear_power('delta_matter:delta_matter')
+    elif str(p_of_k_a) == 'nonlinear':
+        pk2d = cosmo.get_nonlin_power('delta_matter:delta_matter')
+    else:
+        raise TypeError("p_of_k_a must be `None`, \'linear\', "
+                        "\'nonlinear\' or a `Pk2D` object")
+
+    na = len(a_arr)
+    nk = len(k_use)
+    dpk12 = np.zeros([na, nk])
+    dpk34 = np.zeros([na, nk])
+    for ia, aa in enumerate(a_arr):
+        # Compute profile normalizations
+        norm = hmc.profile_norm(cosmo, aa, prof) ** 2
+        i12 = hmc.I_1_2(cosmo, k_use, aa, prof, prof_2pt, prof) * norm
+
+        pk = pk2d.eval(k_use, aa, cosmo)
+        dpk = pk2d.eval_dlogpk_dlogk(k_use, aa, cosmo)
+        # ~ [(47/21 - 1/3 dlogPk/dlogk) * Pk+I12 ] * bias1 * bias2
+        dpk12[ia, :] = dpk34[ia, :] = ((2.2380952381-dpk/3)*pk + i12)
+
+        # Counter terms for clustering (i.e. - (bA + bB) * PAB
+        if is_number_counts1 or is_number_counts2 or is_number_counts3 or \
+           is_number_counts4:
+            b1 = b2 = b3 = b4 = np.zeros_like(k_use)
+
+            i02 = hmc.I_0_2(cosmo, k_use, aa, prof, prof_2pt, prof) * norm
+            P_12 = P_34 = pk + i02
+
+            if is_number_counts1:
+                b1 = bias1[ia]
+            if is_number_counts2:
+                b2 = bias2[ia]
+            if is_number_counts3:
+                b3 = bias3[ia]
+            if is_number_counts4:
+                b4 = bias4[ia]
+
+            dpk12[ia, :] -= (b1 + b2) * P_12
+            dpk34[ia, :] -= (b3 + b4) * P_34
+
+    dpk12 *= bias1 * bias2
+    dpk34 *= bias3 * bias4
+
+    if use_log:
+        if np.any(dpk12 <= 0) or np.any(dpk34 <= 0):
+            warnings.warn(
+                "Some values were not positive. "
+                "Will not interpolate in log-space.",
+                category=CCLWarning)
+            use_log = False
+        else:
+            dpk12 = np.log(dpk12)
+            dpk34 = np.log(dpk34)
+
+    tk3d = Tk3D(a_arr=a_arr, lk_arr=lk_arr,
+                pk1_arr=dpk12, pk2_arr=dpk34,
+                extrap_order_lok=extrap_order_lok,
+                extrap_order_hik=extrap_order_hik, is_logt=use_log)
+    return tk3d
+
+
 def halomod_Tk3D_SSC(cosmo, hmc,
                      prof1, prof2=None, prof12_2pt=None,
                      prof3=None, prof4=None, prof34_2pt=None,
@@ -1005,10 +1162,13 @@ def halomod_Tk3D_SSC(cosmo, hmc,
     .. math::
         \\frac{\\partial P_{u,v}(k)}{\\partial\\delta_L} =
         \\left(\\frac{68}{21}-\\frac{d\\log k^3P_L(k)}{d\\log k}\\right)
-        P_L(k)I^1_1(k,|u)I^1_1(k,|v)+I^1_2(k|u,v)
+        P_L(k)I^1_1(k,|u)I^1_1(k,|v)+I^1_2(k|u,v) - (b_{u} + b_{v})
+        P_{u,v}(k)
 
     where the :math:`I^a_b` are defined in the documentation
-    of :meth:`~HMCalculator.I_1_1` and  :meth:`~HMCalculator.I_1_2`.
+    of :meth:`~HMCalculator.I_1_1` and  :meth:`~HMCalculator.I_1_2` and
+    :math:`b_{uu}` and :math:`b_{vv}` are the linear halo biases for quantities
+    :math:`u` and :math:`v`, respectively (zero if they are not clustering).
 
     Args:
         cosmo (:class:`~pyccl.core.Cosmology`): a Cosmology object.

--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -1004,10 +1004,9 @@ def halomod_Tk3D_SSC_linear_bias(cosmo, hmc, prof, bias1=1, bias2=1, bias3=1,
     calculated as:
 
     .. math::
-        \\frac{\\partial P_{u,v}(k)}{\\partial\\delta_L} =
+        \\frac{\\partial P_{u,v}(k)}{\\partial\\delta_L} = b_u b_v \\left(
         \\left(\\frac{68}{21}-\\frac{d\\log k^3P_L(k)}{d\\log k}\\right)
-        b_u b_v \\left(P_L(k)+I^1_2(k|u,v) - (b_{u} + b_{v})
-        P_{u,v}(k) \\right)
+        P_L(k)+I^1_2(k|u,v) - (b_{u} + b_{v}) P_{u,v}(k) \\right)
 
     where the :math:`I^1_2` is defined in the documentation
     :meth:`~HMCalculator.I_1_2` and :math:`b_{}` and :math:`b_{vv}` are the

--- a/pyccl/tests/test_tkkssc.py
+++ b/pyccl/tests/test_tkkssc.py
@@ -386,7 +386,7 @@ def test_tkkssc_linear_bias_smoke_and_errors():
     # Error when p_of_k_a is wrong
     with pytest.raises(TypeError):
         ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=prof,
-                                                         p_of_k_a=P1)
+                                               p_of_k_a=P1)
 
     # Negative profile in logspace
     assert_warns(ccl.CCLWarning, ccl.halos.halomod_Tk3D_SSC_linear_bias,

--- a/pyccl/tests/test_tkkssc.py
+++ b/pyccl/tests/test_tkkssc.py
@@ -254,7 +254,8 @@ def test_tkkssc_counterterms_gc(kwargs):
 
 @pytest.mark.parametrize('kwargs', [{f'is_number_counts{i+1}': nc[i] for i in
                                      range(4)} for nc in
-                                    itertools.product([True,False], repeat=4)])
+                                    itertools.product([True, False],
+                                                      repeat=4)])
 def test_tkkssc_linear_bias(kwargs):
     hmc = ccl.halos.HMCalculator(COSMO, HMF, HBF, mass_def=M200,
                                  nlog10M=2)

--- a/pyccl/tests/test_tkkssc.py
+++ b/pyccl/tests/test_tkkssc.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import pyccl as ccl
 from pyccl.halos.halo_model import halomod_bias_1pt
+import itertools
 
 
 COSMO = ccl.Cosmology(
@@ -251,39 +252,9 @@ def test_tkkssc_counterterms_gc(kwargs):
     assert np.abs((tk_nogc_34 - tkc34) / tk_gc_34 - 1).max() < 1e-5
 
 
-@pytest.mark.parametrize('kwargs', [{'is_number_counts1': True,
-                                     'is_number_counts2': True,
-                                     'is_number_counts3': True,
-                                     'is_number_counts4': True},
-                                    {'is_number_counts1': True,
-                                     'is_number_counts2': True,
-                                     'is_number_counts3': True,
-                                     'is_number_counts4': False},
-                                    {'is_number_counts1': True,
-                                     'is_number_counts2': True,
-                                     'is_number_counts3': False,
-                                     'is_number_counts4': False},
-                                    {'is_number_counts1': True,
-                                     'is_number_counts2': True,
-                                     'is_number_counts3': False,
-                                     'is_number_counts4': True},
-                                    {'is_number_counts1': True,
-                                     'is_number_counts2': False,
-                                     'is_number_counts3': False,
-                                     'is_number_counts4': True},
-                                    {'is_number_counts1': True,
-                                     'is_number_counts2': False,
-                                     'is_number_counts3': False,
-                                     'is_number_counts4': False},
-                                    {'is_number_counts1': True,
-                                     'is_number_counts2': False,
-                                     'is_number_counts3': True,
-                                     'is_number_counts4': False},
-                                    {'is_number_counts1': False,
-                                     'is_number_counts2': False,
-                                     'is_number_counts3': True,
-                                     'is_number_counts4': False},
-                                    ])
+@pytest.mark.parametrize('kwargs', [{f'is_number_counts{i+1}': nc[i] for i in
+                                     range(4)} for nc in
+                                    itertools.product([True,False], repeat=4)])
 def test_tkkssc_linear_bias(kwargs):
     hmc = ccl.halos.HMCalculator(COSMO, HMF, HBF, mass_def=M200,
                                  nlog10M=2)
@@ -333,8 +304,6 @@ def test_tkkssc_linear_bias(kwargs):
     assert np.abs(tk_lin_12 / tk_12 - 1).max() < 1e-2
     assert np.abs(tk_lin_34 / tk_34 - 1).max() < 1e-2
 
-    print()
-    print('CASE', kwargs)
     # Now with clustering
     tkk_lin_nc = ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=prof,
                                                         bias1=bias1,

--- a/pyccl/tests/test_tkkssc.py
+++ b/pyccl/tests/test_tkkssc.py
@@ -370,26 +370,22 @@ def test_tkkssc_linear_bias_smoke_and_errors():
     prof = ccl.halos.HaloProfileNFW(ccl.halos.ConcentrationDuffy08(M200),
                                     fourier_analytic=True)
 
-    tkk_lin = ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=prof,
-                                                     p_of_k_a='linear')
+    ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=prof,
+                                           p_of_k_a='linear')
 
-    tkk_lin = ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=prof,
-                                                     p_of_k_a='nonlinear')
-
-    tkk_lin = ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=prof,
-                                                     p_of_k_a='nonlinear')
+    ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=prof,
+                                           p_of_k_a='nonlinear')
 
     pk = COSMO.get_nonlin_power()
-    tkk_lin = ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=prof,
-                                                     p_of_k_a=pk)
+    ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=prof, p_of_k_a=pk)
 
     # Error when prof is not NFW
     with pytest.raises(TypeError):
-        tkk_lin = ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=P2)
+        ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=P2)
 
     # Error when p_of_k_a is wrong
     with pytest.raises(TypeError):
-        tkk_lin = ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=prof,
+        ccl.halos.halomod_Tk3D_SSC_linear_bias(COSMO, hmc, prof=prof,
                                                          p_of_k_a=P1)
 
     # Negative profile in logspace

--- a/pyccl/tests/test_tkkssc.py
+++ b/pyccl/tests/test_tkkssc.py
@@ -265,10 +265,10 @@ def test_tkkssc_linear_bias(kwargs):
     # Tk's exact version
     prof = ccl.halos.HaloProfileNFW(ccl.halos.ConcentrationDuffy08(M200),
                                     fourier_analytic=True)
-    bias1 = 1
-    bias2 = 2
-    bias3 = 3
-    bias4 = 4
+    bias1 = 2
+    bias2 = 3
+    bias3 = 4
+    bias4 = 5
     is_nc = False
 
     # Tk's from tkkssc_linear


### PR DESCRIPTION
As a first implementation in TJPCov, in order to avoid the user to have to define several halo model parameters, it might be useful to have an approximation of the SSC. What I have implemented here is `tkk_ssc ~ b1 * b2 * First_term_for_a_NFW_profile + (b1 * delta_1_nc + b2 * delta_2_nc) * Pmm_for_a_NFW_profile` (see Eq. A13 in 1601.05779), where `delta_1_nc = 1` if the first quantity is for number counts and 0 if not.

I have also fixed the docstring for the SSC trispectrum function.