### PR TITLE
Bump Python version to 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
     include_package_data=True,
     use_scm_version=True,
     distclass=Distribution,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     setup_requires=['setuptools_scm'],
     install_requires=['numpy'],
     cmdclass={'build_py': Build, 'develop': Develop, 'clean': Clean},


### PR DESCRIPTION
Some functionality we just introduced only exists in py38+. I forgot to change that in `setup.py`. py37's end-of-life ends in 3 months either way: https://endoflife.date/python. I should have realized, because we run CI using py38.