### PR TITLE
Remove `T_CMB` and `T_ncdm` as constants (reloaded)

### DIFF
--- a/benchmarks/test_distances.py
+++ b/benchmarks/test_distances.py
@@ -46,7 +46,7 @@ Neff_mnu = 3.0
 def Neff_from_N_ur_N_ncdm(N_ur, N_ncdm):
     """Calculate N_eff from the number of relativistic
     and massive neutrinos."""
-    Neff = N_ur + N_ncdm * ccl.physical_constants.T_ncdm**4 / (4./11.)**(4./3.)
+    Neff = N_ur + N_ncdm * ccl.core._Defaults.T_ncdm**4 / (4./11.)**(4./3.)
     return Neff
 
 

--- a/include/ccl_core.h
+++ b/include/ccl_core.h
@@ -82,12 +82,6 @@ typedef struct ccl_physical_constants {
   /**
    * T_ncdm, as taken from CLASS, explanatory.ini
    */
-  double T_ncdm;
-
-  /**
-   * TNCDM: repeat the value to preserve API because we renamed TNCDM to T_ncdm.
-   * TODO: Remove for CCLv3.
-   */
   double TNCDM;
 
   /**

--- a/pyccl/__init__.py
+++ b/pyccl/__init__.py
@@ -146,12 +146,16 @@ from .covariances import (
 from .pyutils import debug_mode, resample_array
 
 # Deprecated & Renamed modules
+import warnings as _warnings
+_warnings.warn(
+    "The default CMB temperature (T_CMB) will change in CCLv3.0.0, "
+    "from 2.725 to 2.7255 (Kelvin).", CCLDeprecationWarning)
+
 def __getattr__(name):
     rename = {"cls": "cells"}
     if name in rename:
         from .errors import CCLDeprecationWarning
-        import warnings
-        warnings.warn(f"Module {name} has been renamed to {rename[name]}.",
+        _warnings.warn(f"Module {name} has been renamed to {rename[name]}.",
                       CCLDeprecationWarning)
         name = rename[name]
         return eval(name)

--- a/pyccl/__init__.py
+++ b/pyccl/__init__.py
@@ -42,12 +42,7 @@ from .errors import (
 )
 
 # Constants and accuracy parameters
-from .parameters import (
-    CCLParameters,
-    gsl_params,
-    spline_params,
-    physical_constants,
-)
+from .parameters import *
 
 # Core data structures
 from .core import (
@@ -191,7 +186,6 @@ from .baryons import (
 __all__ = (
     'lib', 'Caching', 'cache', 'hash_', 'CCLObject', 'CCLAutoreprObject',
     'UnlockInstance', 'unlock_instance',
-    'CCLParameters', 'physical_constants', 'gsl_params', 'spline_params',
     'CCLError', 'CCLWarning', 'CCLDeprecationWarning',
     'Cosmology', 'CosmologyVanillaLCDM', 'CosmologyCalculator',
     'growth_factor', 'growth_factor_unnorm', 'growth_rate',

--- a/pyccl/__init__.py
+++ b/pyccl/__init__.py
@@ -103,11 +103,7 @@ from .bcm import (
     bcm_correct_pk2d,
 )
 
-from .neutrinos import (
-    Omega_nu_h2,
-    Omeganuh2,  # TODO: deprecate this in v3
-    nu_masses,
-)
+from .neutrinos import *
 
 # Cells & Tracers
 from .cells import angular_cl
@@ -202,7 +198,6 @@ __all__ = (
     'linear_matter_power', 'nonlin_matter_power',
     'sigmaR', 'sigmaV', 'sigma8', 'sigmaM', 'kNL',
     'bcm_model_fka', 'bcm_correct_pk2d',
-    'Omeganuh2', 'Omega_nu_h2', 'nu_masses',
     'angular_cl',
     'Tracer', 'NumberCountsTracer', 'WeakLensingTracer', 'CMBLensingTracer',
     'tSZTracer', 'CIBTracer', 'ISWTracer', 'NzTracer',

--- a/pyccl/ccl_core.i
+++ b/pyccl/ccl_core.i
@@ -15,12 +15,34 @@
 
 %include "../include/ccl_core.h"
 
-// Enable vectorised arguments for arrays
+
 %apply (double* IN_ARRAY1, int DIM1) {
-            (double* zarr, int nz),
-            (double* dfarr, int nf),
-            (double* m_nu, int n_m)
+       (double* mass, int num),
+       (double* zarr, int nz),
+       (double* dfarr, int ndf)
 };
+
+%inline %{
+void parameters_m_nu_set_custom(ccl_parameters *params, double *mass, int num) {
+  params->m_nu = (double*) malloc(num*sizeof(double));
+  memcpy(params->m_nu, mass, num*sizeof(double));
+}
+
+void parameters_mgrowth_set_custom(ccl_parameters *params,
+    double* zarr, int nz, double* dfarr, int ndf) {
+  if (nz > 0) {
+    params->has_mgrowth = true;
+    params->nz_mgrowth = nz;
+    params->z_mgrowth = (double*) malloc(nz*sizeof(double));
+    params->df_mgrowth = (double*) malloc(nz*sizeof(double));
+    memcpy(params->z_mgrowth, zarr, nz*sizeof(double));
+    memcpy(params->df_mgrowth, dfarr, nz*sizeof(double));
+  }
+}
+
+%}
+
+
 %apply (int DIM1, double* ARGOUT_ARRAY1) {(int nout, double* output)};
 
 %inline %{
@@ -35,50 +57,4 @@ void parameters_get_nu_masses(ccl_parameters *params, int nout, double* output) 
     }
 }
 
-ccl_parameters parameters_create_nu(
-    double Omega_c, double Omega_b, double Omega_k, double Neff,
-    double w0, double wa, double h, double A_s, double sigma8, double n_s,
-    double T_CMB, double Omega_g, double T_ncdm,
-    double bcm_log10Mc, double bcm_etab, double bcm_ks, double mu_0,
-    double sigma_0, double c1_mg, double c2_mg, double lambda_mg,
-    double* m_nu, int n_m, int* status)
-{
-    return ccl_parameters_create(
-        Omega_c, Omega_b, Omega_k, Neff, m_nu, n_m, w0, wa, h,
-        A_s, sigma8, n_s, T_CMB, Omega_g, T_ncdm,
-        bcm_log10Mc, bcm_etab, bcm_ks,
-        mu_0, sigma_0, c1_mg, c2_mg, lambda_mg,
-        -1, NULL, NULL, status );
-}
-
 %}
-
-%feature("pythonprepend") parameters_create_nu_vec %{
-    if numpy.shape(zarr) != numpy.shape(dfarr):
-        raise CCLError("Input shape for `zarr` must match `dfarr`!")
-%}
-
-%inline %{
-ccl_parameters parameters_create_nu_vec(
-    double Omega_c, double Omega_b, double Omega_k, double Neff,
-    double w0, double wa, double h, double A_s, double sigma8, double n_s,
-    double T_CMB, double Omega_g, double T_ncdm,
-    double bcm_log10Mc, double bcm_etab, double bcm_ks, double mu_0,
-    double sigma_0, double c1_mg, double c2_mg, double lambda_mg,
-    double* zarr, int nz,
-    double* dfarr, int nf, double* m_nu,
-    int n_m, int* status)
-{
-    if (nz == 0){ nz = -1; }
-    return ccl_parameters_create(
-        Omega_c, Omega_b, Omega_k, Neff, m_nu, n_m, w0, wa, h,
-        A_s, sigma8, n_s, T_CMB, Omega_g, T_ncdm,
-        bcm_log10Mc, bcm_etab, bcm_ks,
-        mu_0, sigma_0, c1_mg, c2_mg, lambda_mg,
-        nz, zarr, dfarr, status);
-}
-
-%}
-
-/* The directive gets carried between files, so we reset it at the end. */
-%feature("pythonprepend") %{ %}

--- a/pyccl/ccl_core.i
+++ b/pyccl/ccl_core.i
@@ -48,13 +48,7 @@ void parameters_mgrowth_set_custom(ccl_parameters *params,
 %inline %{
 
 void parameters_get_nu_masses(ccl_parameters *params, int nout, double* output) {
-    output[0] = 0;
-    output[1] = 0;
-    output[2] = 0;
-
-    for (int i=0; i<params->N_nu_mass; ++i) {
-        output[i] = params->m_nu[i];
-    }
+  memcpy(output, params->m_nu, nout*sizeof(double));
 }
 
 %}

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -611,13 +611,13 @@ class Cosmology(CCLObject):
         sqrtk = np.sqrt(np.abs(Omega_k)) * h / c.CLIGHT_HMPC
 
         self._fill_params(
-            sum_nu_masses=sum(nu_mass), N_nu_mass=N_nu_mass, N_nu_rel=N_nu_rel,
-            Neff=Neff, Omega_nu_mass=Omega_nu_mass, Omega_nu_rel=Omega_nu_rel,
-            T_ncdm=T_ncdm, Omega_m=Omega_m, Omega_c=Omega_c, Omega_b=Omega_b,
-            Omega_k=Omega_k, sqrtk=sqrtk, k_sign=int(k_sign), T_CMB=T_CMB,
-            Omega_g=Omega_g, w0=w0, wa=wa, Omega_l=Omega_l, h=h, H0=h*100,
-            A_s=A_s, sigma8=sigma8, n_s=n_s, mu_0=mu_0, sigma_0=sigma_0,
-            c1_mg=c1_mg, c2_mg=c2_mg, lambda_mg=lambda_mg,
+            sum_nu_masses=sum(nu_mass), N_nu_rel=N_nu_rel, Neff=Neff,
+            Omega_nu_mass=Omega_nu_mass, Omega_nu_rel=Omega_nu_rel,
+            Omega_m=Omega_m, Omega_c=Omega_c, Omega_b=Omega_b, Omega_k=Omega_k,
+            sqrtk=sqrtk, k_sign=int(k_sign), Omega_g=Omega_g, w0=w0, wa=wa,
+            Omega_l=Omega_l, h=h, H0=h*100, A_s=A_s, sigma8=sigma8, n_s=n_s,
+            mu_0=mu_0, sigma_0=sigma_0, c1_mg=c1_mg, c2_mg=c2_mg,
+            lambda_mg=lambda_mg,
             bcm_log10Mc=bcm_log10Mc, bcm_etab=bcm_etab, bcm_ks=bcm_ks)
 
         # Modified growth (deprecated)

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -15,8 +15,9 @@ from .pyutils import check
 from .pk2d import Pk2D
 from .bcm import bcm_correct_pk2d
 from .base import CCLObject, cache, unlock_instance
-from .parameters import CCLParameters
+from .parameters import CCLParameters, CosmologyParams
 from .parameters import physical_constants as const
+
 
 # Configuration types
 transfer_function_types = {
@@ -66,6 +67,12 @@ emulator_neutrinos_types = {
     'strict': lib.emu_strict,
     'equalize': lib.emu_equalize
 }
+
+
+class _Defaults:
+    """Default cosmological parameters used throughout the library."""
+    T_CMB = 2.725
+    T_ncdm = 0.71611
 
 
 class Cosmology(CCLObject):
@@ -126,8 +133,7 @@ class Cosmology(CCLObject):
         wa (:obj:`float`, optional): Second order term of dark energy equation
             of state. Defaults to 0.
         T_CMB (:obj:`float`): The CMB temperature today. The default of
-            ``None`` uses the global CCL value in
-            ``pyccl.physical_constants.T_CMB``.
+            is 2.725.
         bcm_log10Mc (:obj:`float`, optional): One of the parameters of the
             BCM model. Defaults to `np.log10(1.2e14)`.
         bcm_etab (:obj:`float`, optional): One of the parameters of the BCM
@@ -181,7 +187,7 @@ class Cosmology(CCLObject):
             parameters. Currently supports extra parameters for CAMB, with
             details described below. Defaults to None.
         T_ncdm (:obj:`float`): Non-CDM temperature in units of photon
-            temperature. The default is ``pyccl.physical_constants.T_ncdm``.
+            temperature. The default is 0.71611.
 
     Currently supported extra parameters for CAMB are:
 
@@ -226,7 +232,7 @@ class Cosmology(CCLObject):
             self, Omega_c=None, Omega_b=None, h=None, n_s=None,
             sigma8=None, A_s=None, Omega_k=0., Omega_g=None,
             Neff=3.046, m_nu=0., m_nu_type=None, w0=-1., wa=0.,
-            T_CMB=None,
+            T_CMB=_Defaults.T_CMB,
             bcm_log10Mc=np.log10(1.2e14), bcm_etab=0.5,
             bcm_ks=55., mu_0=0., sigma_0=0.,
             c1_mg=1., c2_mg=1., lambda_mg=0., z_mg=None, df_mg=None,
@@ -237,7 +243,7 @@ class Cosmology(CCLObject):
             halo_concentration='duffy2008',
             emulator_neutrinos='strict',
             extra_parameters=None,
-            T_ncdm=None):
+            T_ncdm=_Defaults.T_ncdm):
 
         # going to save these for later
         self._params_init_kwargs = dict(
@@ -433,32 +439,19 @@ class Cosmology(CCLObject):
         # Fill-in defaults (SWIG converts `numpy.nan` to `NAN`)
         A_s = np.nan if A_s is None else A_s
         sigma8 = np.nan if sigma8 is None else sigma8
-        T_CMB = const.T_CMB if T_CMB is None else T_CMB
         Omega_g = np.nan if Omega_g is None else Omega_g
-        T_ncdm = const.T_ncdm if T_ncdm is None else T_ncdm
 
         # Check to make sure Omega_k is within reasonable bounds.
         if Omega_k is not None and Omega_k < -1.0135:
             raise ValueError("Omega_k must be more than -1.0135.")
 
-        # Set nz_mg (no. of redshift bins for modified growth fns.)
-        if z_mg is not None and df_mg is not None:
-            # Get growth array size and do sanity check
-            z_mg = np.atleast_1d(z_mg)
-            df_mg = np.atleast_1d(df_mg)
-            if z_mg.size != df_mg.size:
-                raise ValueError(
-                    "The parameters `z_mg` and `dF_mg` are "
-                    "not the same shape!")
-            nz_mg = z_mg.size
-        else:
-            # If one or both of the MG growth arrays are set to zero, disable
-            # all of them
-            if z_mg is not None or df_mg is not None:
-                raise ValueError("Must specify both z_mg and df_mg.")
-            z_mg = None
-            df_mg = None
-            nz_mg = -1
+        # Modified growth.
+        if (z_mg is None) != (df_mg is None):
+            raise ValueError("Both z_mg and df_mg must be arrays or None.")
+        if z_mg is not None:
+            z_mg, df_mg = map(np.atleast_1d, [z_mg, df_mg])
+            if z_mg.shape != df_mg.shape:
+                raise ValueError("Shape mismatch for z_mg and df_mg.")
 
         # Check to make sure specified amplitude parameter is consistent
         if [A_s, sigma8].count(np.nan) != 1:
@@ -467,10 +460,9 @@ class Cosmology(CCLObject):
         # Check if any compulsory parameters are not set
         compul = [Omega_c, Omega_b, Omega_k, w0, wa, h, n_s]
         names = ['Omega_c', 'Omega_b', 'Omega_k', 'w0', 'wa', 'h', 'n_s']
-        for nm, item in zip(names, compul):
+        for name, item in zip(names, compul):
             if item is None:
-                raise ValueError("Necessary parameter '%s' was not set "
-                                 "(or set to None)." % nm)
+                raise ValueError(f"Must set parameter {name}.")
 
         # Make sure the neutrino parameters are consistent
         # and if a sum is given for mass, split into three masses.
@@ -577,35 +569,67 @@ class Cosmology(CCLObject):
 
         # Fill an array with the non-relativistic neutrino masses
         if N_nu_mass > 0:
-            mnu_final_list = [0]*N_nu_mass
+            nu_mass = [0]*N_nu_mass
             relativistic = [0]*3
             for i in range(0, N_nu_mass):
                 for j in range(0, 3):
                     if (mnu_list[j] > 0.00017 and relativistic[j] == 0):
                         relativistic[j] = 1
-                        mnu_final_list[i] = mnu_list[j]
+                        nu_mass[i] = mnu_list[j]
                         break
         else:
-            mnu_final_list = [0.]
+            nu_mass = [0.]
 
-        # Create new instance of ccl_parameters object
-        # Create an internal status variable; needed to check massive neutrino
-        # integral.
-        status = 0
-        if nz_mg == -1:
-            # Create ccl_parameters without modified growth
-            self._params, status = lib.parameters_create_nu(
-                Omega_c, Omega_b, Omega_k, Neff, w0, wa, h, A_s, sigma8, n_s,
-                T_CMB, Omega_g, T_ncdm, bcm_log10Mc, bcm_etab, bcm_ks,
-                mu_0, sigma_0, c1_mg, c2_mg, lambda_mg, mnu_final_list, status)
+        c = const
+        # Fixed radiation parameters: (Omega_g h^2) is known from T_CMB.
+        rho_g = 4 * c.STBOLTZ / c.CLIGHT**3 * T_CMB**4
+        rho_crit = c.RHO_CRITICAL * c.SOLAR_MASS / c.MPC_TO_METER**3 * h**2
+
+        # Get the N_nu_rel from Neff and N_nu_mass.
+        N_nu_rel = Neff - N_nu_mass * T_ncdm**4 / (4/11)**(4/3)
+
+        # Temperature of the relativistic neutrinos in K.
+        T_nu = T_CMB * (4/11)**(1/3)
+        rho_nu_rel = N_nu_rel * (7/8) * 4 * c.STBOLTZ / c.CLIGHT**3 * T_nu**4
+        Omega_nu_rel = rho_nu_rel / rho_crit
+
+        # For non-relativistic neutrinos, calculate the phase-space integral.
+        self._fill_params(m_nu=nu_mass)
+        from .neutrinos import Omega_nu_h2
+        kw = {"m_nu": nu_mass, "T_CMB": T_CMB, "T_ncdm": T_ncdm}
+        Omega_nu_mass = Omega_nu_h2(1., **kw) / h**2 if N_nu_mass > 0 else 0
+        # Omega_nu_mass = self.OmNuh2(1.,) / h**2 if N_nu_mass > 0 else 0
+
+        Omega_m = Omega_b + Omega_c + Omega_nu_mass
+        Omega_l = 1 - Omega_m - rho_g/rho_crit - Omega_nu_rel - Omega_k
+        if np.isnan(Omega_g):
+            # No value passed for Omega_g
+            Omega_g = rho_g/rho_crit
         else:
-            # Create ccl_parameters with modified growth arrays
-            self._params, status = lib.parameters_create_nu_vec(
-                Omega_c, Omega_b, Omega_k, Neff, w0, wa, h, A_s, sigma8, n_s,
-                T_CMB, Omega_g, T_ncdm, bcm_log10Mc, bcm_etab, bcm_ks,
-                mu_0, sigma_0, c1_mg, c2_mg, lambda_mg, z_mg, df_mg,
-                mnu_final_list, status)
-        check(status)
+            # Omega_g was passed - modify Omega_l
+            Omega_l += rho_g/rho_crit - Omega_g
+
+        k_sign = -np.sign(Omega_k) if np.abs(Omega_k) > 1e-6 else 0
+        sqrtk = np.sqrt(np.abs(Omega_k)) * h / c.CLIGHT_HMPC
+
+        self._fill_params(
+            sum_nu_masses=sum(nu_mass), N_nu_mass=N_nu_mass, N_nu_rel=N_nu_rel,
+            Neff=Neff, Omega_nu_mass=Omega_nu_mass, Omega_nu_rel=Omega_nu_rel,
+            T_ncdm=T_ncdm, Omega_m=Omega_m, Omega_c=Omega_c, Omega_b=Omega_b,
+            Omega_k=Omega_k, sqrtk=sqrtk, k_sign=int(k_sign), T_CMB=T_CMB,
+            Omega_g=Omega_g, w0=w0, wa=wa, Omega_l=Omega_l, h=h, H0=h*100,
+            A_s=A_s, sigma8=sigma8, n_s=n_s, mu_0=mu_0, sigma_0=sigma_0,
+            c1_mg=c1_mg, c2_mg=c2_mg, lambda_mg=lambda_mg,
+            bcm_log10Mc=bcm_log10Mc, bcm_etab=bcm_etab, bcm_ks=bcm_ks)
+
+        # Modified growth (deprecated)
+        if z_mg is not None:
+            self._params.mgrowth = [z_mg, df_mg]
+
+    def _fill_params(self, **kwargs):
+        if not hasattr(self, "_params"):
+            self._params = CosmologyParams()
+        [setattr(self._params, par, val) for par, val in kwargs.items()]
 
     def __getitem__(self, key):
         """Access parameter values by name."""
@@ -1092,9 +1116,8 @@ class CosmologyCalculator(Cosmology):
             equation of state. Defaults to -1.
         wa (:obj:`float`, optional): Second order term of dark energy
             equation of state. Defaults to 0.
-        T_CMB (:obj:`float`): The CMB temperature today. The default of
-            ``None`` uses the global CCL value in
-            ``pyccl.physical_constants.T_CMB``.
+        T_CMB (:obj:`float`): The CMB temperature today. The default is the
+            same as in the Cosmology base class.
         mu_0 (:obj:`float`, optional): One of the parameters of the mu-Sigma
             modified gravity model. Defaults to 0.0
         sigma_0 (:obj:`float`, optional): One of the parameters of the mu-Sigma
@@ -1152,16 +1175,17 @@ class CosmologyCalculator(Cosmology):
             corresponding to the "HALOFIT" transformation of
             Takahashi et al. 2012 (arXiv:1208.2701).
         T_ncdm (:obj:`float`): Non-CDM temperature in units of photon
-            temperature. The default is ``pyccl.physical_constants.T_ncdm``.
+            temperature. The default is the same as in the base class
     """
     # TODO: Docstring - Move T_ncdm after T_CMB for CCLv3.
     def __init__(
             self, Omega_c=None, Omega_b=None, h=None, n_s=None,
             sigma8=None, A_s=None, Omega_k=0., Omega_g=None,
             Neff=3.046, m_nu=0., m_nu_type=None, w0=-1., wa=0.,
-            T_CMB=None, mu_0=0., sigma_0=0.,
+            T_CMB=_Defaults.T_CMB, mu_0=0., sigma_0=0.,
             background=None, growth=None,
-            pk_linear=None, pk_nonlin=None, nonlinear_model=None, T_ncdm=None):
+            pk_linear=None, pk_nonlin=None, nonlinear_model=None,
+            T_ncdm=_Defaults.T_ncdm):
         if pk_linear:
             transfer_function = 'calculator'
         else:

--- a/pyccl/core.py
+++ b/pyccl/core.py
@@ -594,11 +594,9 @@ class Cosmology(CCLObject):
         Omega_nu_rel = rho_nu_rel / rho_crit
 
         # For non-relativistic neutrinos, calculate the phase-space integral.
-        self._fill_params(m_nu=nu_mass)
-        from .neutrinos import Omega_nu_h2
-        kw = {"m_nu": nu_mass, "T_CMB": T_CMB, "T_ncdm": T_ncdm}
-        Omega_nu_mass = Omega_nu_h2(1., **kw) / h**2 if N_nu_mass > 0 else 0
-        # Omega_nu_mass = self.OmNuh2(1.,) / h**2 if N_nu_mass > 0 else 0
+        self._fill_params(m_nu=nu_mass, N_nu_mass=N_nu_mass,
+                          T_CMB=T_CMB, T_ncdm=T_ncdm)
+        Omega_nu_mass = self.OmNuh2(1.,) / h**2 if N_nu_mass > 0 else 0
 
         Omega_m = Omega_b + Omega_c + Omega_nu_mass
         Omega_l = 1 - Omega_m - rho_g/rho_crit - Omega_nu_rel - Omega_k

--- a/pyccl/neutrinos.py
+++ b/pyccl/neutrinos.py
@@ -40,6 +40,8 @@ def Omega_nu_h2(a, *, m_nu, T_CMB=_Defaults.T_CMB, T_ncdm=_Defaults.T_ncdm):
     if not isinstance(m_nu, np.ndarray):
         m_nu = np.array([m_nu, ]).flatten()
 
+    # Keep only massive neutrinos
+    m_nu = m_nu[m_nu > 0.]
     N_nu_mass = len(m_nu)
 
     OmNuh2, status = lib.Omeganuh2_vec(N_nu_mass, T_CMB, T_ncdm,

--- a/pyccl/neutrinos.py
+++ b/pyccl/neutrinos.py
@@ -3,6 +3,7 @@ from .pyutils import check
 from .base import deprecated, warn_api
 from .errors import CCLDeprecationWarning
 from .core import _Defaults
+from .background import omega_x
 import numpy as np
 import warnings
 
@@ -15,6 +16,7 @@ neutrino_mass_splits = {
 }
 
 
+@deprecated(new_function=omega_x)
 def Omega_nu_h2(a, *, m_nu, T_CMB=_Defaults.T_CMB, T_ncdm=_Defaults.T_ncdm):
     """Calculate :math:`\\Omega_\\nu\\,h^2` at a given scale factor given
     the neutrino masses.
@@ -52,12 +54,6 @@ def Omega_nu_h2(a, *, m_nu, T_CMB=_Defaults.T_CMB, T_ncdm=_Defaults.T_ncdm):
     if scalar:
         return OmNuh2[0]
     return OmNuh2
-
-
-def OmNuh2(cosmo, a):
-    """Like Omega_nu_h2 but it uses the parameters from a Cosmology object."""
-    return Omega_nu_h2(a, m_nu=cosmo["m_nu"],
-                       T_CMB=cosmo["T_CMB"], T_ncdm=cosmo["T_ncdm"])
 
 
 @deprecated(Omega_nu_h2)

--- a/pyccl/neutrinos.py
+++ b/pyccl/neutrinos.py
@@ -7,6 +7,10 @@ from .background import omega_x
 import numpy as np
 import warnings
 
+
+__all__ = ("nu_masses", "Omeganuh2",)
+
+
 neutrino_mass_splits = {
     'normal': lib.nu_normal,
     'inverted': lib.nu_inverted,
@@ -17,7 +21,7 @@ neutrino_mass_splits = {
 
 
 @deprecated(new_function=omega_x)
-def Omega_nu_h2(a, *, m_nu, T_CMB=_Defaults.T_CMB, T_ncdm=_Defaults.T_ncdm):
+def Omeganuh2(a, *, m_nu, T_CMB=_Defaults.T_CMB, T_ncdm=_Defaults.T_ncdm):
     """Calculate :math:`\\Omega_\\nu\\,h^2` at a given scale factor given
     the neutrino masses.
 
@@ -54,11 +58,6 @@ def Omega_nu_h2(a, *, m_nu, T_CMB=_Defaults.T_CMB, T_ncdm=_Defaults.T_ncdm):
     if scalar:
         return OmNuh2[0]
     return OmNuh2
-
-
-@deprecated(Omega_nu_h2)
-def Omeganuh2(a, m_nu, T_CMB=None):
-    return Omega_nu_h2(a, m_nu=m_nu, T_CMB=T_CMB)
 
 
 @warn_api(pairs=[("OmNuh2", "Omega_nu_h2")])

--- a/pyccl/neutrinos.py
+++ b/pyccl/neutrinos.py
@@ -1,8 +1,8 @@
 from . import ccllib as lib
-from .core import check
-from .parameters import physical_constants as const
+from .pyutils import check
 from .base import deprecated, warn_api
 from .errors import CCLDeprecationWarning
+from .core import _Defaults
 import numpy as np
 import warnings
 
@@ -15,7 +15,7 @@ neutrino_mass_splits = {
 }
 
 
-def Omega_nu_h2(a, *, m_nu, T_CMB=None, T_ncdm=None):
+def Omega_nu_h2(a, *, m_nu, T_CMB=_Defaults.T_CMB, T_ncdm=_Defaults.T_ncdm):
     """Calculate :math:`\\Omega_\\nu\\,h^2` at a given scale factor given
     the neutrino masses.
 
@@ -23,9 +23,9 @@ def Omega_nu_h2(a, *, m_nu, T_CMB=None, T_ncdm=None):
         a (float or array-like): Scale factor, normalized to 1 today.
         m_nu (float or array-like): Neutrino mass(es) (in eV)
         T_CMB (float, optional): Temperature of the CMB (K).
-            The default is ``pyccl.physical_constants.T_CMB``.
+            The default is the same as the Cosmology default.
         T_ncdm (float, optional): Non-CDM temperature in units of photon
-            temperature. The default is ``pyccl.physical_constants.T_ncdm``.
+            temperature. The default is the same as the Cosmology default.
 
     Returns:
         float or array_like: :math:`\\Omega_\\nu\\,h^2` at a given
@@ -42,10 +42,6 @@ def Omega_nu_h2(a, *, m_nu, T_CMB=None, T_ncdm=None):
 
     N_nu_mass = len(m_nu)
 
-    # Fill-in defaults
-    T_CMB = const.T_CMB if T_CMB is None else T_CMB
-    T_ncdm = const.T_ncdm if T_ncdm is None else T_ncdm
-
     OmNuh2, status = lib.Omeganuh2_vec(N_nu_mass, T_CMB, T_ncdm,
                                        a, m_nu, a.size, status)
 
@@ -54,6 +50,12 @@ def Omega_nu_h2(a, *, m_nu, T_CMB=None, T_ncdm=None):
     if scalar:
         return OmNuh2[0]
     return OmNuh2
+
+
+def OmNuh2(cosmo, a):
+    """Like Omega_nu_h2 but it uses the parameters from a Cosmology object."""
+    return Omega_nu_h2(a, m_nu=cosmo["m_nu"],
+                       T_CMB=cosmo["T_CMB"], T_ncdm=cosmo["T_ncdm"])
 
 
 @deprecated(Omega_nu_h2)

--- a/pyccl/parameters.py
+++ b/pyccl/parameters.py
@@ -146,6 +146,13 @@ class PhysicalConstants(CCLParameters, instance=lib.cvar.constants,
 class CosmologyParams(CCLParameters, factory=lib.parameters):
     """Instances of this class hold cosmological parameters."""
 
+    def __getattribute__(self, key):
+        if key == "m_nu":
+            N_nu_mass = self._instance.N_nu_mass
+            nu_masses = lib.parameters_get_nu_masses(self._instance, N_nu_mass)
+            return nu_masses.tolist()
+        return super().__getattribute__(key)
+
     def __setattr__(self, key, value):
         if key == "m_nu":
             return lib.parameters_m_nu_set_custom(self._instance, value)

--- a/pyccl/parameters.py
+++ b/pyccl/parameters.py
@@ -3,28 +3,40 @@ from . import ccllib as lib
 from .errors import CCLDeprecationWarning
 
 
+__all__ = ("CCLParameters", "SplineParams", "spline_params", "GSLParams",
+           "gsl_params", "PhysicalConstants", "physical_constants",
+           "CosmologyParams",)
+
+
 class CCLParameters:
     """Base for classes holding global CCL parameters and their values.
 
     Subclasses contain a reference to the C-struct with the collection
-    of parameters and their values (via SWIG). All subclasses act as proxies
+    of parameters (and their values) (via SWIG). All subclasses act as proxies
     to the CCL parameters at the C-level.
 
     Subclasses automatically store a backup of the initial parameter state
     to enable ad hoc reloading.
     """
 
-    def __init_subclass__(cls, instance=None, freeze=False):
+    def __init_subclass__(cls, *, instance=None, factory=None, freeze=False):
         """Routine for subclass initialization.
 
-        Parameters:
-            instance (``pyccl.ccllib.cvar``):
-                Reference to ``cvar`` where the parameters are implemented.
-            freeze (``bool``):
-                Disable parameter mutation.
+        Parameters
+        ----------
+        instance : :obj:`pyccl.ccllib`
+            Reference to the instance where the parameters are implemented.
+        factory : :class:`pyccl.ccllib`
+            The SWIG factory class where the parameters are stored.
+        freeze : bool
+            Disable parameter mutation.
         """
         super().__init_subclass__()
+        if not (bool(instance) ^ bool(factory)):  # XNOR
+            raise ValueError(
+                "Provide either the instance, or an instance factory.")
         cls._instance = instance
+        cls._factory = factory
         cls._frozen = freeze
 
         def _new_setattr(self, key, value):
@@ -44,9 +56,14 @@ class CCLParameters:
                 CCLDeprecationWarning)
             object.__setattr__(self, key, value)
 
-        cls._instance.__class__.__setattr__ = _new_setattr
+        # Replace C-level `__setattr__`.
+        class_ = cls._factory if cls._factory else cls._instance.__class__
+        class_.__setattr__ = _new_setattr
 
     def __init__(self):
+        # Create a new instance if a factory is provided.
+        if self._factory:
+            object.__setattr__(self, "_instance", self._factory())
         # Keep a copy of the default parameters.
         object.__setattr__(self, "_bak", CCLParameters.get_params_dict(self))
 
@@ -63,9 +80,6 @@ class CCLParameters:
             raise AttributeError(f"Instances of {name} are frozen.")
         if not hasattr(self._instance, key):
             raise KeyError(f"Parameter {key} does not exist.")
-        if (key, value) == ("A_SPLINE_MAX", 1.0):
-            # Setting `A_SPLINE_MAX` to its default value; do nothing.
-            return
         object.__setattr__(self._instance, key, value)
 
     __getitem__ = __getattribute__
@@ -114,6 +128,11 @@ class CCLParameters:
 class SplineParams(CCLParameters, instance=lib.cvar.user_spline_params):
     """Instances of this class hold the spline parameters."""
 
+    def __setattr__(self, key, value):
+        if (key, value) == ("A_SPLINE_MAX", 1.0):
+            return  # Setting `A_SPLINE_MAX` to its default value; do nothing.
+        super().__setattr__(key, value)
+
 
 class GSLParams(CCLParameters, instance=lib.cvar.user_gsl_params):
     """Instances of this class hold the gsl parameters."""
@@ -122,6 +141,17 @@ class GSLParams(CCLParameters, instance=lib.cvar.user_gsl_params):
 class PhysicalConstants(CCLParameters, instance=lib.cvar.constants,
                         freeze=True):
     """Instances of this class hold the physical constants."""
+
+
+class CosmologyParams(CCLParameters, factory=lib.parameters):
+    """Instances of this class hold cosmological parameters."""
+
+    def __setattr__(self, key, value):
+        if key == "m_nu":
+            return lib.parameters_m_nu_set_custom(self._instance, value)
+        if key == "mgrowth":
+            return lib.parameters_mgrowth_set_custom(self._instance, *value)
+        super().__setattr__(key, value)
 
 
 spline_params = SplineParams()

--- a/pyccl/tests/test_cclobject.py
+++ b/pyccl/tests/test_cclobject.py
@@ -6,8 +6,8 @@ import functools
 
 def all_subclasses(cls):
     """Get all subclasses of ``cls``. NOTE: Used in ``conftest.py``."""
-    return set(cls.__subclasses__()).union([s for c in cls.__subclasses__()
-                                            for s in all_subclasses(c)])
+    return set(cls.__subclasses__()).union(
+        [s for c in cls.__subclasses__() for s in all_subclasses(c)])
 
 
 def test_fancy_repr():

--- a/pyccl/tests/test_cosmology.py
+++ b/pyccl/tests/test_cosmology.py
@@ -110,12 +110,6 @@ def test_cosmology_init():
         m_nu_type='normal')
 
 
-def test_cosmology_setitem():
-    cosmo = ccl.CosmologyVanillaLCDM()
-    with pytest.raises(NotImplementedError):
-        cosmo['a'] = 3
-
-
 def test_cosmology_output():
     """
     Check that status messages and other output from Cosmology() object works

--- a/pyccl/tests/test_neutrinos.py
+++ b/pyccl/tests/test_neutrinos.py
@@ -12,7 +12,8 @@ import pyccl as ccl
     [0.1, 0.8, 0.3],
     np.array([0.1, 0.8, 0.3])])
 def test_omnuh2_smoke(a, m):
-    om = ccl.Omega_nu_h2(a, m_nu=m)
+    with pytest.warns(ccl.CCLDeprecationWarning):
+        om = ccl.Omeganuh2(a, m_nu=m)
     assert np.all(np.isfinite(om))
     assert np.shape(om) == np.shape(a)
 
@@ -39,5 +40,6 @@ def test_neutrinos_raises():
 @pytest.mark.parametrize('split', ['normal', 'inverted', 'equal'])
 def test_nu_mass_consistency(a, split):
     m = ccl.nu_masses(Omega_nu_h2=0.1, mass_split=split)
-    assert np.allclose(ccl.Omega_nu_h2(a, m_nu=m),
-                       0.1, rtol=0, atol=1e-4)
+    with pytest.warns(ccl.CCLDeprecationWarning):
+        om = ccl.Omeganuh2(a, m_nu=m)
+    assert np.allclose(om, 0.1, rtol=0, atol=1e-4)

--- a/pyccl/tests/test_parameters.py
+++ b/pyccl/tests/test_parameters.py
@@ -86,9 +86,8 @@ def test_parameters_nu(m_nu_type):
             cosmo['m_nu'][2]**2 - cosmo['m_nu'][0]**2,
             ccl.physical_constants.DELTAM13_sq_pos, atol=1e-4, rtol=0)
     elif m_nu_type == 'single':
+        assert len(cosmo["m_nu"]) == 1
         assert np.allclose(cosmo['m_nu'][0], 0.15, atol=1e-4, rtol=0)
-        assert np.allclose(cosmo['m_nu'][1], 0., atol=1e-4, rtol=0)
-        assert np.allclose(cosmo['m_nu'][2], 0., atol=1e-4, rtol=0)
 
 
 def test_parameters_nu_Nnurel_neg():
@@ -391,18 +390,6 @@ def test_parameters_missing():
         ccl.Cosmology,
         Omega_c=0.25, Omega_b=0.05, h=0.7, A_s=2.1e-9, n_s=0.96,
         df_mg=None)
-
-
-def test_parameters_set():
-    """
-    Check that a Cosmology object doesn't let parameters be set.
-    """
-    params = ccl.Cosmology(
-        Omega_c=0.25, Omega_b=0.05, h=0.7, A_s=2.1e-9,
-        n_s=0.96)
-
-    # Check that error is raised when unrecognized parameter requested
-    assert_raises(KeyError, lambda: params['wibble'])
 
 
 def test_parameters_mgrowth():

--- a/pyccl/tests/test_parameters.py
+++ b/pyccl/tests/test_parameters.py
@@ -27,14 +27,13 @@ def test_parameters_lcdm_defaults():
     assert np.allclose(cosmo['A_s'], 2.1e-9)
     assert np.allclose(cosmo['n_s'], 0.96)
     assert np.isnan(cosmo['sigma8'])
-    assert np.isnan(cosmo['z_star'])
     assert np.allclose(cosmo['Neff'], 3.046)
     assert cosmo['N_nu_mass'] == 0
     assert np.allclose(cosmo['N_nu_rel'], 3.046)
     assert np.allclose(cosmo['sum_nu_masses'], 0)
     assert np.allclose(cosmo['m_nu'], 0)
     assert np.allclose(cosmo['Omega_nu_mass'], 0)
-    assert np.allclose(cosmo['T_CMB'], ccl.physical_constants.T_CMB)
+    assert np.allclose(cosmo['T_CMB'], ccl.core._Defaults.T_CMB)
 
     assert np.allclose(cosmo['bcm_ks'], 55.0)
     assert np.allclose(cosmo['bcm_log10Mc'], np.log10(1.2e14))
@@ -121,8 +120,7 @@ def test_parameters_nu_list():
     assert np.allclose(cosmo['A_s'], 2.1e-9)
     assert np.allclose(cosmo['n_s'], 0.96)
     assert np.isnan(cosmo['sigma8'])
-    assert np.isnan(cosmo['z_star'])
-    assert np.allclose(cosmo['T_CMB'], ccl.physical_constants.T_CMB)
+    assert np.allclose(cosmo['T_CMB'], ccl.core._Defaults.T_CMB)
 
     assert np.allclose(cosmo['bcm_ks'], 55.0)
     assert np.allclose(cosmo['bcm_log10Mc'], np.log10(1.2e14))
@@ -172,8 +170,7 @@ def test_parameters_nu_normal():
     assert np.allclose(cosmo['A_s'], 2.1e-9)
     assert np.allclose(cosmo['n_s'], 0.96)
     assert np.isnan(cosmo['sigma8'])
-    assert np.isnan(cosmo['z_star'])
-    assert np.allclose(cosmo['T_CMB'], ccl.physical_constants.T_CMB)
+    assert np.allclose(cosmo['T_CMB'], ccl.core._Defaults.T_CMB)
 
     assert np.allclose(cosmo['bcm_ks'], 55.0)
     assert np.allclose(cosmo['bcm_log10Mc'], np.log10(1.2e14))
@@ -222,8 +219,7 @@ def test_parameters_nu_inverted():
     assert np.allclose(cosmo['A_s'], 2.1e-9)
     assert np.allclose(cosmo['n_s'], 0.96)
     assert np.isnan(cosmo['sigma8'])
-    assert np.isnan(cosmo['z_star'])
-    assert np.allclose(cosmo['T_CMB'], ccl.physical_constants.T_CMB)
+    assert np.allclose(cosmo['T_CMB'], ccl.core._Defaults.T_CMB)
 
     assert np.allclose(cosmo['bcm_ks'], 55.0)
     assert np.allclose(cosmo['bcm_log10Mc'], np.log10(1.2e14))
@@ -272,8 +268,7 @@ def test_parameters_nu_equal():
     assert np.allclose(cosmo['A_s'], 2.1e-9)
     assert np.allclose(cosmo['n_s'], 0.96)
     assert np.isnan(cosmo['sigma8'])
-    assert np.isnan(cosmo['z_star'])
-    assert np.allclose(cosmo['T_CMB'], ccl.physical_constants.T_CMB)
+    assert np.allclose(cosmo['T_CMB'], ccl.core._Defaults.T_CMB)
 
     assert np.allclose(cosmo['bcm_ks'], 55.0)
     assert np.allclose(cosmo['bcm_log10Mc'], np.log10(1.2e14))

--- a/pyccl/tests/test_swig_interface.py
+++ b/pyccl/tests/test_swig_interface.py
@@ -108,18 +108,6 @@ def test_swig_cls():
         status)
 
 
-def test_swig_core():
-    status = 0
-    assert_raises(
-        CCLError,
-        ccllib.parameters_create_nu_vec,
-        0.25, 0.05, 0.0, 3.0, -1.0, 0.0, 0.7, 2e-9, 0.81, 0.95, 2.7, 5e-5,
-        0.72, 1, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, [1.0, 2.0],
-        [0.0, 0.3, 0.5],
-        [0.02, 0.01, 0.2],
-        status)
-
-
 def test_swig_correlation():
     status = 0
     assert_raises(

--- a/src/ccl_background.c
+++ b/src/ccl_background.c
@@ -64,21 +64,15 @@ double ccl_omega_x(ccl_cosmology * cosmo, double a, ccl_species_x_label label, i
   // If massive neutrinos are present, compute the phase-space integral and
   // get OmegaNuh2. If not, set OmegaNuh2 to zero.
   double OmNuh2;
-  if ((cosmo->params.N_nu_mass) > 0.0001) {
-    // Call the massive neutrino density function just once at this redshift.
-    OmNuh2 = ccl_Omeganuh2(a, cosmo->params.N_nu_mass, cosmo->params.m_nu,
-                           cosmo->params.T_CMB, cosmo->params.T_ncdm, status);
-  }
-  else {
-    OmNuh2 = 0.;
-  }
-
   double hnorm = h_over_h0(a, cosmo, status);
 
   switch(label) {
     case ccl_species_crit_label :
       return 1.;
     case ccl_species_m_label :
+      // Call the massive neutrino density function just once at this redshift.
+      OmNuh2 = ccl_Omeganuh2(a, cosmo->params.N_nu_mass, cosmo->params.m_nu,
+                             cosmo->params.T_CMB, cosmo->params.T_ncdm, status);
       return (cosmo->params.Omega_c + cosmo->params.Omega_b) / (a*a*a) / hnorm / hnorm +
           OmNuh2 / (cosmo->params.h) / (cosmo->params.h) / hnorm / hnorm;
     case ccl_species_l_label :
@@ -93,6 +87,9 @@ double ccl_omega_x(ccl_cosmology * cosmo, double a, ccl_species_x_label label, i
     case ccl_species_ur_label :
       return cosmo->params.Omega_nu_rel / (a*a*a*a) / hnorm / hnorm;
     case ccl_species_nu_label :
+      // Call the massive neutrino density function just once at this redshift.
+      OmNuh2 = ccl_Omeganuh2(a, cosmo->params.N_nu_mass, cosmo->params.m_nu,
+                             cosmo->params.T_CMB, cosmo->params.T_ncdm, status);
       return OmNuh2 / (cosmo->params.h) / (cosmo->params.h) / hnorm / hnorm;
     default:
       *status = CCL_ERROR_PARAMETERS;

--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -227,12 +227,6 @@ ccl_physical_constants ccl_constants = {
   0.71611,
 
   /**
-   * TNCDM: repeat the value to preserve API because we renamed TNCDM to T_ncdm.
-   * TODO: Remove for CCLv3.
-   */
-  0.71611,
-
-  /**
    * neutrino mass splitting differences
    * See Lesgourgues and Pastor, 2012 for these values.
    * Adv. High Energy Phys. 2012 (2012) 608515,


### PR DESCRIPTION
This one completely decouples `T_CMB` and `T_ncdm` from the physical constants.
It also exploits the `CCLParameters` framework that was there to make the C-level cosmological parameters communicate with Python, and port their setting-up to Python fully.