### PR TITLE
`HaloModelCalculator` check cosmo in `get_ingredients`.

### DIFF
--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -123,13 +123,13 @@ class HMCalculator(object):
             self.mf0 = (rho0 - integ) / self._m0
             self._cosmo_mf, self._a_mf = cosmo, a  # cache
 
-    def _get_halo_bias(self, cosmo, a, ρ0):
+    def _get_halo_bias(self, cosmo, a, rho0):
         # Compute the halo bias at this cosmo and a.
         if cosmo != self._cosmo_bf or a != self._a_bf:
             hbias = self.halo_bias.get_halo_bias
             self.bf = hbias(cosmo, self._mass, a)
             integ = self._integrator(self.mf*self.bf*self._mass, self._lmass)
-            self.mbf0 = (ρ0 - integ) / self._m0
+            self.mbf0 = (rho0 - integ) / self._m0
             self._cosmo_bf, self._a_bf = cosmo, a  # cache
 
     def _get_ingredients(self, a, cosmo, get_bf):

--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -117,22 +117,22 @@ class HMCalculator(object):
     def _get_mass_function(self, cosmo, a, rho0):
         # Compute the mass function at this cosmo and a.
         if a != self._a_mf or cosmo != self._cosmo_mf:
-            massfunc = self.mass_function.get_mass_function
-            self.mf = massfunc(cosmo, self._mass, a)
-            integ = self._integrator(self.mf*self._mass, self._lmass)
-            self.mf0 = (rho0 - integ) / self._m0
+            massfunc = self._massfunc.get_mass_function
+            self._mf = massfunc(cosmo, self._mass, a)
+            integ = self._integrator(self._mf*self._mass, self._lmass)
+            self._mf0 = (rho0 - integ) / self._m0
             self._cosmo_mf, self._a_mf = cosmo, a  # cache
 
     def _get_halo_bias(self, cosmo, a, rho0):
         # Compute the halo bias at this cosmo and a.
         if cosmo != self._cosmo_bf or a != self._a_bf:
-            hbias = self.halo_bias.get_halo_bias
-            self.bf = hbias(cosmo, self._mass, a)
-            integ = self._integrator(self.mf*self.bf*self._mass, self._lmass)
-            self.mbf0 = (rho0 - integ) / self._m0
+            hbias = self._hbias.get_halo_bias
+            self._bf = hbias(cosmo, self._mass, a)
+            integ = self._integrator(self._mf*self._bf*self._mass, self._lmass)
+            self._mbf0 = (rho0 - integ) / self._m0
             self._cosmo_bf, self._a_bf = cosmo, a  # cache
 
-    def _get_ingredients(self, a, cosmo, get_bf):
+    def _get_ingredients(self, cosmo, a, get_bf):
         """Compute mass function and halo bias at some scale factor."""
         rho0 = const.RHO_CRITICAL * cosmo["Omega_m"] * cosmo["h"]**2
         self._get_mass_function(cosmo, a, rho0)
@@ -140,14 +140,14 @@ class HMCalculator(object):
             self._get_halo_bias(cosmo, a, rho0)
 
     def _integrate_over_mf(self, array_2):
