### PR TITLE
MG parameters in `CosmologyCalculator`

### DIFF
--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -1137,6 +1137,10 @@ class CosmologyCalculator(Cosmology):
         T_CMB (:obj:`float`): The CMB temperature today. The default of
             ``None`` uses the global CCL value in
             ``pyccl.physical_constants.T_CMB``.
+        mu_0 (:obj:`float`, optional): One of the parameters of the mu-Sigma
+            modified gravity model. Defaults to 0.0
+        sigma_0 (:obj:`float`, optional): One of the parameters of the mu-Sigma
+            modified gravity model. Defaults to 0.0
         background (:obj:`dict`): a dictionary describing the background
             expansion. It must contain three mandatory entries: `'a'`: an
             array of monotonically ascending scale-factor values. `'chi'`:
@@ -1194,7 +1198,7 @@ class CosmologyCalculator(Cosmology):
             self, Omega_c=None, Omega_b=None, h=None, n_s=None,
             sigma8=None, A_s=None, Omega_k=0., Omega_g=None,
             Neff=3.046, m_nu=0., m_nu_type=None, w0=-1., wa=0.,
-            T_CMB=None, background=None, growth=None,
+            T_CMB=None, mu_0=0., sigma_0=0., background=None, growth=None,
             pk_linear=None, pk_nonlin=None, nonlinear_model=None):
         if pk_linear:
             transfer_function = 'calculator'
@@ -1211,7 +1215,7 @@ class CosmologyCalculator(Cosmology):
             n_s=n_s, sigma8=sigma8, A_s=A_s,
             Omega_k=Omega_k, Omega_g=Omega_g,
             Neff=Neff, m_nu=m_nu, m_nu_type=m_nu_type,
-            w0=w0, wa=wa, T_CMB=T_CMB,
+            w0=w0, wa=wa, T_CMB=T_CMB, mu_0=mu_0, sigma_0=sigma_0,
             transfer_function=transfer_function,
             matter_power_spectrum=matter_power_spectrum)
 

--- a/pyccl/tests/test_cls.py
+++ b/pyccl/tests/test_cls.py
@@ -84,3 +84,33 @@ def test_cls_raise_weird_pk():
     ells = [10, 11]
     with pytest.raises(ValueError):
         ccl.angular_cl(COSMO, LENS, LENS, ells, p_of_k_a=lambda k, a: 10)
+
+
+def test_cls_mg():
+    # Check that if we feed the non-linear matter power spectrum from a MG
+    # cosmology into a Calculator and get Cells using MG tracers, we get the
+    # same results.
+
+    # set up a MG cosmology
+    cosmo_MG = ccl.CosmologyVanillaLCDM(mu_0=0.5, sigma_0=0.5,
+                                        transfer_function="bbks",
+                                        matter_power_spectrum="linear")
+    cosmo_MG.compute_nonlin_power()
+    pk2d = cosmo_MG.get_nonlin_power()
+
+    # copy it into a calculator
+    a, lk, pk = pk2d.get_spline_arrays()
+    pk_nonlin = {"a": a, "k": np.exp(lk), "delta_matter:delta_matter": pk}
+    cosmo_calc = ccl.CosmologyCalculator(
+        Omega_c=0.25, Omega_b=0.05, h=0.67, n_s=0.96, sigma8=0.81,
+        mu_0=0.5, sigma_0=0.5, pk_nonlin=pk_nonlin)
+
+    # get the Cells
+    ell = np.geomspace(2, 2000, 128)
+    tr_MG = ccl.CMBLensingTracer(cosmo_MG, 1100.)
+    tr_calc = ccl.CMBLensingTracer(cosmo_calc, 1100.)
+
+    cl0 = ccl.angular_cl(cosmo_MG, tr_MG, tr_MG, ell)
+    cosmo_calc.compute_growth()
+    cl1 = ccl.angular_cl(cosmo_calc, tr_calc, tr_calc, ell)
+    assert not (1 - cl1 / cl0).any()  # all equal to zero

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -413,7 +413,7 @@ class Tracer(object):
         # Sampling scale factor from a very small (at CMB for example)
         # all the way to 1 here and today for the transfer function.
         # For a < a_single it is GR (no early MG)
-        if isinstance(z, float):
+        if isinstance(z, (int, float)):
             a_single = 1/(1+z)
             a = np.linspace(a_single, 1, 100)
             # a_single is for example like for the CMB surface


### PR DESCRIPTION
Closes #976 . MG tracers use `sigma_0` to compute the modified gravity factor for the transfer function. Just this parameter is needed, but I added `mu_0` as well for completeness. Might be good to think about whether it's worth also adding `c1_mg`, `c2_mg` and `lambda_mg`.