### PR TITLE
Implement separate `__eq__` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cosmo = ccl.Cosmology(
     transfer_function='bbks')
 
 # Define a simple binned galaxy number density curve as a function of redshift
-z_n = np.linspace(0., 1., 200)
+z_n = np.linspace(0., 1., 500)
 n = np.ones(z_n.shape)
 
 # Create objects to represent tracers of the weak lensing signal with this

--- a/pyccl/base.py
+++ b/pyccl/base.py
@@ -590,12 +590,12 @@ class CCLObject(ABC):
 
     def __eq__(self, other):
         # Two same-type objects are equal if their representations are equal.
-        if self.__class__ is not other.__class__:
+        if type(self) is not type(other):
             return False
         # Compare the attributes listed in `__eq_attrs__`.
         if hasattr(self, "__eq_attrs__"):
             for attr in self.__eq_attrs__:
-                if any(getattr(self, attr) != getattr(other, attr)):
+                if np.any(getattr(self, attr) != getattr(other, attr)):
                     return False
             return True
         # Fall back to repr comparison.

--- a/pyccl/base.py
+++ b/pyccl/base.py
@@ -597,6 +597,7 @@ class CCLObject(ABC):
             for attr in self.__eq_attrs__:
                 if any(getattr(self, attr) != getattr(other, attr)):
                     return False
+            return True
         # Fall back to repr comparison.
         return repr(self) == repr(other)
 

--- a/pyccl/base.py
+++ b/pyccl/base.py
@@ -594,8 +594,9 @@ class CCLObject(ABC):
             return False
         # Compare the attributes listed in `__eq_attrs__`.
         if hasattr(self, "__eq_attrs__"):
-            return all([getattr(self, attr) == getattr(other, attr)
-                        for attr in self.__eq_attrs__])
+            for attr in self.__eq_attrs__:
+                if any(getattr(self, attr) != getattr(other, attr)):
+                    return False
         # Fall back to repr comparison.
         return repr(self) == repr(other)
 

--- a/pyccl/base.py
+++ b/pyccl/base.py
@@ -5,7 +5,6 @@ import numpy as np
 from inspect import signature
 from _thread import RLock
 from abc import ABC
-from operator import attrgetter
 
 
 def _to_hashable(obj):
@@ -595,7 +594,7 @@ class CCLObject(ABC):
             return False
         # Compare the attributes listed in `__eq_attrs__`.
         if hasattr(self, "__eq_attrs__"):
