### PR TITLE
Check for range of background splines when using halofit with wa != 0.

### DIFF
--- a/pyccl/pk2d.py
+++ b/pyccl/pk2d.py
@@ -174,6 +174,7 @@ class Pk2D(object):
             # HALOFIT translates (w0, wa) to a w0_eff. This requires computing
             # the comoving distance to the CMB, which requires the background
             # splines being sampled to sufficiently high redshifts.
+            cosmo.compute_distances()
             _, a = _get_spline1d_arrays(cosmo.cosmo.data.achi)
             if min(a) > 1/(1 + 3000):
                 raise CCLError("Comoving distance spline does not cover "

--- a/pyccl/pk2d.py
+++ b/pyccl/pk2d.py
@@ -4,8 +4,8 @@ import numpy as np
 
 from . import ccllib as lib
 
-from .errors import CCLWarning
-from .pyutils import check, _get_spline2d_arrays
+from .errors import CCLError, CCLWarning
+from .pyutils import check, _get_spline1d_arrays, _get_spline2d_arrays
 
 
 class Pk2D(object):
@@ -170,6 +170,20 @@ class Pk2D(object):
             pk_linear (:class:`Pk2D`): a :class:`Pk2D` object containing
                 the linear power spectrum to transform.
         """
+        if cosmo["wa"] != 0:
+            # HALOFIT translates (w0, wa) to a w0_eff. This requires computing
+            # the comoving distance to the CMB, which requires the background
+            # splines being sampled to sufficiently high redshifts.
+            _, a = _get_spline1d_arrays(cosmo.cosmo.data.achi)
+            if min(a) > 1/(1 + 3000):
+                raise CCLError("Comoving distance spline does not cover "
+                               "sufficiently high redshifts for HALOFIT. "
+                               "HALOFIT translates (w0, wa) to a w0_eff. This "
+                               "requires computing the comoving distance to "
+                               "the CMB, which requires the background "
+                               "splines being sampled to sufficiently high "
+                               "redshifts. If using the calculator mode, "
+                               "check the support of the background data.")
         pk2d = Pk2D(empty=True)
         status = 0
         ret = lib.apply_halofit(cosmo.cosmo, pk_linear.psp, status)

--- a/pyccl/tests/test_halofit_highz.py
+++ b/pyccl/tests/test_halofit_highz.py
@@ -45,7 +45,6 @@ def test_halofit_background_check():
     cosmo.cosmo.spline_params.A_SPLINE_MINLOG = 0.3
     cosmo.cosmo.spline_params.A_SPLINE_MIN_PK = 0.4
     cosmo.cosmo.spline_params.A_SPLINE_MINLOG_PK = 0.3
-    cosmo.compute_distances()
 
     k = np.geomspace(1e-3, 1, 10)
 

--- a/pyccl/tests/test_halofit_highz.py
+++ b/pyccl/tests/test_halofit_highz.py
@@ -2,6 +2,8 @@ import numpy as np
 import pyccl as ccl
 import pytest
 
+from pyccl.errors import CCLError
+
 COSMO = ccl.Cosmology(
     Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
     transfer_function='bbks', matter_power_spectrum='halofit')
@@ -29,3 +31,23 @@ def test_halofit_highz(cosmo):
         )
 
         assert np.all(pkratl >= pkrath), (zl, zh, pkratl, pkrath)
+
+
+def test_halofit_background_check():
+    cosmo = ccl.Cosmology(Omega_c=0.25, Omega_b=0.05, h=0.7,
+                          n_s=0.97,
+                          sigma8=0.8,
+                          w0=-1.04, wa=-0.1,
+                          matter_power_spectrum="halofit",
+                          transfer_function="eisenstein_hu")
+
+    cosmo.cosmo.spline_params.A_SPLINE_MIN = 0.4
+    cosmo.cosmo.spline_params.A_SPLINE_MINLOG = 0.3
+    cosmo.cosmo.spline_params.A_SPLINE_MIN_PK = 0.4
+    cosmo.cosmo.spline_params.A_SPLINE_MINLOG_PK = 0.3
+    cosmo.compute_distances()
+
+    k = np.geomspace(1e-3, 1, 10)
+
+    with pytest.raises(CCLError):
+        ccl.nonlin_matter_power(cosmo, k, a=0.5)


### PR DESCRIPTION
This issue recently came up when people tried using the CCL halofit with wa != 0 cosmologies in calculator mode and caused unhelpful error messages. Specifically, halofit translates (w0, wa) to a w0_eff. This requires computing the comoving distance to the CMB, which requires the background splines being sampled to sufficiently high redshifts. This PR adds a check for this case and gives a more informative error message.