### PR TITLE
Fix error message for incorrect calls with `unlock_instance`

### DIFF
--- a/pyccl/base.py
+++ b/pyccl/base.py
@@ -393,14 +393,14 @@ class UnlockInstance:
             self.object_lock.lock()
 
     @classmethod
-    def unlock_instance(cls, func=None, *, argv=0, mutate=True):
+    def unlock_instance(cls, func=None, *, name=None, mutate=True):
         """Decorator that temporarily unlocks an instance of CCLObject.
 
         Arguments:
             func (``function``):
                 Function which changes one of its ``CCLObject`` arguments.
-            argv (``int``):
-                Which argument should be unlocked. Defaults to the first one.
+            name (``str``):
+                Name of the parameter to unlock. Defaults to the first one.
                 If not a ``CCLObject`` the decorator will do nothing.
             mutate (``bool``):
                 If after the function ``instance_old != instance_new``, the
@@ -409,17 +409,23 @@ class UnlockInstance:
         """
         if func is None:
             # called with parentheses
-            return functools.partial(cls.unlock_instance, argv=argv,
+            return functools.partial(cls.unlock_instance, name=name,
                                      mutate=mutate)
+
+        if not hasattr(func, "__signature__"):
+            # store the function signature
+            func.__signature__ = signature(func)
+        names = list(func.__signature__.parameters.keys())
+        name = names[0] if name is None else name  # default name
+        if name not in names:
+            # ensure the name makes sense
+            raise NameError(f"{name} does not exist in {func.__name__}.")
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            # Pick argument from list of `args` or `kwargs` as needed.
-            size = len(args)
-            arg = args[argv] if size > argv else list(kwargs.values())[argv-size]  # noqa
-            with UnlockInstance(arg, mutate=mutate):
-                out = func(*args, **kwargs)
-            return out
+            bound = func.__signature__.bind(*args, **kwargs)
+            with UnlockInstance(bound.arguments[name], mutate=mutate):
+                return func(*args, **kwargs)
         return wrapper
 
     @classmethod

--- a/pyccl/bcm.py
+++ b/pyccl/bcm.py
@@ -36,7 +36,7 @@ def bcm_model_fka(cosmo, k, a):
     return fka
 
 
-@unlock_instance(mutate=True, argv=1)
+@unlock_instance(mutate=True, name="pk2d")
 def bcm_correct_pk2d(cosmo, pk2d):
     """Apply the BCM model correction factor to a given power spectrum.
 


### PR DESCRIPTION
While reviewing `baryons_v3` I realized I had not implemented a fallback mechanism in case the input of `unlock_instance` was nonsense. This resulted to a very cryptic error message when
- users called the decorated function with wrong arguments
- developers specified an incorrect number in `argv`
```python
@ccl.unlock_instance(argv=1)
def func(item, pk, a0=0, *, a1=None, a2):
    return

func()  # wrong call to function

Traceback (most recent call last):

  Cell In[3], line 1
    func()

  File ~/CCL/pyccl/base.py:419 in wrapper
    arg = args[argv] if size > argv else list(kwargs.values())[argv-size]  # noqa

IndexError: list index out of range
```

This PR uses `inspect.signature.bind` which mimics the default Python behavior for incorrect function calls. The main difference with what is currently in `master` is that we now have to specify the `name` of the unlocked argument, rather than the `argv`. As an added bonus, it checks on import if the name actually exists, or if the developer has made a typo. The previous version would only complain at runtime.