### PR TITLE
Add action to publish to pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Upload to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  Upload:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Setup python
+      uses: actions/setup-python@v2
+
+    - name: Build wheel and source tarball
+      run: |
+        python setup.py sdist
+
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_PYCCL_UPLOAD }}
+        repository_url: https://test.pypi.org/legacy/
+
+    # - name: Publish to PyPI
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     password: ${{ secrets.PYPI_PYCCL_UPLOAD }}


### PR DESCRIPTION
This adds a github action that automatically pushes the code to pypi whenever you create a release on Github.

The current version just pushes to the test version of pypi, so that we can see if everything is working before releasing to the real version. I'd suggest we do that as a first PR and then check it's all working and then a second PR to change it to use the real pypi.

To work this will need one of the maintainers of the PyPI project to create an upload token, by following these steps if they don't have one already.

- Log into test.pypi.org
- Click on your user name in the top right > Your Projects > Account Settings
- Scroll down to "API tokens". Click "Add API Token"
- Choose a sensible name like `CCL_UPLOAD_TOKEN`
- Under "scope", select pyccl from the drop-down menu
- Click "Add Token", and copy the token that appears to your text file.
- Go to the Github actions settings page for CCL
- Click Secrets > Actions in the bar on the left
- Click New Repository Secret
- Set the name to `TEST_PYPI_PYCCL_UPLOAD` and copy the token text in as the value, and add click Add Secret.

From the conda-forge feedstock it looks like the conda version is then automatically updated from the PyPI version.