### PR TITLE
Unfreeze option for `physical_constants`

### DIFF
--- a/pyccl/parameters.py
+++ b/pyccl/parameters.py
@@ -87,6 +87,14 @@ class CCLParameters:
             setattr(self, param, value)
         object.__setattr__(self, "_frozen", frozen)
 
+    def freeze(self):
+        """Freeze an instance of ``CCLParameters``."""
+        object.__setattr__(self, "_frozen", True)
+
+    def unfreeze(self):
+        """Unfreeze an instance of ``CCLParameters``."""
+        object.__setattr__(self, "_frozen", False)
+
     @classmethod
     def get_params_dict(cls, name):
         """Get a dictionary of the current parameters.

--- a/pyccl/tests/test_cosmology.py
+++ b/pyccl/tests/test_cosmology.py
@@ -4,6 +4,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_raises, assert_, assert_no_warnings
 import pyccl as ccl
+import warnings
 
 
 def test_cosmo_methods():
@@ -242,6 +243,15 @@ def test_pyccl_default_params():
     # complains when we try to change the physical constants
     with pytest.raises(AttributeError):
         ccl.physical_constants.CLIGHT = 1
+
+    # but if we unfreeze them, we can change them
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ccl.physical_constants.unfreeze()
+        ccl.physical_constants.CLIGHT = 1
+    assert ccl.physical_constants.CLIGHT == 1
+    ccl.physical_constants.freeze()
+    ccl.physical_constants.reload()
 
     # verify that this has changed
     assert ccl.gsl_params.HM_MMIN != HM_MMIN

--- a/readthedocs/source/notation_and_other_cosmological_conventions.rst
+++ b/readthedocs/source/notation_and_other_cosmological_conventions.rst
@@ -227,8 +227,11 @@ parameters.
 Specifying Physical Constants
 -----------------------------
 
-The values of physical constants are set globally. These can be changed by
-assigning a new value to the attributes of ``pyccl.physical_constants``.
+The values of physical constants are set globally and are frozen. We do not
+recommend changing them, as some constants derive from others (such as Newton's
+gravitational constant and the solar mass). However, if you know what you are
+doing, you can unfreeze with ``pyccl.physical_constants.unfreeze()`` and then
+set your desired value to the parameter you would like to change.
 The following constants are defined and their default values are located
 in ``src/ccl_core.c``. Note that the neutrino mass splittings are taken
 from Lesgourgues & Pastor (2012; 1212.6154). Also, see the


### PR DESCRIPTION
Adds an option to unfreeze the physical constants, for users who want to set their own constants to match simulations etc.
Closes #1007.