### PR TITLE
Fix incorrect Python version in CI

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -1,5 +1,6 @@
 name: test  # default testing environment name from conda-incubator
 dependencies:
+  - python=3.8
   - pip
   - cmake
   - gsl
@@ -12,3 +13,5 @@ dependencies:
   - fast-pt
   - pytest
   - pytest-cov
+  - pip:
+      - classy<3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
           - os: ubuntu-latest
             label: linux-64
             prefix: /usr/share/miniconda3
-        py:
-          - 3.8
 
     steps:
       - name: Cancel previous runs
@@ -87,11 +85,9 @@ jobs:
         run: |
           export MAMBA_NO_BANNER=1  # hide mamba banner from output
           mamba env update --file ${{ env.CONDA_ENV }} --prune
-          pip install "classy<3"
 
       - name: Install CCL
-        run: |
-          pip install -e .
+        run: pip install -e .
 
       - name: Unit tests
         run: |


### PR DESCRIPTION
Some years ago, when the Python package handling in CI was changed to `conda`, the Python version was still left as a specifier in the matrix. However, this doesn't do anything at all. Conda would just use Python 3.11 (the latest version) even though we had 3.8 specified.

[Proof](https://github.com/LSSTDESC/CCL/actions/runs/4437584140/jobs/7787479584) (build from `master`):
```
  Package                 Version  Build                Channel                    Size
─────────────────────────────────────────────────────────────────────────────────────────────────
  Install:
─────────────────────────────────────────────────────────────────────────────────────────────────
      ...
  + python                 3.11.0  he550d4f_1_cpython   conda-forge/linux-64       31MB
      ...
```

This PR moves the Python version inside of the Anaconda environment, so that we use the correct one.