### PR TITLE
Stop supporting Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
     include_package_data=True,
     use_scm_version=True,
     distclass=Distribution,
-    python_requires='>3.7.0',
+    python_requires='>=3.7.0',
     setup_requires=['setuptools_scm'],
     install_requires=['numpy', 'pyyaml'],
     cmdclass={'build_py': Build, 'develop': Develop, 'clean': Clean},

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
     include_package_data=True,
     use_scm_version=True,
     distclass=Distribution,
+    python_requires='>3.7.0',
     setup_requires=['setuptools_scm'],
     install_requires=['numpy', 'pyyaml'],
     cmdclass={'build_py': Build, 'develop': Develop, 'clean': Clean},
@@ -102,9 +103,7 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: C',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python',
         'Topic :: Scientific/Engineering :: Physics'
     ]
 )


### PR DESCRIPTION
As mentioned in #949 , `setuptools` won't work anymore because it requires py37+.
Python 3.6 is past its end of life so with this PR we stop supporting it and require that py37+ is used, in order to install CCL.