-            return all([attrgetter(attr)(self) == attrgetter(attr)(other)
+            return all([getattr(self, attr) == getattr(other, attr)
                         for attr in self.__eq_attrs__])
         # Fall back to repr comparison.
         return repr(self) == repr(other)

--- a/pyccl/base.py
+++ b/pyccl/base.py
@@ -440,6 +440,15 @@ class UnlockInstance:
 unlock_instance = UnlockInstance.unlock_instance
 
 
+def is_equal(this, other):
+    """Powerful helper for equivalence checking."""
+    try:
+        np.testing.assert_equal(this, other)
+        return True
+    except AssertionError:
+        return False
+
+
 class FancyRepr:
     """Controls the usage of fancy ``__repr__` for ``CCLObjects."""
     _enabled: bool = True
@@ -595,7 +604,7 @@ class CCLObject(ABC):
         # Compare the attributes listed in `__eq_attrs__`.
         if hasattr(self, "__eq_attrs__"):
             for attr in self.__eq_attrs__:
-                if np.any(getattr(self, attr) != getattr(other, attr)):
+                if not is_equal(getattr(self, attr), getattr(other, attr)):
                     return False
             return True
         # Fall back to repr comparison.

--- a/pyccl/base.py
+++ b/pyccl/base.py
@@ -607,8 +607,8 @@ class CCLObject(ABC):
                 if not is_equal(getattr(self, attr), getattr(other, attr)):
                     return False
             return True
-        # Fall back to repr comparison.
-        return repr(self) == repr(other)
+        # Fall back to default Python comparison.
+        return id(self) == id(other)
 
 
 class CCLHalosObject(CCLObject):

--- a/pyccl/base.py
+++ b/pyccl/base.py
@@ -5,6 +5,7 @@ import numpy as np
 from inspect import signature
 from _thread import RLock
 from abc import ABC
+from operator import attrgetter
 
 
 def _to_hashable(obj):
@@ -586,6 +587,11 @@ class CCLObject(ABC):
         # Two same-type objects are equal if their representations are equal.
         if self.__class__ is not other.__class__:
             return False
+        # Compare the attributes listed in `__eq_attrs__`.
+        if hasattr(self, "__eq_attrs__"):
+            return all([attrgetter(attr)(self) == attrgetter(attr)(other)
+                        for attr in self.__eq_attrs__])
+        # Fall back to repr comparison.
         return repr(self) == repr(other)
 
 

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -1181,7 +1181,7 @@ class CosmologyCalculator(Cosmology):
             Takahashi et al. 2012 (arXiv:1208.2701).
     """
     __eq_attrs__ = ("_params_init_kwargs", "_config_init_kwargs",
-                    "_accuracy_params", "_pk_lin", "_pk_nl",)
+                    "_accuracy_params", "_input_arrays",)
 
     def __init__(
             self, Omega_c=None, Omega_b=None, h=None, n_s=None,
@@ -1215,6 +1215,9 @@ class CosmologyCalculator(Cosmology):
         has_pknl = pk_nonlin is not None
         has_nonlin_model = nonlinear_model is not None
 
+        self._input_arrays = {"background": background, "growth": growth,
+                              "pk_linear": pk_linear, "pk_nonlin": pk_nonlin,
+                              "nonlinear_model": nonlinear_model}
         if has_bg:
             self._init_bg(background)
         if has_dz:

--- a/pyccl/halos/concentration.py
+++ b/pyccl/halos/concentration.py
@@ -18,7 +18,7 @@ class Concentration(CCLHalosObject):
             object that fixes the mass definition used by this c(M)
             parametrization.
     """
-    __repr_attrs__ = ("mdef",)
+    __repr_attrs__ = __eq_attrs__ = ("mdef",)
 
     def __init__(self, mass_def=None):
         if mass_def is not None:
@@ -395,7 +395,7 @@ class ConcentrationIshiyama21(Concentration):
             method. Otherwise, use the concentration found with profile
             fitting. The default is False.
     """
-    __repr_attrs__ = ("mdef", "relaxed", "Vmax",)
+    __repr_attrs__ = __eq_attrs__ = ("mdef", "relaxed", "Vmax",)
     name = 'Ishiyama21'
 
     def __init__(self, mdef=None, relaxed=False, Vmax=False):
@@ -555,7 +555,7 @@ class ConcentrationConstant(Concentration):
             the mass definition used by this c(M)
             parametrization. In this case it's arbitrary.
     """
-    __repr_attrs__ = ("mdef", "c",)
+    __repr_attrs__ = __eq_attrs__ = ("mdef", "c",)
     name = 'Constant'
 
     def __init__(self, c=1, mdef=None):

--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -53,7 +53,7 @@ class HMCalculator(CCLHalosObject):
             determines what is considered a "very large" scale.
             Default: 1E-5.
     """
-    __repr_attrs__ = ("_massfunc", "_hbias", "_mdef", "_prec",)
+    __repr_attrs__ = __eq_attrs__ = ("_massfunc", "_hbias", "_mdef", "_prec",)
 
     def __init__(self, cosmo, massfunc, hbias, mass_def,
                  log10M_min=8., log10M_max=16.,

--- a/pyccl/halos/hbias.py
+++ b/pyccl/halos/hbias.py
@@ -27,7 +27,7 @@ class HaloBias(CCLHalosObject):
         mass_def_strict (bool): if False, consistency of the mass
             definition will be ignored.
     """
-    __repr_attrs__ = ("mdef", "mass_def_strict",)
+    __repr_attrs__ = __eq_attrs__ = ("mdef", "mass_def_strict",)
 
     def __init__(self, cosmo, mass_def=None, mass_def_strict=True):
         cosmo.compute_sigma()
@@ -190,7 +190,8 @@ class HaloBiasSheth99(HaloBias):
             the fit of Nakamura & Suto 1997. Otherwise use
             delta_crit = 1.68647.
     """
-    __repr_attrs__ = ("mdef", "mass_def_strict", "use_delta_c_fit",)
+    __repr_attrs__ = __eq_attrs__ = ("mdef", "mass_def_strict",
+                                     "use_delta_c_fit",)
     name = "Sheth99"
 
     def __init__(self, cosmo, mass_def=None,

--- a/pyccl/halos/hmfunc.py
+++ b/pyccl/halos/hmfunc.py
@@ -32,7 +32,7 @@ class MassFunc(CCLHalosObject):
         mass_def_strict (bool): if False, consistency of the mass
             definition will be ignored.
     """
-    __repr_attrs__ = ("mdef", "mass_def_strict",)
+    __repr_attrs__ = __eq_attrs__ = ("mdef", "mass_def_strict",)
 
     def __init__(self, cosmo, mass_def=None, mass_def_strict=True):
         # Initialize sigma(M) splines if needed
@@ -251,7 +251,8 @@ class MassFuncSheth99(MassFunc):
             the fit of Nakamura & Suto 1997. Otherwise use
             delta_crit = 1.68647.
     """
-    __repr_attrs__ = ("mdef", "mass_def_strict", "use_delta_c_fit",)
+    __repr_attrs__ = __eq_attrs__ = ("mdef", "mass_def_strict",
+                                     "use_delta_c_fit",)
     name = 'Sheth99'
 
     def __init__(self, cosmo, mass_def=None, mass_def_strict=True,
@@ -393,7 +394,7 @@ class MassFuncDespali16(MassFunc):
         mass_def_strict (bool): if False, consistency of the mass
             definition will be ignored.
     """
-    __repr_attrs__ = ("mdef", "mass_def_strict", "ellipsoidal",)
+    __repr_attrs__ = __eq_attrs__ = ("mdef", "mass_def_strict", "ellipsoidal",)
     name = 'Despali16'
 
     def __init__(self, cosmo, mass_def=None, mass_def_strict=True,
@@ -456,7 +457,7 @@ class MassFuncTinker10(MassFunc):
         norm_all_z (bool): should we normalize the mass function
             at z=0 or at all z?
     """
-    __repr_attrs__ = ("mdef", "mass_def_strict", "norm_all_z",)
+    __repr_attrs__ = __eq_attrs__ = ("mdef", "mass_def_strict", "norm_all_z",)
     name = 'Tinker10'
 
     def __init__(self, cosmo, mass_def=None, mass_def_strict=True,
@@ -539,7 +540,7 @@ class MassFuncBocquet16(MassFunc):
             using dark-matter-only simulations. Otherwise, include
             baryonic effects (default).
     """
-    __repr_attrs__ = ("mdef", "mass_def_strict", "hydro",)
+    __repr_attrs__ = __eq_attrs__ = ("mdef", "mass_def_strict", "hydro",)
     name = 'Bocquet16'
 
     def __init__(self, cosmo, mass_def=None, mass_def_strict=True,

--- a/pyccl/halos/massdef.py
+++ b/pyccl/halos/massdef.py
@@ -286,3 +286,12 @@ def MassDefVir(c_m='Klypin11'):
         c_m (string): concentration-mass relation.
     """
     return MassDef('vir', 'critical', c_m_relation=c_m)
+
+
+def MassDefFof(c_m=None):
+    r""":math:`\Delta = \rm FoF` mass definition.
+
+    Args:
+        c_m (string): concentration-mass relation.
+    """
+    return MassDef('fof', 'matter', c_m_relation=c_m)

--- a/pyccl/halos/massdef.py
+++ b/pyccl/halos/massdef.py
@@ -3,6 +3,7 @@ from ..core import check
 from ..background import species_types, rho_x, omega_x
 from ..base import CCLHalosObject
 import numpy as np
+from functools import cached_property
 
 
 def mass2radius_lagrangian(cosmo, M):
@@ -106,7 +107,7 @@ class MassDef(CCLHalosObject):
         else:
             self._concentration_init(c_m_relation)
 
-    @property
+    @cached_property
     def name(self):
         """Give a name to this mass definition."""
         if isinstance(self.Delta, (int, float)):

--- a/pyccl/halos/massdef.py
+++ b/pyccl/halos/massdef.py
@@ -84,7 +84,7 @@ class MassDef(CCLHalosObject):
             If `None`, no c(M) relation will be attached to this mass
             definition (and hence one can't translate into other definitions).
     """
-    __repr_attrs__ = ("name",)
+    __repr_attrs__ = __eq_attrs__ = ("name",)
 
     def __init__(self, Delta, rho_type, c_m_relation=None):
         # Check it makes sense

--- a/pyccl/halos/massdef.py
+++ b/pyccl/halos/massdef.py
@@ -289,10 +289,10 @@ def MassDefVir(c_m='Klypin11'):
     return MassDef('vir', 'critical', c_m_relation=c_m)
 
 
-def MassDefFof(c_m=None):
+def MassDefFof():
     r""":math:`\Delta = \rm FoF` mass definition.
 
     Args:
         c_m (string): concentration-mass relation.
     """
-    return MassDef('fof', 'matter', c_m_relation=c_m)
+    return MassDef('fof', 'matter')

--- a/pyccl/halos/profiles.py
+++ b/pyccl/halos/profiles.py
@@ -651,8 +651,8 @@ class HaloProfileNFW(HaloProfile):
             radii.
     """
     __repr_attrs__ = __eq_attrs__ = (
-        "cM", "fourier_analytic", "projected_analytic",
-        "cumul2d_analytic", "truncated", "precision_fftlog",)
+        "fourier_analytic", "projected_analytic",
+        "cumul2d_analytic", "truncated", "cM", "precision_fftlog",)
     name = 'NFW'
 
     def __init__(self, c_M_relation,
@@ -848,8 +848,8 @@ class HaloProfileEinasto(HaloProfile):
         alpha (float, 'cosmo'): Set the Einasto alpha parameter or set to
             'cosmo' to calculate the value from cosmology. Default: 'cosmo'
     """
-    __repr_attrs__ = __eq_attrs__ = ("cM", "truncated", "alpha",
-                                     "precision_fftlog",)
+    __repr_attrs__ = __eq_attrs__ = ("truncated", "alpha",
+                                     "cM", "precision_fftlog",)
     name = 'Einasto'
 
     def __init__(self, c_M_relation, truncated=True, alpha='cosmo'):
@@ -960,8 +960,8 @@ class HaloProfileHernquist(HaloProfile):
             radii.
     """
     __repr_attrs__ = __eq_attrs__ = (
-        "cM", "fourier_analytic", "projected_analytic",
-        "cumul2d_analytic", "truncated", "precision_fftlog",)
+        "fourier_analytic", "projected_analytic", "cumul2d_analytic",
+        "truncated", "cM", "precision_fftlog",)
     name = 'Hernquist'
 
     def __init__(self, c_M_relation,
@@ -1472,9 +1472,10 @@ class HaloProfileHOD(HaloProfile):
             satellites when centrals are present.
     """
     __repr_attrs__ = __eq_attrs__ = (
-        "cM", "lMmin_0", "lMmin_p", "siglM_0", "siglM_p", "lM0_0", "lM0_p",
-        "lM1_0", "lM1_p", "alpha_0", "alpha_p", "fc_0", "fc_p", "bg_0", "bg_p",
-        "bmax_0", "bmax_p", "a_pivot", "ns_independent", "precision_fftlog",)
+        "lMmin_0", "lMmin_p", "siglM_0", "siglM_p", "lM0_0", "lM0_p", "lM1_0",
+        "lM1_p", "alpha_0", "alpha_p", "fc_0", "fc_p", "bg_0", "bg_p",
+        "bmax_0", "bmax_p", "a_pivot", "ns_independent",
+        "cM", "precision_fftlog",)
     name = 'HOD'
     is_number_counts = True
 

--- a/pyccl/halos/profiles.py
+++ b/pyccl/halos/profiles.py
@@ -53,10 +53,6 @@ class HaloProfile(CCLHalosObject):
                                  'plaw_fourier': -1.5,
                                  'plaw_projected': -1.}
 
-    __eq__ = object.__eq__
-
-    __hash__ = object.__hash__  # TODO: remove once __eq__ is replaced.
-
     @unlock_instance(mutate=True)
     def update_precision_fftlog(self, **kwargs):
         """ Update any of the precision parameters used by

--- a/pyccl/halos/profiles.py
+++ b/pyccl/halos/profiles.py
@@ -531,7 +531,7 @@ class HaloProfileGaussian(HaloProfile):
         rho0 (:obj:`function`): the amplitude of the profile.
             It should have the same signature as `r_scale`.
     """
-    __repr_attrs__ = ("r_s", "rho_0", "precision_fftlog",)
+    __repr_attrs__ = __eq_attrs__ = ("r_s", "rho_0", "precision_fftlog",)
     name = 'Gaussian'
 
     def __init__(self, r_scale, rho0):
@@ -578,7 +578,7 @@ class HaloProfilePowerLaw(HaloProfile):
             profile. The signature of this function should
             be `f(cosmo, a)`.
     """
-    __repr_attrs__ = ("r_s", "tilt", "precision_fftlog",)
+    __repr_attrs__ = __eq_attrs__ = ("r_s", "tilt", "precision_fftlog",)
     name = 'PowerLaw'
 
     def __init__(self, r_scale, tilt):
@@ -650,8 +650,9 @@ class HaloProfileNFW(HaloProfile):
             truncated at :math:`r = R_\\Delta` (i.e. zero at larger
             radii.
     """
-    __repr_attrs__ = ("cM", "fourier_analytic", "projected_analytic",
-                      "cumul2d_analytic", "truncated", "precision_fftlog",)
+    __repr_attrs__ = __eq_attrs__ = (
+        "cM", "fourier_analytic", "projected_analytic",
+        "cumul2d_analytic", "truncated", "precision_fftlog",)
     name = 'NFW'
 
     def __init__(self, c_M_relation,
@@ -847,7 +848,8 @@ class HaloProfileEinasto(HaloProfile):
         alpha (float, 'cosmo'): Set the Einasto alpha parameter or set to
             'cosmo' to calculate the value from cosmology. Default: 'cosmo'
     """
-    __repr_attrs__ = ("cM", "truncated", "alpha", "precision_fftlog",)
+    __repr_attrs__ = __eq_attrs__ = ("cM", "truncated", "alpha",
+                                     "precision_fftlog",)
     name = 'Einasto'
 
     def __init__(self, c_M_relation, truncated=True, alpha='cosmo'):
@@ -957,8 +959,9 @@ class HaloProfileHernquist(HaloProfile):
             truncated at :math:`r = R_\\Delta` (i.e. zero at larger
             radii.
     """
-    __repr_attrs__ = ("cM", "fourier_analytic", "projected_analytic",
-                      "cumul2d_analytic", "truncated", "precision_fftlog",)
+    __repr_attrs__ = __eq_attrs__ = (
+        "cM", "fourier_analytic", "projected_analytic",
+        "cumul2d_analytic", "truncated", "precision_fftlog",)
     name = 'Hernquist'
 
     def __init__(self, c_M_relation,
@@ -1189,9 +1192,9 @@ class HaloProfilePressureGNFW(HaloProfile):
         Profile threshold, in units of :math:`R_{\\mathrm{500c}}`.
         Defaults to :math:`+\\infty`.
     """
-    __repr_attrs__ = ("mass_bias", "P0", "c500", "alpha", "alpha_P", "beta",
-                      "gamma", "P0_hexp", "qrange", "nq", "x_out",
-                      "precision_fftlog",)
+    __repr_attrs__ = __eq_attrs__ = (
+        "mass_bias", "P0", "c500", "alpha", "alpha_P", "beta", "gamma",
+        "P0_hexp", "qrange", "nq", "x_out", "precision_fftlog",)
     name = 'GNFW'
 
     def __init__(self, mass_bias=0.8, P0=6.41,
@@ -1468,10 +1471,10 @@ class HaloProfileHOD(HaloProfile):
         ns_independent (bool): drop requirement to only form
             satellites when centrals are present.
     """
-    __repr_attrs__ = ("cM", "lMmin_0", "lMmin_p", "siglM_0", "siglM_p",
-                      "lM0_0", "lM0_p", "lM1_0", "lM1_p", "alpha_0", "alpha_p",
-                      "fc_0", "fc_p", "bg_0", "bg_p", "bmax_0", "bmax_p",
-                      "a_pivot", "ns_independent", "precision_fftlog",)
+    __repr_attrs__ = __eq_attrs__ = (
+        "cM", "lMmin_0", "lMmin_p", "siglM_0", "siglM_p", "lM0_0", "lM0_p",
+        "lM1_0", "lM1_p", "alpha_0", "alpha_p", "fc_0", "fc_p", "bg_0", "bg_p",
+        "bmax_0", "bmax_p", "a_pivot", "ns_independent", "precision_fftlog",)
     name = 'HOD'
     is_number_counts = True
 

--- a/pyccl/halos/profiles_2pt.py
+++ b/pyccl/halos/profiles_2pt.py
@@ -28,10 +28,6 @@ class Profile2pt(CCLHalosObject):
     def __init__(self, r_corr=0.):
         self.r_corr = r_corr
 
-    __eq__ = object.__eq__
-
-    __hash__ = object.__hash__  # TODO: remove once __eq__ is replaced.
-
     def update_parameters(self, r_corr=None):
         """ Update any of the parameters associated with this 1-halo
         2-point correlator. Any parameter set to `None` won't be updated.

--- a/pyccl/halos/profiles_2pt.py
+++ b/pyccl/halos/profiles_2pt.py
@@ -23,7 +23,7 @@ class Profile2pt(CCLHalosObject):
             Defaults to ``r_corr=0``, returning simply the product
             of the fourier profiles.
     """
-    __repr_attrs__ = ("r_corr",)
+    __repr_attrs__ = __eq_attrs__ = ("r_corr",)
 
     def __init__(self, r_corr=0.):
         self.r_corr = r_corr

--- a/pyccl/halos/profiles_cib.py
+++ b/pyccl/halos/profiles_cib.py
@@ -78,8 +78,8 @@ class HaloProfileCIBShang12(HaloProfile):
             :math:`{\\rm Jy}\\,{\\rm Mpc}^2\\,M_\\odot^{-1}`).
     """
     __repr_attrs__ = __eq_attrs__ = (
-        "cM", "nu", "alpha", "T0", "beta", "gamma", "s_z",
-        "l10meff", "sigLM", "Mmin", "L0", "precision_fftlog",)
+        "nu", "alpha", "T0", "beta", "gamma", "s_z",
+        "l10meff", "sigLM", "Mmin", "L0", "cM", "precision_fftlog",)
     name = 'CIBShang12'
     _one_over_4pi = 0.07957747154
 

--- a/pyccl/halos/profiles_cib.py
+++ b/pyccl/halos/profiles_cib.py
@@ -77,8 +77,9 @@ class HaloProfileCIBShang12(HaloProfile):
         L0 (float): luminosity scale (in
             :math:`{\\rm Jy}\\,{\\rm Mpc}^2\\,M_\\odot^{-1}`).
     """
-    __repr_attrs__ = ("cM", "nu", "alpha", "T0", "beta", "gamma", "s_z",
-                      "l10meff", "sigLM", "Mmin", "L0", "precision_fftlog",)
+    __repr_attrs__ = __eq_attrs__ = (
+        "cM", "nu", "alpha", "T0", "beta", "gamma", "s_z",
+        "l10meff", "sigLM", "Mmin", "L0", "precision_fftlog",)
     name = 'CIBShang12'
     _one_over_4pi = 0.07957747154
 

--- a/pyccl/parameters.py
+++ b/pyccl/parameters.py
@@ -2,9 +2,6 @@ from . import ccllib as lib
 from .errors import warnings, CCLDeprecationWarning
 
 
-EQ_TOL = 0.  # tolerance when comparing arrays in `__eq__` methods
-
-
 class CCLParameters:
     """Base for classes holding global CCL parameters and their values.
 

--- a/pyccl/parameters.py
+++ b/pyccl/parameters.py
@@ -2,6 +2,9 @@ from . import ccllib as lib
 from .errors import warnings, CCLDeprecationWarning
 
 
+EQ_TOL = 0.  # tolerance when comparing arrays in `__eq__` methods
+
+
 class CCLParameters:
     """Base for classes holding global CCL parameters and their values.
 

--- a/pyccl/pk2d.py
+++ b/pyccl/pk2d.py
@@ -130,17 +130,34 @@ class Pk2D(CCLObject):
                                                         int(is_logp), status)
         check(status, cosmo=cosmo)
 
+    def __eq__(self, other):
+        # Check the object class.
+        if self.__class__ is not other.__class__:
+            return False
+        # If the objects contain no data, return early.
+        if not (self or other):
+            return True
+        # Check extrapolation orders.
+        if not (self.extrap_order_lok == other.extrap_order_lok
+                and self.extrap_order_hik == other.extrap_order_hik):
+            return False
+        # Check the individual splines.
+        a1, lk1, pk1 = self.get_spline_arrays()
+        a2, lk2, pk2 = other.get_spline_arrays()
+        return ((a1 == a2).all() and (lk1 == lk2).all()
+                and np.allclose(pk1, pk2, atol=0, rtol=1e-12))
+
     @property
     def has_psp(self):
         return 'psp' in vars(self)
 
     @property
     def extrap_order_lok(self):
-        return self.psp.extrap_order_lok
+        return self.psp.extrap_order_lok if self else None
 
     @property
     def extrap_order_hik(self):
-        return self.psp.extrap_order_hik
+        return self.psp.extrap_order_hik if self else None
 
     @classmethod
     def from_model(cls, cosmo, model):

--- a/pyccl/pk2d.py
+++ b/pyccl/pk2d.py
@@ -7,7 +7,6 @@ from .errors import CCLWarning, CCLError
 from .pyutils import (check, get_pk_spline_a, get_pk_spline_lk,
                       _get_spline1d_arrays, _get_spline2d_arrays)
 from .base import CCLObject, UnlockInstance, unlock_instance
-from .parameters import EQ_TOL
 
 
 class _Pk2D_descriptor:
@@ -146,7 +145,7 @@ class Pk2D(CCLObject):
         a1, lk1, pk1 = self.get_spline_arrays()
         a2, lk2, pk2 = other.get_spline_arrays()
         return ((a1 == a2).all() and (lk1 == lk2).all()
-                and np.allclose(pk1, pk2, atol=0, rtol=EQ_TOL))
+                and np.array_equal(pk1, pk2))
 
     def __hash__(self):
         return hash(repr(self))

--- a/pyccl/pk2d.py
+++ b/pyccl/pk2d.py
@@ -147,6 +147,9 @@ class Pk2D(CCLObject):
         return ((a1 == a2).all() and (lk1 == lk2).all()
                 and np.allclose(pk1, pk2, atol=0, rtol=1e-12))
 
+    def __hash__(self):
+        return hash(repr(self))
+
     @property
     def has_psp(self):
         return 'psp' in vars(self)

--- a/pyccl/pk2d.py
+++ b/pyccl/pk2d.py
@@ -7,6 +7,7 @@ from .errors import CCLWarning, CCLError
 from .pyutils import (check, get_pk_spline_a, get_pk_spline_lk,
                       _get_spline1d_arrays, _get_spline2d_arrays)
 from .base import CCLObject, UnlockInstance, unlock_instance
+from .parameters import EQ_TOL
 
 
 class _Pk2D_descriptor:
@@ -145,7 +146,7 @@ class Pk2D(CCLObject):
         a1, lk1, pk1 = self.get_spline_arrays()
         a2, lk2, pk2 = other.get_spline_arrays()
         return ((a1 == a2).all() and (lk1 == lk2).all()
-                and np.allclose(pk1, pk2, atol=0, rtol=1e-12))
+                and np.allclose(pk1, pk2, atol=0, rtol=EQ_TOL))
 
     def __hash__(self):
         return hash(repr(self))

