### PR TITLE
GHA: Remove leftover Python version in `conda-incubator`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: ${{ matrix.py }}
           channels: conda-forge, defaults
           channel-priority: strict
           show-channel-urls: true


### PR DESCRIPTION
As the title says. The Python version is specified in `environment.yml`. There is no need to pass it to the incubator, and in fact this is now trying to access a variable that doesn't exist.