### PR TITLE
Consistent lensing for modified gravity

### DIFF
--- a/pyccl/cls.py
+++ b/pyccl/cls.py
@@ -58,6 +58,8 @@ def angular_cl(cosmo, cltracer1, cltracer2, ell, p_of_k_a=None,
     cosmo_in = cosmo
     cosmo = cosmo.cosmo
 
+    if p_of_k_a is None:
+        p_of_k_a = cltracer1.name_delta + ':' + cltracer2.name_delta
     psp = parse_pk2d(cosmo_in, p_of_k_a)
 
     # Create tracer colections

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -175,6 +175,8 @@ class Tracer(object):
     tracers that get combined linearly when computing power spectra.
     Further details can be found in Section 4.9 of the CCL note.
     """
+    name_delta = 'delta_matter'
+
     def __init__(self):
         """By default this `Tracer` object will contain no actual
         tracers


### PR DESCRIPTION
Being worked on with @noller 
The aim of this branch is to allow CCL to select the right P(k) when computing angular power spectra involving lensing in the context of non-LCDM theories, where psi != phi.


- [ ] Associate all tracers with a 3D cosmological quantity (e.g. `delta_matter` or `delta_weyl`)
- [ ] Allow `angular_cls` to select the right P(k) by default (unless provided).
- [ ] Get the `Cosmology` object to store at least the following power spectra: `delta_matter:delta_matter`, `delta_matter:delta_weyl`, `delta_weyl:delta_weyl`, both for linear and non-linear pks. In the first instance, forget about MG.
- [ ] Then, make sure any factors of Sigma are multiplied correctly.
- [ ] Extract these P(k)s from CAMB (and CLASS if possible)
- [ ] Same for isitgr.
- [ ] Document what `delta_weyl` means.
- [ ] If the non-linear Pks are not provided, then we halofit them.
- [ ] Add a warning when the above happens (since this is wrong at some level)

Once the above is done, we need to worry about:
- [ ] Remnant growth factors in IAs and RSD
- [ ] Decide between the `delta_weyl` and `phi_weyl` nomenclature.