--- a/pyccl/pk2d.py
+++ b/pyccl/pk2d.py
@@ -132,7 +132,7 @@ class Pk2D(CCLObject):
 
     def __eq__(self, other):
         # Check the object class.
-        if self.__class__ is not other.__class__:
+        if type(self) is not type(other):
             return False
         # If the objects contain no data, return early.
         if not (self or other):

--- a/pyccl/tests/test_cclobject.py
+++ b/pyccl/tests/test_cclobject.py
@@ -99,16 +99,12 @@ def test_CCLObject():
     TR2 = ccl.CMBLensingTracer(cosmo, z_source=1101)
     assert TR1 == TR2
     assert repr(TR1) == repr(TR2)
-    # with transfer
-    z_n = np.linspace(0, 1, 500)
-    n = np.ones(z_n.shape)
-    TR3 = ccl.WeakLensingTracer(cosmo, dndz=(z_n, n))
-    TR4 = ccl.WeakLensingTracer(cosmo, dndz=(z_n, n))
-    assert TR3 == TR4
-    assert repr(TR3) == repr(TR4)
-    TR5 = ccl.WeakLensingTracer(cosmo, dndz=(z_n, 2*n))
-    assert TR3 != TR5
-    assert repr(TR3) != repr(TR5)
+    lk = np.linspace(-5, 1, 32)
+    a = np.linspace(0.5, 1, 4)
+    tka = np.ones((a.size, lk.size))
+    TR1.add_tracer(cosmo, transfer_ka=(a, lk, tka))
+    assert TR1 != TR2
+    assert repr(TR1) != repr(TR2)
 
 
 def test_CCLHalosObject():

--- a/pyccl/tests/test_cclobject.py
+++ b/pyccl/tests/test_cclobject.py
@@ -36,10 +36,12 @@ def test_CCLObject():
     COSMO1 = ccl.CosmologyVanillaLCDM(**kwargs)
     COSMO2 = ccl.CosmologyVanillaLCDM(**kwargs)
     assert COSMO1 == COSMO2
+    assert repr(COSMO1) == repr(COSMO2)
     kwargs = copy.deepcopy(kwargs)
     kwargs["extra_parameters"]["camb"]["halofit_version"] = "mead2020_feedback"
     COSMO2 = ccl.CosmologyVanillaLCDM(**kwargs)
     assert COSMO1 != COSMO2
+    assert repr(COSMO1) != repr(COSMO2)
 
     # 2. Using a Pk2D object.
     cosmo = ccl.CosmologyVanillaLCDM(transfer_function="bbks")
@@ -47,8 +49,11 @@ def test_CCLObject():
     PK1 = cosmo.get_linear_power()
     PK2 = ccl.Pk2D.pk_from_model(cosmo, "bbks")
     assert PK1 == PK2
+    assert repr(PK1) == repr(PK2)
     assert ccl.Pk2D(empty=True) == ccl.Pk2D(empty=True)
+    assert repr(ccl.Pk2D(empty=True)) == repr(ccl.Pk2D(empty=True))
     assert 2*PK1 != PK2
+    assert repr(2*PK1) != repr(PK2)
 
     # 3.1. Using a factorizable Tk3D object.
     a_arr, lk_arr, pk_arr = PK1.get_spline_arrays()
@@ -59,7 +64,9 @@ def test_CCLObject():
     TK3 = ccl.Tk3D(a_arr=a_arr, lk_arr=lk_arr,
                    pk1_arr=2*pk_arr, pk2_arr=2*pk_arr, is_logt=False)
     assert TK1 == TK2
+    assert repr(TK1) == repr(TK2)
     assert TK1 != TK3