-        i1 = self._integrator(self.mf[..., :] * array_2,
+        i1 = self._integrator(self._mf[..., :] * array_2,
                               self._lmass)
-        return i1 + self.mf0 * array_2[..., 0]
+        return i1 + self._mf0 * array_2[..., 0]
 
     def _integrate_over_mbf(self, array_2):
-        i1 = self._integrator((self.mf * self.bf)[..., :] * array_2,
+        i1 = self._integrator((self._mf * self._bf)[..., :] * array_2,
                               self._lmass)
-        return i1 + self.mbf0 * array_2[..., 0]
+        return i1 + self._mbf0 * array_2[..., 0]
 
     def profile_norm(self, cosmo, a, prof):
         """ Returns :math:`I^0_1(k\\rightarrow0,a|u)`
@@ -163,7 +163,7 @@ class HMCalculator(object):
             float or array_like: integral value.
         """
         # Compute mass function
-        self._get_ingredients(a, cosmo, False)
+        self._get_ingredients(cosmo, a, False)
         uk0 = prof.fourier(cosmo, self._prec['k_min'],
                            self._mass, a, mass_def=self._mdef).T
         norm = 1. / self._integrate_over_mf(uk0)
@@ -218,10 +218,10 @@ class HMCalculator(object):
         # now do m intergrals in a loop
         mint = np.zeros_like(a)
         for i, _a in enumerate(a):
-            self._get_ingredients(_a, cosmo, False)
+            self._get_ingredients(cosmo, _a, False)
             _selm = np.atleast_2d(sel(self._mass, _a)).T
             mint[i] = self._integrator(
-                dvda[i] * self.mf[..., :] * _selm[..., :],
+                dvda[i] * self._mf[..., :] * _selm[..., :],
                 self._lmass
             )
 
@@ -252,7 +252,7 @@ class HMCalculator(object):
             value of `k`.
         """
         # Compute mass function
-        self._get_ingredients(a, cosmo, False)
+        self._get_ingredients(cosmo, a, False)
         uk = prof.fourier(cosmo, k, self._mass, a,
                           mass_def=self._mdef).T
         i01 = self._integrate_over_mf(uk)
@@ -282,7 +282,7 @@ class HMCalculator(object):
             value of `k`.
         """
         # Compute mass function and halo bias
-        self._get_ingredients(a, cosmo, True)
+        self._get_ingredients(cosmo, a, True)
         uk = prof.fourier(cosmo, k, self._mass, a,
                           mass_def=self._mdef).T
         i11 = self._integrate_over_mbf(uk)
@@ -318,7 +318,7 @@ class HMCalculator(object):
              value of `k`.
         """
         # Compute mass function
-        self._get_ingredients(a, cosmo, False)
+        self._get_ingredients(cosmo, a, False)
         uk = prof_2pt.fourier_2pt(prof1, cosmo, k, self._mass, a,
                                   prof2=prof2,
                                   mass_def=self._mdef).T
@@ -356,7 +356,7 @@ class HMCalculator(object):
              value of `k`.
         """
         # Compute mass function
-        self._get_ingredients(a, cosmo, True)
+        self._get_ingredients(cosmo, a, True)
         uk = prof_2pt.fourier_2pt(prof1, cosmo, k, self._mass, a,
                                   prof2=prof2,
                                   mass_def=self._mdef).T
@@ -409,7 +409,7 @@ class HMCalculator(object):
         if prof34_2pt is None:
             prof34_2pt = prof12_2pt
 
-        self._get_ingredients(a, cosmo, False)
+        self._get_ingredients(cosmo, a, False)
         uk12 = prof12_2pt.fourier_2pt(prof1, cosmo, k, self._mass, a,
                                       prof2=prof2, mass_def=self._mdef).T
         uk34 = prof34_2pt.fourier_2pt(prof3, cosmo, k, self._mass, a,

--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -12,7 +12,7 @@ from ..power import linear_matter_power, nonlin_matter_power
 from ..pyutils import _spline_integrate
 from .. import background
 from ..errors import CCLWarning
-from ..parameters import physical_constants
+from ..parameters import physical_constants as const
 import numpy as np
 
 
@@ -106,36 +106,38 @@ class HMCalculator(object):
         else:
             self._integrator = self._integ_spline
 
-        self._a_current_mf = -1
-        self._a_current_bf = -1
+        # Cache last results for mass function and halo bias.
+        self._cosmo_mf = self._cosmo_bf = None
+        self._a_mf = self._a_bf = -1
 
     def _integ_spline(self, fM, lM):
         # Spline integrator
         return _spline_integrate(lM, fM, lM[0], lM[-1])
 
-    def _get_ingredients(self, a, cosmo, get_bf):
-        # Compute mass function and bias (if needed) at a new
-        # value of the scale factor.
-        rho0 = None
-        if a != self._a_current_mf:
-            rho0 = cosmo.rho_x(1., "matter", is_comoving=True)
-            self.mf = self._massfunc.get_mass_function(cosmo, self._mass, a,
-                                                       mdef_other=self._mdef)
-            self.mf0 = (rho0 -
-                        self._integrator(self.mf * self._mass,
-                                         self._lmass)) / self._m0
-            self._a_current_mf = a
+    def _get_mass_function(self, cosmo, a, rho0):
+        # Compute the mass function at this cosmo and a.
+        if a != self._a_mf or cosmo != self._cosmo_mf:
+            massfunc = self.mass_function.get_mass_function
+            self.mf = massfunc(cosmo, self._mass, a)
+            integ = self._integrator(self.mf*self._mass, self._lmass)
+            self.mf0 = (rho0 - integ) / self._m0
+            self._cosmo_mf, self._a_mf = cosmo, a  # cache
 
+    def _get_halo_bias(self, cosmo, a, ρ0):
+        # Compute the halo bias at this cosmo and a.
+        if cosmo != self._cosmo_bf or a != self._a_bf:
+            hbias = self.halo_bias.get_halo_bias
+            self.bf = hbias(cosmo, self._mass, a)
+            integ = self._integrator(self.mf*self.bf*self._mass, self._lmass)
+            self.mbf0 = (ρ0 - integ) / self._m0
+            self._cosmo_bf, self._a_bf = cosmo, a  # cache
+
+    def _get_ingredients(self, a, cosmo, get_bf):
+        """Compute mass function and halo bias at some scale factor."""
+        rho0 = const.RHO_CRITICAL * cosmo["Omega_m"] * cosmo["h"]**2
+        self._get_mass_function(cosmo, a, rho0)
         if get_bf:
-            if a != self._a_current_bf:
-                if rho0 is None:
-                    rho0 = cosmo.rho_x(1., "matter", is_comoving=True)
-                self.bf = self._hbias.get_halo_bias(cosmo, self._mass, a,
-                                                    mdef_other=self._mdef)
-                self.mbf0 = (rho0 -
-                             self._integrator(self.mf * self.bf * self._mass,
-                                              self._lmass)) / self._m0
-            self._a_current_bf = a
+            self._get_halo_bias(cosmo, a, rho0)
 
     def _integrate_over_mf(self, array_2):
         i1 = self._integrator(self.mf[..., :] * array_2,
@@ -209,7 +211,7 @@ class HMCalculator(object):
         abs_dzda = 1 / a / a
         dc = background.comoving_angular_distance(cosmo, a)
         ez = background.h_over_h0(cosmo, a)
-        dh = physical_constants.CLIGHT_HMPC / cosmo['h']
+        dh = const.CLIGHT_HMPC / cosmo['h']
         dvdz = dh * dc**2 / ez
         dvda = dvdz * abs_dzda
 

--- a/pyccl/tests/test_halofit_highz.py
+++ b/pyccl/tests/test_halofit_highz.py
@@ -34,6 +34,11 @@ def test_halofit_highz(cosmo):
 
 
 def test_halofit_background_check():
+    ccl.spline_params.A_SPLINE_MIN = 0.4
+    ccl.spline_params.A_SPLINE_MINLOG = 0.3
+    ccl.spline_params.A_SPLINE_MIN_PK = 0.4
+    ccl.spline_params.A_SPLINE_MINLOG_PK = 0.3
+
     cosmo = ccl.Cosmology(Omega_c=0.25, Omega_b=0.05, h=0.7,
                           n_s=0.97,
                           sigma8=0.8,
@@ -41,12 +46,9 @@ def test_halofit_background_check():
                           matter_power_spectrum="halofit",
                           transfer_function="eisenstein_hu")
 
-    cosmo.cosmo.spline_params.A_SPLINE_MIN = 0.4
-    cosmo.cosmo.spline_params.A_SPLINE_MINLOG = 0.3
-    cosmo.cosmo.spline_params.A_SPLINE_MIN_PK = 0.4
-    cosmo.cosmo.spline_params.A_SPLINE_MINLOG_PK = 0.3
-
     k = np.geomspace(1e-3, 1, 10)
 
     with pytest.raises(CCLError):
         ccl.nonlin_matter_power(cosmo, k, a=0.5)
+
+    ccl.spline_params.reload()


### PR DESCRIPTION
In #925 , I moved the `rho0` calculation inside of `get_ingredients` but forgot to include a check, so that `rho0` is re-computed every time `cosmo` changes. In essence, we didn't fix the problem in 925, we just moved it to a different method.

With this PR we now check for cosmo equality. There is no `__eq__` currently implemented in `Cosmology`, so Python falls back to id-checking (an okay assumption for now).

I moved `rho0` out of the if-statement (so it gets computed every time), or we'd have to carry out checks for every possible combination of (mass_function, halo_bias), (cached a, not cached, or None), (cached cosmo, not cached, or None), which would complicate things a lot.

I simplified the way we compute `rho0`, so that it doesn't call `rho_x` anymore, and so it doesn't have to evaluate any splines. This is now very fast (200x faster than calculating the mass function, 400x faster than calculating mf+hb), so we don't need to worry about the overhead every time `_get_ingredients` is called.

![Screenshot from 2022-08-16 19-49-36](https://user-images.githubusercontent.com/22447385/184936537-702f2b14-ee24-4c2a-9490-b50581f04acb.png)
