### PR TITLE
Add function to check if OpenMP is working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ find_package(OpenMP)
 set(CMAKE_C_FLAGS_RELEASE "-O3 -fomit-frame-pointer -fno-common -fPIC -std=gnu99 -DHAVE_ANGPOW")
 set(CMAKE_C_FLAGS_DEBUG   "-O0 -g -fomit-frame-pointer -fno-common -fPIC -std=gnu99 -DHAVE_ANGPOW")
 
-if ("${CMAKE_C_COMPILER_ID}" MATCHES "^(Apple)?Clang$") 
+if ("${CMAKE_C_COMPILER_ID}" MATCHES "^(Apple)+Clang$")
     if(OpenMP_C_FOUND)
         # OpenMP flags for macOS clang
         set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Xpreprocessor -fopenmp")

--- a/include/ccl_utils.h
+++ b/include/ccl_utils.h
@@ -63,6 +63,8 @@ void ccl_integ_spline(int ny, int nx,double *x,double **y,
                       double a, double b, double *result,
                       const gsl_interp_type *T, int *status);
 
+int ccl_check_openmp();
+
 CCL_END_DECLS
 
 #endif

--- a/pyccl/pyutils.py
+++ b/pyccl/pyutils.py
@@ -664,3 +664,10 @@ def _get_spline3d_arrays(gsl_spline, length):
     check(status)
 
     return xarr, yarr, zarr.reshape((length, x_size, y_size))
+
+def check_openmp():
+    N = lib.check_openmp()
+    if N > 0:
+        print(f'OpenMP is working with {N} threads enabled')
+    else:
+        print('OpenMP not supported')

--- a/src/ccl_utils.c
+++ b/src/ccl_utils.c
@@ -340,3 +340,15 @@ void ccl_integ_spline(int ny, int nx,double *x,double **y,
     } //end omp parallel
   }
 }
+
+int ccl_check_openmp()
+{
+  int total = 0;
+  #ifdef _OPENMP
+  #pragma omp parallel
+  {
+    total = omp_get_num_threads();
+  }
+  #endif
+    return total;
+}


### PR DESCRIPTION
I haven't written in C language for a while. This is how I check if OpenMP is working on the compiled pyccl. Checked on macOS 10.15.7 with Apple Clang with OpenMP disabled and homebrew-installed Clang 15, the function is working as expected even if the environment variable "OMP_NUM_THREAD" is set to 0.