+    assert repr(TK1) != repr(TK3)
 
     # 3.2. Using a non-factorizable Tk3D object.
     a_arr_2 = np.arange(0.5, 0.9, 0.1)
@@ -71,6 +78,7 @@ def test_CCLObject():
         a_arr=a_arr_2, lk_arr=lk_arr_2,
         tkk_arr=np.ones((a_arr_2.size, lk_arr_2.size, lk_arr_2.size)))
     assert TK1 == TK2
+    assert repr(TK1) == repr(TK2)
 
     # 4. Using a CosmologyCalculator.
     pk_linear = {"a": a_arr,
@@ -83,11 +91,13 @@ def test_CCLObject():
         Omega_c=0.25, Omega_b=0.05, h=0.67, n_s=0.96, sigma8=0.81,
         pk_linear=pk_linear, pk_nonlin=pk_linear)
     assert COSMO1 == COSMO2
+    assert repr(COSMO1) == repr(COSMO2)
 
     # 5. Using a Tracer object.
     TR1 = ccl.CMBLensingTracer(cosmo, z_source=1101)
     TR2 = ccl.CMBLensingTracer(cosmo, z_source=1101)
     assert TR1 == TR2
+    assert repr(TR1) == repr(TR2)
 
 
 def test_CCLHalosObject():
@@ -116,16 +126,19 @@ def test_CCLHalosObject():
     CM2 = ccl.halos.ConcentrationDuffy08()
     assert CM1 == CM2
 
-    # TODO: uncomment once __eq__ methods are implemented.
-    # P1 = ccl.halos.HaloProfileHOD(c_M_relation=CM1)
-    # P2 = ccl.halos.HaloProfileHOD(c_M_relation=CM2)
-    # assert P1 == P2
+    P1 = ccl.halos.HaloProfileHOD(c_M_relation=CM1)
+    P2 = ccl.halos.HaloProfileHOD(c_M_relation=CM2)
+    assert P1 == P2
+    assert repr(P1) == repr(P2)
+    P1.update_parameters(lMmin_0=P1.lMmin_0/2)
+    assert P1 != P2
+    assert repr(P1) != repr(P2)
 
-    # PCOV1 = ccl.halos.Profile2pt(r_corr=1.5)
-    # PCOV2 = ccl.halos.Profile2pt(r_corr=1.0)
-    # assert PCOV1 != PCOV2
-    # PCOV2.update_parameters(r_corr=1.5)
-    # assert PCOV1 == PCOV2
+    PCOV1 = ccl.halos.Profile2pt(r_corr=1.5)
+    PCOV2 = ccl.halos.Profile2pt(r_corr=1.0)
+    assert PCOV1 != PCOV2
+    PCOV2.update_parameters(r_corr=1.5)
+    assert PCOV1 == PCOV2
 
 
 def test_CCLObject_immutable():
@@ -151,13 +164,14 @@ def test_CCLObject_immutable():
     prof.update_parameters(mass_bias=0.7)
     assert prof.mass_bias == 0.7
 
-    # TODO: uncomment once __eq__ methods are implemented.
     # Check that the hash repr is deleted as required.
-    # prof1 = ccl.halos.HaloProfilePressureGNFW(mass_bias=0.5)
-    # prof2 = ccl.halos.HaloProfilePressureGNFW(mass_bias=0.5)
-    # assert prof1 == prof2                   # repr is cached
-    # prof2.update_parameters(mass_bias=0.7)  # cached repr is deleted
-    # assert prof1 != prof2                   # repr is cached again
+    prof1 = ccl.halos.HaloProfilePressureGNFW(mass_bias=0.5)
+    prof2 = ccl.halos.HaloProfilePressureGNFW(mass_bias=0.5)
+    assert prof1 == prof2                   # repr is cached
+    assert hash(prof1) == hash(prof2)
+    prof2.update_parameters(mass_bias=0.7)  # cached repr is deleted
+    assert prof1 != prof2                   # repr is cached again
+    assert hash(prof1) != hash(prof2)
 
 
 def test_CCLObject_default_behavior():

--- a/pyccl/tests/test_cclobject.py
+++ b/pyccl/tests/test_cclobject.py
@@ -2,23 +2,21 @@ import pytest
 import numpy as np
 import pyccl as ccl
 import functools
+import copy
 
 
 def test_fancy_repr():
     # Test fancy-repr controls.
-    cosmo1 = ccl.CosmologyVanillaLCDM()
-    cosmo2 = ccl.CosmologyVanillaLCDM()
+    cosmo = ccl.CosmologyVanillaLCDM()
 
     ccl.CCLObject._fancy_repr.disable()
-    assert repr(cosmo1) == object.__repr__(cosmo1)
-    assert cosmo1 != cosmo2
+    assert repr(cosmo) == object.__repr__(cosmo)
 
     ccl.CCLObject._fancy_repr.enable()
-    assert repr(cosmo1) != object.__repr__(cosmo1)
-    assert cosmo1 == cosmo2
+    assert repr(cosmo) != object.__repr__(cosmo)
 
     with pytest.raises(AttributeError):
-        cosmo1._fancy_repr.disable()
+        cosmo._fancy_repr.disable()
 
     with pytest.raises(AttributeError):
         ccl.Cosmology._fancy_repr.disable()
@@ -34,13 +32,12 @@ def test_CCLObject():
     extras = {"camb": {"halofit_version": "mead2020", "HMCode_logT_AGN": 7.8}}
     kwargs = {"transfer_function": "bbks",
               "matter_power_spectrum": "emu",
-              "z_mg": np.ones(10),
-              "df_mg": np.ones(10),
               "extra_parameters": extras}
     COSMO1 = ccl.CosmologyVanillaLCDM(**kwargs)
     COSMO2 = ccl.CosmologyVanillaLCDM(**kwargs)
     assert COSMO1 == COSMO2
-    kwargs["df_mg"] *= 2
+    kwargs = copy.deepcopy(kwargs)
+    kwargs["extra_parameters"]["camb"]["halofit_version"] = "mead2020_feedback"
     COSMO2 = ccl.CosmologyVanillaLCDM(**kwargs)
     assert COSMO1 != COSMO2
 

--- a/pyccl/tests/test_cclobject.py
+++ b/pyccl/tests/test_cclobject.py
@@ -94,10 +94,21 @@ def test_CCLObject():
     assert repr(COSMO1) == repr(COSMO2)
 
     # 5. Using a Tracer object.
+    # no transfer
     TR1 = ccl.CMBLensingTracer(cosmo, z_source=1101)
     TR2 = ccl.CMBLensingTracer(cosmo, z_source=1101)
     assert TR1 == TR2
     assert repr(TR1) == repr(TR2)
+    # with transfer
+    z_n = np.linspace(0, 1, 500)
+    n = np.ones(z_n.shape)
+    TR3 = ccl.WeakLensingTracer(cosmo, dndz=(z_n, n))
+    TR4 = ccl.WeakLensingTracer(cosmo, dndz=(z_n, n))
+    assert TR3 == TR4
+    assert repr(TR3) == repr(TR4)
+    TR5 = ccl.WeakLensingTracer(cosmo, dndz=(z_n, 2*n))
+    assert TR3 != TR5
+    assert repr(TR3) != repr(TR5)
 
 
 def test_CCLHalosObject():
@@ -187,6 +198,14 @@ def test_HaloProfile_abstractmethods():
     # either `_real` or `_fourier` have not been defined.
     with pytest.raises(TypeError):
         ccl.halos.HaloProfile()
+
+
+def repr_attrs_default():
+    """Test that all subclasses of ``CCLHalosObject`` use Python's default
+    ``repr`` if no ``__repr_attrs__`` has been defined.
+    """
+    ccl.CCLHalosObject() != ccl.CCLHalosObject()
+    repr(ccl.CCLHalosObject) != repr(ccl.CCLHalosObject())
 
 
 def init_decorator(func):

--- a/pyccl/tests/test_cclobject.py
+++ b/pyccl/tests/test_cclobject.py
@@ -1,8 +1,6 @@
 import pytest
-import numpy as np
 import pyccl as ccl
 import functools
-import copy
 
 
 def test_fancy_repr():
@@ -25,130 +23,20 @@ def test_fancy_repr():
         ccl.base.FancyRepr()
 
 
