### PR TITLE
Useful error for transfer functions with non-monotonic scale factors

### DIFF
--- a/pyccl/tests/test_tracers.py
+++ b/pyccl/tests/test_tracers.py
@@ -278,17 +278,19 @@ def test_tracer_magnification_kernel_spline_vs_gsl_intergation(z_min, z_max,
     if z_min > 0:
         assert n[0] > 0
 
-    cosmo.cosmo.gsl_params.LENSING_KERNEL_SPLINE_INTEGRATION = True
+    ccl.gsl_params.LENSING_KERNEL_SPLINE_INTEGRATION = True
     tr_mg = ccl.NumberCountsTracer(cosmo, False, dndz=(z, n),
                                    bias=(z, b), mag_bias=(z, b))
     w_mg_spline, _ = tr_mg.get_kernel(chi=None)
+    ccl.gsl_params.reload()
 
-    cosmo.cosmo.gsl_params.LENSING_KERNEL_SPLINE_INTEGRATION = False
+    ccl.gsl_params.LENSING_KERNEL_SPLINE_INTEGRATION = True
     tr_mg = ccl.NumberCountsTracer(cosmo, False, dndz=(z, n),
                                    bias=(z, b), mag_bias=(z, b))
     w_mg_gsl, chi = tr_mg.get_kernel(chi=None)
     tr_wl = ccl.WeakLensingTracer(cosmo, dndz=(z, n))
     w_wl_gsl, _ = tr_wl.get_kernel(chi=None)
+    ccl.gsl_params.reload()
 
     # Peak of kernel is ~1e-5
     if n_z_samples >= 1000:
@@ -370,3 +372,17 @@ def test_tracer_chi_min_max():
     tr.add_tracer(COSMO, kernel=(chi, wchi))
     assert tr.chi_min == tr._trc[0].chi_min
     assert tr.chi_max == tr._trc[1].chi_max
+
+
+def test_tracer_increase_sf():
+    z = np.linspace(0, 3., 32)
+    one = np.ones(len(z))
+    chi = ccl.comoving_radial_distance(COSMO, 1./(1+z))
+    sf = 1./(1+z)
+    tr = ccl.Tracer()
+    with pytest.raises(ValueError):
+        tr.add_tracer(COSMO, kernel=(chi, one),
+                      transfer_a=(sf, one))
+    # Check it works in the right order
+    tr.add_tracer(COSMO, kernel=(chi, one),
+                  transfer_a=(sf[::-1], one))

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -555,6 +555,11 @@ class Tracer(object):
             ta_s = NoneArr
             tk_s = NoneArr
 
+        if a_s is not None:
+            if not np.all(np.diff(a_s) > 0):
+                raise ValueError("Scale factor must be monotonically "
+                                 "increasing")
+
         status = 0
         ret = lib.cl_tracer_t_new_wrapper(cosmo.cosmo,
                                           int(der_bessel),

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -555,10 +555,9 @@ class Tracer(object):
             ta_s = NoneArr
             tk_s = NoneArr
 
-        if a_s is not None:
-            if not np.all(np.diff(a_s) > 0):
-                raise ValueError("Scale factor must be monotonically "
-                                 "increasing")
+        if not (np.diff(a_s) > 0).all():
+            raise ValueError("Scale factor must be monotonically "
+                             "increasing")
 
         status = 0
         ret = lib.cl_tracer_t_new_wrapper(cosmo.cosmo,


### PR DESCRIPTION
Closes #823 

This is actually documented, but at least now we'll throw a more useful error.