-def test_CCLObject():
-    # Test eq --> repr <-- hash for all kinds of CCL objects.
-
-    # 1.1. Using a complicated Cosmology object.
-    extras = {"camb": {"halofit_version": "mead2020", "HMCode_logT_AGN": 7.8}}
-    kwargs = {"transfer_function": "bbks",
-              "matter_power_spectrum": "emu",
-              "extra_parameters": extras}
-    COSMO1 = ccl.CosmologyVanillaLCDM(**kwargs)
-    COSMO2 = ccl.CosmologyVanillaLCDM(**kwargs)
-    assert COSMO1 == COSMO2
-    assert repr(COSMO1) == repr(COSMO2)
-    kwargs = copy.deepcopy(kwargs)
-    kwargs["extra_parameters"]["camb"]["halofit_version"] = "mead2020_feedback"
-    COSMO2 = ccl.CosmologyVanillaLCDM(**kwargs)
-    assert COSMO1 != COSMO2
-    assert repr(COSMO1) != repr(COSMO2)
-
-    # 2. Using a Pk2D object.
-    cosmo = ccl.CosmologyVanillaLCDM(transfer_function="bbks")
-    cosmo.compute_linear_power()
-    PK1 = cosmo.get_linear_power()
-    PK2 = ccl.Pk2D.pk_from_model(cosmo, "bbks")
-    assert PK1 == PK2
-    assert repr(PK1) == repr(PK2)
-    assert ccl.Pk2D(empty=True) == ccl.Pk2D(empty=True)
-    assert repr(ccl.Pk2D(empty=True)) == repr(ccl.Pk2D(empty=True))
-    assert 2*PK1 != PK2
-    assert repr(2*PK1) != repr(PK2)
-
-    # 3.1. Using a factorizable Tk3D object.
-    a_arr, lk_arr, pk_arr = PK1.get_spline_arrays()
-    TK1 = ccl.Tk3D(a_arr=a_arr, lk_arr=lk_arr,
-                   pk1_arr=pk_arr, pk2_arr=pk_arr, is_logt=False)
-    TK2 = ccl.Tk3D(a_arr=a_arr, lk_arr=lk_arr,
-                   pk1_arr=pk_arr, pk2_arr=pk_arr, is_logt=False)
-    TK3 = ccl.Tk3D(a_arr=a_arr, lk_arr=lk_arr,
-                   pk1_arr=2*pk_arr, pk2_arr=2*pk_arr, is_logt=False)
-    assert TK1 == TK2
-    assert repr(TK1) == repr(TK2)
-    assert TK1 != TK3
-    assert repr(TK1) != repr(TK3)
-
-    # 3.2. Using a non-factorizable Tk3D object.
-    a_arr_2 = np.arange(0.5, 0.9, 0.1)
-    lk_arr_2 = np.linspace(-2, 1, 8)
-    TK1 = ccl.Tk3D(
-        a_arr=a_arr_2, lk_arr=lk_arr_2,
-        tkk_arr=np.ones((a_arr_2.size, lk_arr_2.size, lk_arr_2.size)))
-    TK2 = ccl.Tk3D(
-        a_arr=a_arr_2, lk_arr=lk_arr_2,
-        tkk_arr=np.ones((a_arr_2.size, lk_arr_2.size, lk_arr_2.size)))
-    assert TK1 == TK2
-    assert repr(TK1) == repr(TK2)
-
-    # 4. Using a CosmologyCalculator.
-    pk_linear = {"a": a_arr,
-                 "k": np.exp(lk_arr),
-                 "delta_matter:delta_matter": pk_arr}
-    COSMO1 = ccl.CosmologyCalculator(
-        Omega_c=0.25, Omega_b=0.05, h=0.67, n_s=0.96, sigma8=0.81,
-        pk_linear=pk_linear, pk_nonlin=pk_linear)
-    COSMO2 = ccl.CosmologyCalculator(
-        Omega_c=0.25, Omega_b=0.05, h=0.67, n_s=0.96, sigma8=0.81,
-        pk_linear=pk_linear, pk_nonlin=pk_linear)
-    assert COSMO1 == COSMO2
-    assert repr(COSMO1) == repr(COSMO2)
-
-    # 5. Using a Tracer object.
-    # no transfer
-    TR1 = ccl.CMBLensingTracer(cosmo, z_source=1101)
-    TR2 = ccl.CMBLensingTracer(cosmo, z_source=1101)
-    assert TR1 == TR2
-    assert repr(TR1) == repr(TR2)
-    lk = np.linspace(-5, 1, 32)
-    a = np.linspace(0.5, 1, 4)
-    tka = np.ones((a.size, lk.size))
-    TR1.add_tracer(cosmo, transfer_ka=(a, lk, tka))
-    assert TR1 != TR2
-    assert repr(TR1) != repr(TR2)
+def check_eq_repr_hash(self, other, *, equal=True):
+    # Helper to ensure `__eq__`, `__repr__`, `__hash__` are consistent.
+    if equal:
+        return (self == other
+                and repr(self) == repr(other)
+                and hash(self) == hash(other))
+    return (self != other
+            and repr(self) != repr(other)
+            and hash(self) != hash(other))
 
 
-def test_CCLHalosObject():
-    # Test eq --> repr <-- hash for all kinds of CCL halo objects.
-
-    # 1. Build a halo model calculator using the default parametrizations.
-    cosmo = ccl.CosmologyVanillaLCDM(transfer_function="bbks")
-    HMC = ccl.halos.HMCalculator(
-        cosmo, massfunc="Tinker08", hbias="Tinker10", mass_def="200m")
-
-    # 2. Define separate default halo model ingredients.
-    MDEF = ccl.halos.MassDef200m()
-    HMF = ccl.halos.MassFuncTinker08(cosmo, mass_def=MDEF)
-    HBF = ccl.halos.HaloBiasTinker10(cosmo, mass_def=MDEF)
-
-    # 3. Test equivalence.
-    assert MDEF == HMC._mdef
-    assert HMF == HMC._massfunc
-    assert HBF == HMC._hbias
-    HMC2 = ccl.halos.HMCalculator(
-        cosmo, massfunc=HMF, hbias=HBF, mass_def=MDEF)
-    assert HMC == HMC2
-
-    # 4. Test halo profiles.
-    CM1 = ccl.halos.Concentration.from_name("Duffy08")()
-    CM2 = ccl.halos.ConcentrationDuffy08()
-    assert CM1 == CM2
-
-    P1 = ccl.halos.HaloProfileHOD(c_M_relation=CM1)
-    P2 = ccl.halos.HaloProfileHOD(c_M_relation=CM2)
-    assert P1 == P2
-    assert repr(P1) == repr(P2)
-    P1.update_parameters(lMmin_0=P1.lMmin_0/2)
-    assert P1 != P2
-    assert repr(P1) != repr(P2)
-
-    PCOV1 = ccl.halos.Profile2pt(r_corr=1.5)
-    PCOV2 = ccl.halos.Profile2pt(r_corr=1.0)
-    assert PCOV1 != PCOV2
-    PCOV2.update_parameters(r_corr=1.5)
-    assert PCOV1 == PCOV2
-
-
-def test_CCLObject_immutable():
+def test_CCLObject_immutability():
+    # These tests check the behavior of immutable objects, i.e. instances
+    # of classes where `Funlock` or `unlock_instance` is not used.
     # test `CCLObject` lock
     obj = ccl.CCLObject()
     obj._object_lock.unlock()
@@ -171,37 +59,22 @@ def test_CCLObject_immutable():
     prof.update_parameters(mass_bias=0.7)
     assert prof.mass_bias == 0.7
 
-    # Check that the hash repr is deleted as required.
-    prof1 = ccl.halos.HaloProfilePressureGNFW(mass_bias=0.5)
-    prof2 = ccl.halos.HaloProfilePressureGNFW(mass_bias=0.5)
-    assert prof1 == prof2                   # repr is cached
-    assert hash(prof1) == hash(prof2)
-    prof2.update_parameters(mass_bias=0.7)  # cached repr is deleted
-    assert prof1 != prof2                   # repr is cached again
-    assert hash(prof1) != hash(prof2)
-
 
 def test_CCLObject_default_behavior():
     # Test that if `__repr__` is not defined the fall back is safe.
     MyType = type("MyType", (ccl.CCLObject,), {"test": 0})
     instances = [MyType() for _ in range(2)]
-    assert instances[0] != instances[1]
-    assert hash(instances[0]) != hash(instances[1])
+    assert check_eq_repr_hash(*instances, equal=False)
+
+    # Test that all subclasses of ``CCLHalosObject`` use Python's default
+    # ``repr`` if no ``__repr_attrs__`` has been defined.
+    instances = [ccl.CCLHalosObject() for _ in range(2)]
+    assert check_eq_repr_hash(*instances, equal=False)
 
 
-def test_HaloProfile_abstractmethods():
-    # Test that `HaloProfile` and its subclasses can't be instantiated if
-    # either `_real` or `_fourier` have not been defined.
-    with pytest.raises(TypeError):
-        ccl.halos.HaloProfile()
-
-
-def repr_attrs_default():
-    """Test that all subclasses of ``CCLHalosObject`` use Python's default
-    ``repr`` if no ``__repr_attrs__`` has been defined.
-    """
-    ccl.CCLHalosObject() != ccl.CCLHalosObject()
-    repr(ccl.CCLHalosObject) != repr(ccl.CCLHalosObject())
+# +==========================================================================+
+# | The following functions are used by `conftest.py` to check correct setup.|
+# +==========================================================================+
 
 
 def init_decorator(func):

--- a/pyccl/tests/test_concentration.py
+++ b/pyccl/tests/test_concentration.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import pyccl as ccl
+from .test_cclobject import check_eq_repr_hash
 
 
 COSMO = ccl.Cosmology(
@@ -18,6 +19,19 @@ MS = [1E13, [1E12, 1E15], np.array([1E12, 1E15])]
 # are defined for FoF halos, or 400 critical.
 MDEF = ccl.halos.MassDef('fof', 'matter')
 M400 = ccl.halos.MassDef(400, 'critical')
+
+
+def test_Concentration_eq_repr_hash():
+    # Test eq, repr, hash for Concentration.
+    CM1 = ccl.halos.Concentration.from_name("Duffy08")()
+    CM2 = ccl.halos.ConcentrationDuffy08()
+    assert check_eq_repr_hash(CM1.mdef, CM2.mdef)
+    assert check_eq_repr_hash(CM1, CM2)
+
+    M200m = ccl.halos.MassDef200m()
+    CM3 = ccl.halos.ConcentrationDuffy08(mdef=M200m)
+    assert check_eq_repr_hash(CM1.mdef, CM3.mdef, equal=False)
+    assert check_eq_repr_hash(CM1, CM3, equal=False)
 
 
 @pytest.mark.parametrize('cM_class', CONCS)

--- a/pyccl/tests/test_cosmology.py
+++ b/pyccl/tests/test_cosmology.py
@@ -9,7 +9,7 @@ import warnings
 from .test_cclobject import check_eq_repr_hash
 
 
-def test_HMIngredients_eq_repr_hash():
+def test_Cosmology_eq_repr_hash():
     # Test eq, repr, hash for Cosmology and CosmologyCalculator.
     # 1. Using a complicated Cosmology object.
     extras = {"camb": {"halofit_version": "mead2020", "HMCode_logT_AGN": 7.8}}
@@ -40,7 +40,9 @@ def test_HMIngredients_eq_repr_hash():
         pk_linear=pk_linear, pk_nonlin=pk_linear)
     assert check_eq_repr_hash(COSMO4, COSMO5)
 
-    pk_linear["delta_matter:delta_matter"] *= 2
+    pk_linear = {"a": a_arr,
+                 "k": np.exp(lk_arr),
+                 "delta_matter:delta_matter": 2*pk_arr}
     COSMO6 = ccl.CosmologyCalculator(
         Omega_c=0.25, Omega_b=0.05, h=0.67, n_s=0.96, sigma8=0.81,
         pk_linear=pk_linear, pk_nonlin=pk_linear)

--- a/pyccl/tests/test_cosmology.py
+++ b/pyccl/tests/test_cosmology.py
@@ -4,6 +4,46 @@ import pytest
 import numpy as np
 from numpy.testing import assert_raises, assert_, assert_no_warnings
 import pyccl as ccl
+import copy
+from .test_cclobject import check_eq_repr_hash
+
+
+def test_HMIngredients_eq_repr_hash():
+    # Test eq, repr, hash for Cosmology and CosmologyCalculator.
+    # 1. Using a complicated Cosmology object.
+    extras = {"camb": {"halofit_version": "mead2020", "HMCode_logT_AGN": 7.8}}
+    kwargs = {"transfer_function": "bbks",
+              "matter_power_spectrum": "linear",
+              "extra_parameters": extras}
+    COSMO1 = ccl.CosmologyVanillaLCDM(**kwargs)
+    COSMO2 = ccl.CosmologyVanillaLCDM(**kwargs)
+    assert check_eq_repr_hash(COSMO1, COSMO2)
+
+    # 2. Now make a copy and change it.
+    kwargs = copy.deepcopy(kwargs)
+    kwargs["extra_parameters"]["camb"]["halofit_version"] = "mead2020_feedback"
+    COSMO3 = ccl.CosmologyVanillaLCDM(**kwargs)
+    assert check_eq_repr_hash(COSMO1, COSMO3, equal=False)
+
+    # 3. Using a CosmologyCalculator.
+    COSMO1.compute_linear_power()
+    a_arr, lk_arr, pk_arr = COSMO1.get_linear_power().get_spline_arrays()
+    pk_linear = {"a": a_arr,
+                 "k": np.exp(lk_arr),
+                 "delta_matter:delta_matter": pk_arr}
+    COSMO4 = ccl.CosmologyCalculator(
+        Omega_c=0.25, Omega_b=0.05, h=0.67, n_s=0.96, sigma8=0.81,
+        pk_linear=pk_linear, pk_nonlin=pk_linear)
+    COSMO5 = ccl.CosmologyCalculator(
+        Omega_c=0.25, Omega_b=0.05, h=0.67, n_s=0.96, sigma8=0.81,
+        pk_linear=pk_linear, pk_nonlin=pk_linear)
+    assert check_eq_repr_hash(COSMO4, COSMO5)
+
+    pk_linear["delta_matter:delta_matter"] *= 2
+    COSMO6 = ccl.CosmologyCalculator(
+        Omega_c=0.25, Omega_b=0.05, h=0.67, n_s=0.96, sigma8=0.81,
+        pk_linear=pk_linear, pk_nonlin=pk_linear)
+    assert check_eq_repr_hash(COSMO4, COSMO6, equal=False)
 
 
 def test_cosmo_methods():

--- a/pyccl/tests/test_pk2d.py
+++ b/pyccl/tests/test_pk2d.py
@@ -5,6 +5,29 @@ from numpy.testing import (
     assert_raises, assert_almost_equal, assert_allclose)
 import pyccl as ccl
 from pyccl import CCLWarning
+from .test_cclobject import check_eq_repr_hash
+
+
+def test_Pk2D_eq_repr_hash():
+    # Test eq, repr, hash for Pk2D.
+    cosmo = ccl.CosmologyVanillaLCDM(transfer_function="bbks")
+    cosmo.compute_linear_power()
+    PK1 = cosmo.get_linear_power()
+    PK2 = ccl.Pk2D.pk_from_model(cosmo, "bbks")
+    assert check_eq_repr_hash(PK1, PK2)
+    assert check_eq_repr_hash(ccl.Pk2D(empty=True), ccl.Pk2D(empty=True))
+    assert check_eq_repr_hash(2*PK1, PK2, equal=False)
+
+    # edge-case: comparing different types
+    assert check_eq_repr_hash(PK1, 1, equal=False)
+
+    # edge-case: different extrapolation orders
+    a_arr, lk_arr, pk_arr = PK1.get_spline_arrays()
+    pk1 = ccl.Pk2D(a_arr=a_arr, lk_arr=lk_arr, pk_arr=pk_arr,
+                   is_logp=False, extrap_order_lok=0)
+    pk2 = ccl.Pk2D(a_arr=a_arr, lk_arr=lk_arr, pk_arr=pk_arr,
+                   is_logp=False, extrap_order_lok=1)
+    assert check_eq_repr_hash(pk1, pk2, equal=False)
 
 
 def pk1d(k):

--- a/pyccl/tests/test_pkhm.py
+++ b/pyccl/tests/test_pkhm.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import pyccl as ccl
+from .test_cclobject import check_eq_repr_hash
 
 
 COSMO = ccl.Cosmology(
@@ -72,6 +73,34 @@ def smoke_assert_pkhm_real(func):
         p = func(k, a)
         assert np.shape(p) == sh
         assert np.all(np.isfinite(p))
+
+
+def test_HMIngredients_eq_repr_hash():
+    # Test eq, repr, hash for the HMCalculator and its ingredients.
+    # 1. Build a halo model calculator using the default parametrizations.
+    cosmo = ccl.CosmologyVanillaLCDM(transfer_function="bbks")
+    HMC = ccl.halos.HMCalculator(
+        cosmo, massfunc="Tinker08", hbias="Tinker10", mass_def="200m")
+
+    # 2. Define separate default halo model ingredients.
+    MDEF = ccl.halos.MassDef200m()
+    HMF = ccl.halos.MassFuncTinker08(cosmo, mass_def=MDEF)
+    HBF = ccl.halos.HaloBiasTinker10(cosmo, mass_def=MDEF)
+    HMC2 = ccl.halos.HMCalculator(
+        cosmo, massfunc=HMF, hbias=HBF, mass_def=MDEF)  # equal
+    HMC3 = ccl.halos.HMCalculator(
+        cosmo, massfunc="Press74", hbias="Sheth01", mass_def="fof")  # unequal
+
+    # 3. Test equivalence.
+    assert check_eq_repr_hash(MDEF, HMC._mdef)
+    assert check_eq_repr_hash(HMF, HMC._massfunc)
+    assert check_eq_repr_hash(HBF, HMC._hbias)
+    assert check_eq_repr_hash(HMC, HMC2)
+
+    assert check_eq_repr_hash(MDEF, HMC3._mdef, equal=False)
+    assert check_eq_repr_hash(HMF, HMC3._massfunc, equal=False)
+    assert check_eq_repr_hash(HBF, HMC3._hbias, equal=False)
+    assert check_eq_repr_hash(HMC, HMC3, equal=False)
 
 
 @pytest.mark.parametrize('norm', [True, False])

--- a/pyccl/tests/test_profiles.py
+++ b/pyccl/tests/test_profiles.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import pyccl as ccl
 from pyccl import UnlockInstance
+from .test_cclobject import check_eq_repr_hash
 
 
 COSMO = ccl.Cosmology(
@@ -9,6 +10,29 @@ COSMO = ccl.Cosmology(
     transfer_function='bbks', matter_power_spectrum='linear')
 M200 = ccl.halos.MassDef200c()
 M500c = ccl.halos.MassDef(500, 'critical')
+
+
+def test_HaloProfile_eq_repr_hash():
+    # Test eq, repr, hash for HaloProfile and Profile2pt.
+    # 1. HaloProfile
+    CM1 = ccl.halos.Concentration.from_name("Duffy08")()
+    CM2 = ccl.halos.Concentration.from_name("Duffy08")()
+
+    P1 = ccl.halos.HaloProfileHOD(c_M_relation=CM1)
+    P2 = ccl.halos.HaloProfileHOD(c_M_relation=CM2)
+    assert check_eq_repr_hash(CM1, CM2)
+    assert check_eq_repr_hash(P1, P2)
+
+    P1.update_parameters(lMmin_0=P1.lMmin_0/2)
+    assert check_eq_repr_hash(P1, P2, equal=False)
+
+    # 2. Profile2pt
+    PCOV1 = ccl.halos.Profile2pt(r_corr=1.0)
+    PCOV2 = ccl.halos.Profile2pt(r_corr=1.0)
+    assert check_eq_repr_hash(PCOV1, PCOV2)
+
+    PCOV2.update_parameters(r_corr=1.5)
+    assert check_eq_repr_hash(PCOV1, PCOV2, equal=False)
 
 
 def one_f(cosmo, M, a=1, mdef=M200):
@@ -571,3 +595,10 @@ def test_hernquist_cumul2d_accuracy(fourier_analytic):
 
     res2 = np.fabs(srt2/srt1-1)
     assert np.all(res2 < 5E-3)
+
+
+def test_HaloProfile_abstractmethods():
+    # Test that `HaloProfile` and its subclasses can't be instantiated if
+    # either `_real` or `_fourier` have not been defined.
+    with pytest.raises(TypeError):
+        ccl.halos.HaloProfile()

--- a/pyccl/tests/test_tk3d.py
+++ b/pyccl/tests/test_tk3d.py
@@ -4,6 +4,60 @@ from numpy.testing import (
     assert_,
     assert_raises, assert_almost_equal, assert_allclose)
 import pyccl as ccl
+from .test_cclobject import check_eq_repr_hash
+
+
+def test_Tk3D_eq_repr_hash():
+    # Test eq, repr, hash for Tk3D.
+    cosmo = ccl.CosmologyVanillaLCDM(transfer_function="bbks")
+    cosmo.compute_linear_power()
+    PK1 = cosmo.get_linear_power()
+
+    # 1. Using a factorizable Tk3D object.
+    a_arr, lk_arr, pk_arr = PK1.get_spline_arrays()
+    TK1 = ccl.Tk3D(a_arr=a_arr, lk_arr=lk_arr,
+                   pk1_arr=pk_arr, pk2_arr=pk_arr, is_logt=False)
+    TK2 = ccl.Tk3D(a_arr=a_arr, lk_arr=lk_arr,
+                   pk1_arr=pk_arr, pk2_arr=pk_arr, is_logt=False)
+    assert check_eq_repr_hash(TK1, TK2)
+
+    TK3 = ccl.Tk3D(a_arr=a_arr, lk_arr=lk_arr,
+                   pk1_arr=2*pk_arr, pk2_arr=2*pk_arr, is_logt=False)
+    assert check_eq_repr_hash(TK1, TK3, equal=False)
+
+    # 2. Using a non-factorizable Tk3D object.
+    a_arr_2 = np.arange(0.5, 0.9, 0.1)
+    lk_arr_2 = np.linspace(-2, 1, 8)
+    TK4 = ccl.Tk3D(
+        a_arr=a_arr_2, lk_arr=lk_arr_2,
+        tkk_arr=np.ones((a_arr_2.size, lk_arr_2.size, lk_arr_2.size)))
+    TK5 = ccl.Tk3D(
+        a_arr=a_arr_2, lk_arr=lk_arr_2,
+        tkk_arr=np.ones((a_arr_2.size, lk_arr_2.size, lk_arr_2.size)))
+    assert check_eq_repr_hash(TK4, TK5)
+
+    TK6 = ccl.Tk3D(
+        a_arr=a_arr_2, lk_arr=lk_arr_2,
+        tkk_arr=2*np.ones((a_arr_2.size, lk_arr_2.size, lk_arr_2.size)))
+    assert check_eq_repr_hash(TK4, TK6, equal=False)
+
+    # edge-case: comparing different types
+    assert check_eq_repr_hash(TK1, 1, equal=False)
+
+    # edge-case: empty objects
+    tka1, tka2 = [ccl.Tk3D.__new__(ccl.Tk3D) for _ in range(2)]
+    assert check_eq_repr_hash(tka1, tka2)
+
+    # edge-case: only one Tk is factorizable (exits early)
+    assert check_eq_repr_hash(TK1, TK4, equal=False)
+
+    # edge-case: different extrapolation orders
+    a_arr, lk_arr, pk_arr = PK1.get_spline_arrays()
+    t1 = ccl.Tk3D(a_arr=a_arr, lk_arr=lk_arr, pk1_arr=pk_arr, pk2_arr=pk_arr,
+                  is_logt=False, extrap_order_lok=0)
+    t2 = ccl.Tk3D(a_arr=a_arr, lk_arr=lk_arr, pk1_arr=pk_arr, pk2_arr=pk_arr,
+                  is_logt=False, extrap_order_lok=1)
+    assert check_eq_repr_hash(t1, t2, equal=False)
 
 
 def kf(k):

--- a/pyccl/tests/test_tracers.py
+++ b/pyccl/tests/test_tracers.py
@@ -60,6 +60,12 @@ def test_Tracer_eq_repr_hash():
     t2.add_tracer(COSMO)
     assert check_eq_repr_hash(t1, t2, equal=False)
 
+    # edge-case: only one has specific transfer type
+    t1, t2 = ccl.Tracer(), ccl.Tracer()
+    t1.add_tracer(COSMO, transfer_k=(lk, np.ones_like(lk)))
+    t2.add_tracer(COSMO, transfer_a=(a, np.ones_like(a)))
+    assert check_eq_repr_hash(t1, t2, equal=False)
+
 
 def dndz(z):
     return np.exp(-((z-0.5)/0.1)**2)

--- a/pyccl/tests/test_tracers.py
+++ b/pyccl/tests/test_tracers.py
@@ -418,6 +418,11 @@ def test_tracer_repr():
     t_k = np.ones_like(lk)
     tr6.add_tracer(COSMO, transfer_k=(lk, t_k))
     tr7.add_tracer(COSMO, transfer_k=(lk, t_k))
+    assert tr6 == tr7
+    # transfer_a
+    tr6.add_tracer(COSMO, transfer_a=(1/(1+z)[::-1], nz))
+    tr7.add_tracer(COSMO, transfer_a=(1/(1+z)[::-1], nz))
+    assert tr6 == tr7
     # transfer_ka
     a = np.linspace(0.5, 1.0, 8)
     t_ka = np.ones((a.size, lk.size))

--- a/pyccl/tk3d.py
+++ b/pyccl/tk3d.py
@@ -135,7 +135,7 @@ class Tk3D(CCLObject):
 
     def __eq__(self, other):
         # Check the object class.
-        if self.__class__ is not other.__class__:
+        if type(self) is not type(other):
             return False
         # If the objects contain no data, return early.
         if not (self or other):

--- a/pyccl/tk3d.py
+++ b/pyccl/tk3d.py
@@ -154,6 +154,9 @@ class Tk3D(CCLObject):
                 and (lk11 == lk21).all() and (lk21 == lk22).all()
                 and np.allclose(tk1, tk2, atol=0, rtol=1e-12))
 
+    def __hash__(self):
+        return hash(repr(self))
+
     @property
     def has_tsp(self):
         return 'tsp' in vars(self)

--- a/pyccl/tk3d.py
+++ b/pyccl/tk3d.py
@@ -1,7 +1,6 @@
 from . import ccllib as lib
 from .pyutils import check, _get_spline2d_arrays, _get_spline3d_arrays
 from .base import CCLObject
-from .parameters import EQ_TOL
 import numpy as np
 
 
@@ -153,7 +152,7 @@ class Tk3D(CCLObject):
         a2, lk21, lk22, tk2 = other.get_spline_arrays()
         return ((a1 == a2).all()
                 and (lk11 == lk21).all() and (lk21 == lk22).all()
-                and np.allclose(tk1, tk2, atol=0, rtol=EQ_TOL))
+                and np.array_equal(tk1, tk2))
 
     def __hash__(self):
         return hash(repr(self))

--- a/pyccl/tk3d.py
+++ b/pyccl/tk3d.py
@@ -133,9 +133,38 @@ class Tk3D(CCLObject):
                                                         int(is_logt), status)
         check(status)
 
+    def __eq__(self, other):
+        # Check the object class.
+        if self.__class__ is not other.__class__:
+            return False
+        # If the objects contain no data, return early.
+        if not (self or other):
+            return True
+        # If one is factorizable and the other one is not, return early.
+        if self.tsp.is_product ^ other.tsp.is_product:
+            return False
+        # Check extrapolation orders.
+        if not (self.extrap_order_lok == other.extrap_order_lok
+                and self.extrap_order_hik == other.extrap_order_hik):
+            return False
+        # Check the individual splines.
+        a1, lk11, lk12, tk1 = self.get_spline_arrays()
+        a2, lk21, lk22, tk2 = other.get_spline_arrays()
+        return ((a1 == a2).all()
+                and (lk11 == lk21).all() and (lk21 == lk22).all()
+                and np.allclose(tk1, tk2, atol=0, rtol=1e-12))
+
     @property
     def has_tsp(self):
         return 'tsp' in vars(self)
+
+    @property
+    def extrap_order_lok(self):
+        return self.tsp.extrap_order_lok if self else None
+
+    @property
+    def extrap_order_hik(self):
+        return self.tsp.extrap_order_hik if self else None
 
     def eval(self, k, a):
         """Evaluate trispectrum. If `k` is a 1D array with size `nk`, the

--- a/pyccl/tk3d.py
+++ b/pyccl/tk3d.py
@@ -1,6 +1,7 @@
 from . import ccllib as lib
 from .pyutils import check, _get_spline2d_arrays, _get_spline3d_arrays
 from .base import CCLObject
+from .parameters import EQ_TOL
 import numpy as np
 
 
@@ -152,7 +153,7 @@ class Tk3D(CCLObject):
         a2, lk21, lk22, tk2 = other.get_spline_arrays()
         return ((a1 == a2).all()
                 and (lk11 == lk21).all() and (lk21 == lk22).all()
-                and np.allclose(tk1, tk2, atol=0, rtol=1e-12))
+                and np.allclose(tk1, tk2, atol=0, rtol=EQ_TOL))
 
     def __hash__(self):
         return hash(repr(self))

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -187,7 +187,7 @@ class Tracer(CCLObject):
 
     def __eq__(self, other):
         # Check the object class.
-        if self.__class__ is not other.__class__:
+        if type(self) is not type(other):
             return False
 
         # If the tracer collections are empty, return early.

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -7,7 +7,7 @@ from .core import check
 from .background import (comoving_radial_distance, growth_rate,
                          growth_factor, scale_factor_of_chi, h_over_h0)
 from .errors import CCLWarning
-from .parameters import physical_constants
+from .parameters import physical_constants, EQ_TOL
 from .base import CCLObject, UnlockInstance, unlock_instance
 from .pyutils import (_check_array_params, NoneArr, _vectorize_fn6,
                       _get_spline1d_arrays, _get_spline2d_arrays)
@@ -205,7 +205,7 @@ class Tracer(CCLObject):
             return False
 
         # Check the kernels.
-        kwargs = {"atol": 0, "rtol": 1e-12, "equal_nan": True}
+        kwargs = {"atol": 0, "rtol": EQ_TOL, "equal_nan": True}
         for t1, t2 in zip(self._trc, other._trc):
             if bool(t1.kernel) ^ bool(t2.kernel):
                 # only one of them has a kernel

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -185,6 +185,29 @@ class Tracer(CCLObject):
         # Do nothing, just initialize list of tracers
         self._trc = []
 
+    def __eq__(self, other):
+        # Check the object class.
+        if self.__class__ is not other.__class__:
+            return False
+        # If the tracer collections are empty, return early.
+        if not (self or other):
+            return True
+        # If the tracer collections are not the same length, return early.
+        if len(self._trc) != len(other._trc):
+            return False
+        # Check `der_angles` & `der_bessel` for each tracer in the collection.
+        for tr1, tr2 in zip(self._trc, other._trc):
+            if not (tr1.der_angles == tr2.der_angles
+                    and tr1.der_bessel == tr2.der_bessel):
+                return False
+        # TODO: Check the kernels. :: get_kernel() doesn't really work...
+        if not np.allclose(
+                self.get_kernel(), other.get_kernel(),
+                atol=0, rtol=1e-12):
+            return False
+        # TODO: Check the transfer functions.
+        return True
+
     def __bool__(self):
         return bool(self._trc)
 

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -7,7 +7,7 @@ from .core import check
 from .background import (comoving_radial_distance, growth_rate,
                          growth_factor, scale_factor_of_chi, h_over_h0)
 from .errors import CCLWarning
-from .parameters import physical_constants, EQ_TOL
+from .parameters import physical_constants
 from .base import CCLObject, UnlockInstance, unlock_instance
 from .pyutils import (_check_array_params, NoneArr, _vectorize_fn6,
                       _get_spline1d_arrays, _get_spline2d_arrays)
@@ -205,7 +205,6 @@ class Tracer(CCLObject):
             return False
 
         # Check the kernels.
-        kwargs = {"atol": 0, "rtol": EQ_TOL, "equal_nan": True}
         for t1, t2 in zip(self._trc, other._trc):
             if bool(t1.kernel) ^ bool(t2.kernel):
                 # only one of them has a kernel
@@ -213,9 +212,8 @@ class Tracer(CCLObject):
             if t1.kernel is None:
                 # none of them has a kernel
                 continue
-            if not np.allclose(_get_spline1d_arrays(t1.kernel.spline),
-                               _get_spline1d_arrays(t2.kernel.spline),
-                               **kwargs):
+            if not np.array_equal(_get_spline1d_arrays(t1.kernel.spline),
+                                  _get_spline1d_arrays(t2.kernel.spline)):
                 # both have kernels, but they are unequal
                 return False
 
@@ -249,7 +247,7 @@ class Tracer(CCLObject):
                 pts1, pts2 = c2py[attr](spl1), c2py[attr](spl2)
                 for pt1, pt2 in zip(pts1, pts2):
                     # loop through output points of `_get_splinend_arrays`
-                    if not np.allclose(pt1, pt2, **kwargs):
+                    if not np.array_equal(pt1, pt2):
                         # both have this transfer type, but they are unequal
                         # or are defined at different grid points
                         return False

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -233,22 +233,22 @@ class Tracer(CCLObject):
                 if getattr(t1.transfer, arg) != getattr(t2.transfer, arg):
                     return False
 
-            # c2py = {"fa": _get_spline1d_arrays,
-            #         "fk": _get_spline1d_arrays,
-            #         "fka": _get_spline2d_arrays}
-            # for attr in c2py.keys():
-            #     spl1 = getattr(t1.transfer, attr, None)
-            #     spl2 = getattr(t2.transfer, attr, None)
-            #     if bool(spl1) ^ bool(spl2):
-            #         # only one of them has this transfer type
-            #         return False
-            #     if spl1 is None:
-            #         # none of them has this transfer type
-            #         continue
-            #     if not np.allclose(c2py[attr](spl1),
-            #                         c2py[attr](spl2), **kwargs):
-            #         # both have this transfer type, but they are unequal
-            #         return False
+            c2py = {"fa": _get_spline1d_arrays,
+                    "fk": _get_spline1d_arrays,
+                    "fka": _get_spline2d_arrays}
+            for attr in c2py.keys():
+                spl1 = getattr(t1.transfer, attr, None)
+                spl2 = getattr(t2.transfer, attr, None)
+                if bool(spl1) ^ bool(spl2):
+                    # only one of them has this transfer type
+                    return False
+                if spl1 is None:
+                    # none of them has this transfer type
+                    continue
+                if not np.allclose(c2py[attr](spl1),
+                                    c2py[attr](spl2), **kwargs):
+                    # both have this transfer type, but they are unequal
+                    return False
         return True
 
     def __bool__(self):

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -10,7 +10,7 @@ from .errors import CCLWarning
 from .parameters import physical_constants
 from .base import CCLObject, UnlockInstance, unlock_instance
 from .pyutils import (_check_array_params, NoneArr, _vectorize_fn6,
-                      _get_spline1d_arrays)
+                      _get_spline1d_arrays, _get_spline2d_arrays)
 
 
 def _Sig_MG(cosmo, a, k=None):
@@ -189,23 +189,66 @@ class Tracer(CCLObject):
         # Check the object class.
         if self.__class__ is not other.__class__:
             return False
+
         # If the tracer collections are empty, return early.
         if not (self or other):
             return True
+
         # If the tracer collections are not the same length, return early.
         if len(self._trc) != len(other._trc):
             return False
+
         # Check `der_angles` & `der_bessel` for each tracer in the collection.
-        for tr1, tr2 in zip(self._trc, other._trc):
-            if not (tr1.der_angles == tr2.der_angles
-                    and tr1.der_bessel == tr2.der_bessel):
-                return False
-        # TODO: Check the kernels. :: get_kernel() doesn't really work...
-        if not np.allclose(
-                self.get_kernel(), other.get_kernel(),
-                atol=0, rtol=1e-12):
+        bessel = self.get_bessel_derivative(), other.get_bessel_derivative()
+        angles = self.get_angles_derivative(), other.get_angles_derivative()
+        if not (np.array_equal(*bessel) and np.array_equal(*angles)):
             return False
-        # TODO: Check the transfer functions.
+
+        # Check the kernels.
+        kwargs = {"atol": 0, "rtol": 1e-12, "equal_nan": True}
+        for t1, t2 in zip(self._trc, other._trc):
+            if bool(t1.kernel) ^ bool(t2.kernel):
+                # only one of them has a kernel
+                return False
+            if t1.kernel is None:
+                # none of them has a kernel
+                continue
+            if not np.allclose(_get_spline1d_arrays(t1.kernel.spline),
+                               _get_spline1d_arrays(t2.kernel.spline),
+                               **kwargs):
+                # both have kernels, but they are unequal
+                return False
+
+        # Check the transfer functions.
+        for t1, t2 in zip(self._trc, other._trc):
+            if bool(t1.transfer) ^ bool(t2.transfer):
+                # only one of them has a transfer
+                return False
+            if t1.transfer is None:
+                # none of them has a transfer
+                continue
+            # Check the characteristics of the transfer function.
+            for arg in ("extrap_order_lok", "extrap_order_hik",
+                        "is_factorizable", "is_log"):
+                if getattr(t1.transfer, arg) != getattr(t2.transfer, arg):
+                    return False
+
+            # c2py = {"fa": _get_spline1d_arrays,
+            #         "fk": _get_spline1d_arrays,
+            #         "fka": _get_spline2d_arrays}
+            # for attr in c2py.keys():
+            #     spl1 = getattr(t1.transfer, attr, None)
+            #     spl2 = getattr(t2.transfer, attr, None)
+            #     if bool(spl1) ^ bool(spl2):
+            #         # only one of them has this transfer type
+            #         return False
+            #     if spl1 is None:
+            #         # none of them has this transfer type
+            #         continue
+            #     if not np.allclose(c2py[attr](spl1),
+            #                         c2py[attr](spl2), **kwargs):
+            #         # both have this transfer type, but they are unequal
+            #         return False
         return True
 
     def __bool__(self):
@@ -229,10 +272,6 @@ class Tracer(CCLObject):
         chis = [tr.chi_max for tr in self._trc]
         return max(chis) if chis else None
 
-    def _dndz(self, z):
-        raise NotImplementedError("`get_dndz` not implemented for "
-                                  "this `Tracer` type.")
-
     def get_dndz(self, z):
         """Get the redshift distribution for this tracer.
         Only available for some tracers (:class:`NumberCountsTracer` and
@@ -245,6 +284,8 @@ class Tracer(CCLObject):
             array_like: redshift distribution evaluated at the
                 input values of `z`.
         """
+        if not hasattr(self, "_dndz"):
+            raise NotImplementedError("Tracer has no redshift distribution.")
         return self._dndz(z)
 
     def get_kernel(self, chi=None):
@@ -270,26 +311,28 @@ class Tracer(CCLObject):
             chis = []
         else:
             chi_use = np.atleast_1d(chi)
+
         kernels = []
         for t in self._trc:
-            if chi is None:
-                chi_use, w = _get_spline1d_arrays(t.kernel.spline)
-                chis.append(chi_use)
+            if t.kernel is None:
+                continue
             else:
-                status = 0
-                w, status = lib.cl_tracer_get_kernel(t, chi_use,
-                                                     chi_use.size,
-                                                     status)
-                check(status)
-            kernels.append(w)
+                if chi is None:
+                    chi_use, w = _get_spline1d_arrays(t.kernel.spline)
+                    chis.append(chi_use)
+                else:
+                    status = 0
+                    w, status = lib.cl_tracer_get_kernel(
+                        t, chi_use, chi_use.size, status)
+                    check(status)
+                kernels.append(w)
+
         if chi is None:
             return kernels, chis
-        else:
-            kernels = np.array(kernels)
-            if np.ndim(chi) == 0:
-                if kernels.shape != (0,):
-                    kernels = np.squeeze(kernels, axis=-1)
-            return kernels
+        kernels = np.array(kernels)
+        if np.ndim(chi) == 0 and kernels.shape != (0,):
+            kernels = np.squeeze(kernels, axis=-1)
+        return kernels
 
     def get_f_ell(self, ell):
         """Get the ell-dependent prefactors for all tracers
@@ -365,6 +408,12 @@ class Tracer(CCLObject):
             array_like: list of Bessel derivative orders for each tracer.
         """
         return np.array([t.der_bessel for t in self._trc])
+
+    def get_angles_derivative(self):
+        r"""Get ``enum`` of the :math:`\ell`-dependent prefactor for all
+        tracers contained in this tracer collection.
+        """
+        return np.array([t.der_angles for t in self._trc])
 
     def _MG_add_tracer(self, cosmo, kernel, z_b, der_bessel=0, der_angles=0,
                        bias_transfer_a=None, bias_transfer_k=None):

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -245,9 +245,12 @@ class Tracer(CCLObject):
                 if spl1 is None:
                     # none of them has this transfer type
                     continue
-                if not np.allclose(c2py[attr](spl1),
-                                    c2py[attr](spl2), **kwargs):
+                # unpack the grid points and the transfer functions separately
+                (*pts1, tk1), (*pts2, tk2) = c2py[attr](spl1), c2py[attr](spl2)
+                if not (np.allclose(pts1, pts2, **kwargs)
+                        and np.allclose(tk1, tk2, **kwargs)):
                     # both have this transfer type, but they are unequal
+                    # or are defined at different grid points
                     return False
         return True
 

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -245,14 +245,18 @@ class Tracer(CCLObject):
                 if spl1 is None:
                     # none of them has this transfer type
                     continue
-                # unpack the grid points and the transfer functions separately
-                (*pts1, tk1), (*pts2, tk2) = c2py[attr](spl1), c2py[attr](spl2)
-                if not (np.allclose(pts1, pts2, **kwargs)
-                        and np.allclose(tk1, tk2, **kwargs)):
-                    # both have this transfer type, but they are unequal
-                    # or are defined at different grid points
-                    return False
+                # `pts` contain the the grid points and the transfer functions
+                pts1, pts2 = c2py[attr](spl1), c2py[attr](spl2)
+                for pt1, pt2 in zip(pts1, pts2):
+                    # loop through output points of `_get_splinend_arrays`
+                    if not np.allclose(pt1, pt2, **kwargs):
+                        # both have this transfer type, but they are unequal
+                        # or are defined at different grid points
+                        return False
         return True
+
+    def __hash__(self):
+        return hash(repr(self))
 
     def __bool__(self):
         return bool(self._trc)


### PR DESCRIPTION
As @rmjarvis and @marcpaterno correctly pointed out, we can save loads of time comparing `CCLObjects` if we compare parameters instead of strings. To that end, I extended some functionality that was already there to do parameter comparisons for most objects.

Just like the `__repr_attrs__` class variable, which automatically builds a repr using a list of specified arguments, `__eq_attrs__` now makes sure that the default `__eq__` is overridden and that the individual attributes are compared one-by-one.
For example, in the `Cosmology` object, we only need to add this line in the beginning:
```python
    __eq_attrs__ = ("_params_init_kwargs", "_config_init_kwargs", "_accuracy_params",)  # check these

    def __init__(...):
        ...
```

There are only 3 classes where this is not possible (because we have to check the C-level objects): `Pk2D`, `Tk3D`, `Tracer`. For these, I implemented full `__eq__` methods as per the usual way.

Timings show that this way is indeed much faster (`bld` is the `repr`):
![Screenshot from 2023-03-16 04-37-34](https://user-images.githubusercontent.com/22447385/225513441-d5e17b75-f743-43d9-b128-c8c44c0d6f15.png)
![Screenshot from 2023-03-16 05-02-53](https://user-images.githubusercontent.com/22447385/225513475-09e49179-8699-4819-950a-18a3d91d55d9.png)

Note, however, that with the current implementation in `master`, the first computation of `_repr` might be slow, but every new call to `__eq__` is of the order of nanoseconds (compare to microseconds with this PR proposal). It is a trade-off. So, if we compare objects sequentially (and discard the old one if they are not equal, like in an MCMC) this PR wins. But if we compare one object with several others, the currently implemented way wins.