### PR TITLE
Fix halo inconsistencies v3

### DIFF
--- a/pyccl/halos/__init__.py
+++ b/pyccl/halos/__init__.py
@@ -3,6 +3,7 @@ from .concentration import *
 from .hmfunc import *
 from .hbias import *
 from .massdef import *
+from .mass_concentration import *
 from .profiles import *
 from .profiles_2pt import *
 from .halo_model import *

--- a/pyccl/halos/mass_concentration.py
+++ b/pyccl/halos/mass_concentration.py
@@ -1,0 +1,79 @@
+from ..base import CCLAutoRepr
+from .massdef import MassDef, convert_concentration
+from .halo_model_base import Concentration
+
+
+__all__ = ("MassConcentration",)
+
+
+class MassConcentration(CCLAutoRepr):
+    """
+    """
+    __repr_attrs__ = __eq_attrs__ = ("mass_def", "concentration",)
+
+    def __init__(self, *, mass_def, concentration=None):
+        self.mass_def = mass_def
+        if (concentration is not None
+            and not isinstance(concentration, Concentration)):
+            raise TypeError("concentration must be Concentration")
+        self.concentration = concentration
+
+    @classmethod
+    def from_specs(cls, *, mass_def, concentration=None):
+        """
+        """
+        mass_def = MassDef.create_instance(mass_def)
+        if concentration is not None:
+            concentration = Concentration.create_instance(concentration,
+                                                          mass_def=mass_def)
+        return cls(mass_def=mass_def, concentration=concentration)
+
+    @property
+    def rho_type(self):
+        """Helper to access ``mass_def.rho_type``."""
+        return self.mass_def.rho_type
+
+    def get_Delta(self, cosmo, a):
+        """Helper to access ``mass_def.get_Delta``."""
+        return self.mass_def.get_Delta(cosmo, a)
+
+    def get_radius(self, cosmo, M, a):
+        """Helper to access ``mass_def.get_radius``."""
+        return self.mass_def.get_radius(cosmo, M, a)
+
+    def get_mass(self, cosmo, R, a):
+        """Helper to access ``mass_def.get_mass.``"""
+        return self.mass_def.get_mass(cosmo, R, a)
+
+    def get_concentration(self, cosmo, M, a):
+        """Helper to call ``concentration``."""
+        return self.concentration(cosmo, M, a)
+
+    def get_comoving_virial_radius(self, cosmo, M, a):
+        """Compute the comoving virial radius given the mass."""
+        R = self.get_radius(cosmo, M, a) / a
+        c = self.get_concentration(cosmo, M, a)
+        return R/c
+
+    def mass_translator(self, other):
+        """Translate between different mass definitions, using the internal
+        concentration and assuming an NFW profile.
+        """
+
+        def translate(cosmo, M, a):
+            if self == other:
+                return M
+
+            c_this = self.get_concentration(cosmo, M, a)
+            Om_this = cosmo.omega_x(a, self.rho_type)
+            D_this = self.get_Delta(cosmo, a) * Om_this
+            R_this = self.get_radius(cosmo, M, a)
+
+            Om_other = cosmo.omega_x(a, other.rho_type)
+            D_other = other.get_Delta(cosmo, a) * Om_other
+            c_other = convert_concentration(
+                cosmo, c_old=c_this, Delta_old=D_this, Delta_new=D_other)
+            R_other = R_this * c_other/c_this
+            return other.get_mass(cosmo, R_other, a)
+
+        return translate

--- a/pyccl/halos/mass_concentration.py
+++ b/pyccl/halos/mass_concentration.py
@@ -14,7 +14,7 @@ class MassConcentration(CCLAutoRepr):
     def __init__(self, *, mass_def, concentration=None):
         self.mass_def = mass_def
         if (concentration is not None
-            and not isinstance(concentration, Concentration)):
+                and not isinstance(concentration, Concentration)):
             raise TypeError("concentration must be Concentration")
         self.concentration = concentration
 

--- a/pyccl/halos/mass_concentration.py
+++ b/pyccl/halos/mass_concentration.py
@@ -37,23 +37,17 @@ class MassConcentration(CCLAutoRepr):
         """Helper to access ``mass_def.get_Delta``."""
         return self.mass_def.get_Delta(cosmo, a)
 
-    def get_radius(self, cosmo, M, a):
-        """Helper to access ``mass_def.get_radius``."""
-        return self.mass_def.get_radius(cosmo, M, a)
-
     def get_mass(self, cosmo, R, a):
         """Helper to access ``mass_def.get_mass.``"""
         return self.mass_def.get_mass(cosmo, R, a)
 
+    def get_radius(self, cosmo, M, a):
+        """Helper to access ``mass_def.get_radius``."""
+        return self.mass_def.get_radius(cosmo, M, a)
+
     def get_concentration(self, cosmo, M, a):
         """Helper to call ``concentration``."""
         return self.concentration(cosmo, M, a)
-
-    def get_comoving_virial_radius(self, cosmo, M, a):
-        """Compute the comoving virial radius given the mass."""
-        R = self.get_radius(cosmo, M, a) / a
-        c = self.get_concentration(cosmo, M, a)
-        return R/c
 
     def mass_translator(self, other):
         """Translate between different mass definitions, using the internal

--- a/pyccl/halos/massdef.py
+++ b/pyccl/halos/massdef.py
@@ -307,27 +307,3 @@ def MassDefFof(concentration=None):
         concentration (string): concentration-mass relation.
     """
     return MassDef('fof', 'matter', concentration=concentration)
-
-
-def translate_mass(cosmo, M, a,
-                   mass_def_in: MassDef,
-                   mass_def_out: MassDef,
-                   concentration):
-    """
-    """
-    if mass_def_in == mass_def_out:
-        return M
-    from .halo_model_base import Concentration
-    cm = Concentration.create_instance(concentration, mass_def=mass_def_in)
-    c_in = cm(cosmo, M, a)
-
-    Om_in = cosmo.omega_x(a, mass_def_in.rho_type)
-    D_in = mass_def_in.get_Delta(cosmo, a) * Om_in
-    R_in = mass_def_in.get_radus(cosmo, M, a)
-
-    Om_out = cosmo.omega_x(a, mass_def_out.rho_type)
-    D_out = mass_def_out.get_Delta(cosmo, a) * Om_out
-    c_out = convert_concentration(
-        cosmo, c_old=c_in, Delta_old=D_in, Delta_new=D_out)
-    R_out = R_in * c_out/c_in
-    return mass_def_out.get_mass(cosmo, R_out, a)

--- a/pyccl/halos/profiles/cib_shang12.py
+++ b/pyccl/halos/profiles/cib_shang12.py
@@ -87,7 +87,6 @@ class HaloProfileCIBShang12(HaloProfileCIB):
                                         ('l10meff', 'log10Meff'),
                                         ('sigLM', 'siglog10M')]
                                  )(super.__getattribute__)
-    name = 'CIBShang12'
     _one_over_4pi = 0.07957747154
 
     @warn_api(pairs=[("c_M_relation", "concentration"),

--- a/pyccl/halos/profiles/einasto.py
+++ b/pyccl/halos/profiles/einasto.py
@@ -43,7 +43,6 @@ class HaloProfileEinasto(HaloProfileMatter):
     """
     __repr_attrs__ = __eq_attrs__ = ("concentration", "truncated", "alpha",
                                      "precision_fftlog", "normprof",)
-    name = 'Einasto'
 
     @warn_api(pairs=[("c_M_relation", "concentration")])
     def __init__(self, *, concentration, truncated=True, alpha='cosmo'):

--- a/pyccl/halos/profiles/gaussian.py
+++ b/pyccl/halos/profiles/gaussian.py
@@ -24,7 +24,6 @@ class HaloProfileGaussian(HaloProfile):
     """
     __repr_attrs__ = __eq_attrs__ = ("r_scale", "rho_0", "precision_fftlog",
                                      "normprof",)
-    name = 'Gaussian'
     normprof = False
 
     @deprecated()

--- a/pyccl/halos/profiles/hernquist.py
+++ b/pyccl/halos/profiles/hernquist.py
@@ -46,7 +46,6 @@ class HaloProfileHernquist(HaloProfileMatter):
     __repr_attrs__ = __eq_attrs__ = (
         "concentration", "fourier_analytic", "projected_analytic",
         "cumul2d_analytic", "truncated", "precision_fftlog", "normprof",)
-    name = 'Hernquist'
 
     @warn_api(pairs=[("c_M_relation", "concentration")])
     def __init__(self, *, concentration,

--- a/pyccl/halos/profiles/hernquist.py
+++ b/pyccl/halos/profiles/hernquist.py
@@ -1,5 +1,4 @@
 from ...base import warn_api
-from ..concentration import Concentration
 from .profile_base import HaloProfileMatter
 import numpy as np
 from scipy.special import sici
@@ -44,19 +43,16 @@ class HaloProfileHernquist(HaloProfileMatter):
             radii.
     """
     __repr_attrs__ = __eq_attrs__ = (
-        "concentration", "fourier_analytic", "projected_analytic",
+        "mass_concentration", "fourier_analytic", "projected_analytic",
         "cumul2d_analytic", "truncated", "precision_fftlog", "normprof",)
 
     @warn_api(pairs=[("c_M_relation", "concentration")])
-    def __init__(self, *, concentration,
+    def __init__(self, *, mass_concentration,
                  truncated=True,
                  fourier_analytic=False,
                  projected_analytic=False,
                  cumul2d_analytic=False):
-        if not isinstance(concentration, Concentration):
-            raise TypeError("concentration must be of type `Concentration`")
 
-        self.concentration = concentration
         self.truncated = truncated
         self.fourier_analytic = fourier_analytic
         self.projected_analytic = projected_analytic
@@ -75,7 +71,7 @@ class HaloProfileHernquist(HaloProfileMatter):
                                  "for truncated Hernquist. Set `truncated` or "
                                  "`cumul2d_analytic` to `False`.")
             self._cumul2d = self._cumul2d_analytic
-        super().__init__()
+        super().__init__(mass_concentration=mass_concentration)
         self.update_precision_fftlog(padding_hi_fftlog=1E2,
                                      padding_lo_fftlog=1E-4,
                                      n_per_decade=1000,
@@ -85,13 +81,13 @@ class HaloProfileHernquist(HaloProfileMatter):
         # Hernquist normalization from mass, radius and concentration
         return M / (2 * np.pi * Rs**3 * (c / (1 + c))**2)
 
-    def _real(self, cosmo, r, M, a, mass_def):
+    def _real(self, cosmo, r, M, a):
         r_use = np.atleast_1d(r)
         M_use = np.atleast_1d(M)
 
         # Comoving virial radius
-        R_M = mass_def.get_radius(cosmo, M_use, a) / a
-        c_M = self.concentration(cosmo, M_use, a)
+        R_M = self.mass_concentration.get_radius(cosmo, M_use, a) / a
+        c_M = self.mass_concentration.get_concentration(cosmo, M_use, a)
         R_s = R_M / c_M
 
         norm = self._norm(M_use, R_s, c_M)
@@ -124,13 +120,13 @@ class HaloProfileHernquist(HaloProfileMatter):
                             [xf < 1, xf > 1],
                             [f1, f2, 2./15.]).reshape(x.shape)
 
-    def _projected_analytic(self, cosmo, r, M, a, mass_def):
+    def _projected_analytic(self, cosmo, r, M, a):
         r_use = np.atleast_1d(r)
         M_use = np.atleast_1d(M)
 
         # Comoving virial radius
-        R_M = mass_def.get_radius(cosmo, M_use, a) / a
-        c_M = self.concentration(cosmo, M_use, a)
+        R_M = self.mass_concentration.get_radius(cosmo, M_use, a) / a
+        c_M = self.mass_concentration.get_concentration(cosmo, M_use, a)
         R_s = R_M / c_M
 
         x = r_use[None, :] / R_s[:, None]
@@ -163,13 +159,13 @@ class HaloProfileHernquist(HaloProfileMatter):
 
         return f / x**2
 
-    def _cumul2d_analytic(self, cosmo, r, M, a, mass_def):
+    def _cumul2d_analytic(self, cosmo, r, M, a):
         r_use = np.atleast_1d(r)
         M_use = np.atleast_1d(M)
 
         # Comoving virial radius
-        R_M = mass_def.get_radius(cosmo, M_use, a) / a
-        c_M = self.concentration(cosmo, M_use, a)
+        R_M = self.mass_concentration.get_radius(cosmo, M_use, a) / a
+        c_M = self.mass_concentration.get_concentration(cosmo, M_use, a)
         R_s = R_M / c_M
 
         x = r_use[None, :] / R_s[:, None]
@@ -183,13 +179,13 @@ class HaloProfileHernquist(HaloProfileMatter):
             prof = np.squeeze(prof, axis=0)
         return prof
 
-    def _fourier_analytic(self, cosmo, k, M, a, mass_def):
+    def _fourier_analytic(self, cosmo, k, M, a):
         M_use = np.atleast_1d(M)
         k_use = np.atleast_1d(k)
 
         # Comoving virial radius
-        R_M = mass_def.get_radius(cosmo, M_use, a) / a
-        c_M = self.concentration(cosmo, M_use, a)
+        R_M = self.mass_concentration.get_radius(cosmo, M_use, a) / a
+        c_M = self.mass_concentration.get_concentration(cosmo, M_use, a)
         R_s = R_M / c_M
 
         x = k_use[None, :] * R_s[:, None]

--- a/pyccl/halos/profiles/hod.py
+++ b/pyccl/halos/profiles/hod.py
@@ -120,7 +120,6 @@ class HaloProfileHOD(HaloProfileNumberCounts):
         ("lM0_0", "log10M0_0"), ("lM0_p", "log10M0_p"),
         ("lM1_0", "log10M1_0"), ("lM1_p", "log10M1_p")]
     )(super.__getattribute__)
-    name = 'HOD'
 
     @warn_api(pairs=[("c_M_relation", "concentration"),
                      ("siglM_0", "siglnM_0"), ("siglM_p", "siglnM_p"),

--- a/pyccl/halos/profiles/hod.py
+++ b/pyccl/halos/profiles/hod.py
@@ -1,5 +1,4 @@
 from ...base import warn_api, deprecate_attr
-from ..concentration import Concentration
 from .profile_base import HaloProfileNumberCounts
 import numpy as np
 from scipy.special import sici, erf
@@ -110,7 +109,8 @@ class HaloProfileHOD(HaloProfileNumberCounts):
             satellites when centrals are present.
     """
     __repr_attrs__ = __eq_attrs__ = (
-        "concentration", "log10Mmin_0", "log10Mmin_p", "siglnM_0", "siglnM_p",
+        "mass_concentration",
+        "log10Mmin_0", "log10Mmin_p", "siglnM_0", "siglnM_p",
         "log10M0_0", "log10M0_p", "log10M1_0", "log10M1_p", "alpha_0",
         "alpha_p", "fc_0", "fc_p", "bg_0", "bg_p", "bmax_0", "bmax_p",
         "a_pivot", "ns_independent", "precision_fftlog", "normprof",)
@@ -126,17 +126,14 @@ class HaloProfileHOD(HaloProfileNumberCounts):
                      ("lMmin_0", "log10Mmin_0"), ("lMmin_p", "log10Mmin_p"),
                      ("lM0_0", "log10M0_0"), ("lM0_p", "log10M0_p"),
                      ("lM1_0", "log10M1_0"), ("lM1_p", "log10M1_p")])
-    def __init__(self, *, concentration,
+    def __init__(self, *, mass_concentration,
                  log10Mmin_0=12., log10Mmin_p=0., siglnM_0=0.4,
                  siglnM_p=0., log10M0_0=7., log10M0_p=0.,
                  log10M1_0=13.3, log10M1_p=0., alpha_0=1.,
                  alpha_p=0., fc_0=1., fc_p=0.,
                  bg_0=1., bg_p=0., bmax_0=1., bmax_p=0.,
                  a_pivot=1., ns_independent=False):
-        if not isinstance(concentration, Concentration):
-            raise TypeError("concentration must be of type `Concentration`")
 
-        self.concentration = concentration
         self.log10Mmin_0 = log10Mmin_0
         self.log10Mmin_p = log10Mmin_p
         self.log10M0_0 = log10M0_0
@@ -155,7 +152,7 @@ class HaloProfileHOD(HaloProfileNumberCounts):
         self.bmax_p = bmax_p
         self.a_pivot = a_pivot
         self.ns_independent = ns_independent
-        super().__init__()
+        super().__init__(mass_concentration=mass_concentration)
 
     @warn_api(pairs=[("lMmin_0", "log10Mmin_0"), ("lMmin_p", "log10Mmin_p"),
                      ("siglM_0", "siglnM_0"), ("siglM_p", "siglnM_p"),
@@ -248,15 +245,15 @@ class HaloProfileHOD(HaloProfileNumberCounts):
         if ns_independent is not None:
             self.ns_independent = ns_independent
 
-    def _usat_real(self, cosmo, r, M, a, mass_def):
+    def _usat_real(self, cosmo, r, M, a):
         r_use = np.atleast_1d(r)
         M_use = np.atleast_1d(M)
 
         # Comoving virial radius
         bg = self.bg_0 + self.bg_p * (a - self.a_pivot)
         bmax = self.bmax_0 + self.bmax_p * (a - self.a_pivot)
-        R_M = mass_def.get_radius(cosmo, M_use, a) / a
-        c_M = self.concentration(cosmo, M_use, a)
+        R_M = self.mass_concentration.get_radius(cosmo, M_use, a) / a
+        c_M = self.mass_concentration.get_concentration(cosmo, M_use, a)
         R_s = R_M / c_M
         c_M *= bmax / bg
 
@@ -274,15 +271,15 @@ class HaloProfileHOD(HaloProfileNumberCounts):
             prof = np.squeeze(prof, axis=0)
         return prof
 
-    def _usat_fourier(self, cosmo, k, M, a, mass_def):
+    def _usat_fourier(self, cosmo, k, M, a):
         M_use = np.atleast_1d(M)
         k_use = np.atleast_1d(k)
 
         # Comoving virial radius
         bg = self.bg_0 + self.bg_p * (a - self.a_pivot)
         bmax = self.bmax_0 + self.bmax_p * (a - self.a_pivot)
-        R_M = mass_def.get_radius(cosmo, M_use, a) / a
-        c_M = self.concentration(cosmo, M_use, a)
+        R_M = self.mass_concentration.get_radius(cosmo, M_use, a) / a
+        c_M = self.mass_concentration.get_concentration(cosmo, M_use, a)
         R_s = R_M / c_M
         c_M *= bmax / bg
 
@@ -301,7 +298,7 @@ class HaloProfileHOD(HaloProfileNumberCounts):
             prof = np.squeeze(prof, axis=0)
         return prof
 
-    def _real(self, cosmo, r, M, a, mass_def):
+    def _real(self, cosmo, r, M, a):
         r_use = np.atleast_1d(r)
         M_use = np.atleast_1d(M)
 
@@ -309,7 +306,7 @@ class HaloProfileHOD(HaloProfileNumberCounts):
         Ns = self._Ns(M_use, a)
         fc = self._fc(a)
         # NFW profile
-        ur = self._usat_real(cosmo, r_use, M_use, a, mass_def)
+        ur = self._usat_real(cosmo, r_use, M_use, a)
 
         if self.ns_independent:
             prof = Nc[:, None] * fc + Ns[:, None] * ur
@@ -322,7 +319,7 @@ class HaloProfileHOD(HaloProfileNumberCounts):
             prof = np.squeeze(prof, axis=0)
         return prof
 
-    def _fourier(self, cosmo, k, M, a, mass_def):
+    def _fourier(self, cosmo, k, M, a):
         M_use = np.atleast_1d(M)
         k_use = np.atleast_1d(k)
 
@@ -330,7 +327,7 @@ class HaloProfileHOD(HaloProfileNumberCounts):
         Ns = self._Ns(M_use, a)
         fc = self._fc(a)
         # NFW profile
-        uk = self._usat_fourier(cosmo, k_use, M_use, a, mass_def)
+        uk = self._usat_fourier(cosmo, k_use, M_use, a)
 
         if self.ns_independent:
             prof = Nc[:, None] * fc + Ns[:, None] * uk
@@ -343,7 +340,7 @@ class HaloProfileHOD(HaloProfileNumberCounts):
             prof = np.squeeze(prof, axis=0)
         return prof
 
-    def _fourier_variance(self, cosmo, k, M, a, mass_def):
+    def _fourier_variance(self, cosmo, k, M, a):
         # Fourier-space variance of the HOD profile
         M_use = np.atleast_1d(M)
         k_use = np.atleast_1d(k)
@@ -352,7 +349,7 @@ class HaloProfileHOD(HaloProfileNumberCounts):
         Ns = self._Ns(M_use, a)
         fc = self._fc(a)
         # NFW profile
-        uk = self._usat_fourier(cosmo, k_use, M_use, a, mass_def)
+        uk = self._usat_fourier(cosmo, k_use, M_use, a)
 
         prof = Ns[:, None] * uk
         if self.ns_independent:

--- a/pyccl/halos/profiles/nfw.py
+++ b/pyccl/halos/profiles/nfw.py
@@ -48,7 +48,6 @@ class HaloProfileNFW(HaloProfileMatter):
     __repr_attrs__ = __eq_attrs__ = (
         "concentration", "fourier_analytic", "projected_analytic",
         "cumul2d_analytic", "truncated", "precision_fftlog", "normprof",)
-    name = 'NFW'
 
     @warn_api(pairs=[("c_M_relation", "concentration")])
     def __init__(self, *, concentration,

--- a/pyccl/halos/profiles/powerlaw.py
+++ b/pyccl/halos/profiles/powerlaw.py
@@ -24,7 +24,6 @@ class HaloProfilePowerLaw(HaloProfile):
     """
     __repr_attrs__ = __eq_attrs__ = ("r_scale", "tilt", "precision_fftlog",
                                      "normprof",)
-    name = 'PowerLaw'
     normprof = False
 
     @deprecated()

--- a/pyccl/halos/profiles/pressure_gnfw.py
+++ b/pyccl/halos/profiles/pressure_gnfw.py
@@ -69,7 +69,6 @@ class HaloProfilePressureGNFW(HaloProfilePressure):
         "mass_bias", "P0", "c500", "alpha", "alpha_P", "beta",
         "gamma", "P0_hexp", "qrange", "nq", "x_out",
         "precision_fftlog", "normprof",)
-    name = 'GNFW'
 
     @warn_api
     def __init__(self, *, mass_bias=0.8, P0=6.41,

--- a/pyccl/halos/profiles/profile_base.py
+++ b/pyccl/halos/profiles/profile_base.py
@@ -41,7 +41,8 @@ class HaloProfile(CCLAutoRepr):
     __getattr__ = deprecate_attr(pairs=[('cM', 'concentration')]
                                  )(super.__getattribute__)
 
-    def __init__(self):
+    def __init__(self, *, mass_concentration):
+        self.mass_concentration = mass_concentration
         self.precision_fftlog = FFTLogParams()
 
     @property
@@ -105,24 +106,28 @@ class HaloProfile(CCLAutoRepr):
         """
         return self.precision_fftlog['plaw_projected']
 
+    def _get_comoving_radius(self, cosmo, M, a):
+        """Helper to get the comoving radius."""
+        return self.mass_concentration.get_radius(cosmo, M, a) / a
+
     @abstractlinkedmethod
-    def _real(self, cosmo, r, M, a, mass_def=None):
+    def _real(self, cosmo, r, M, a):
         """TODO: Write some useful docstring."""
 
     @abstractlinkedmethod
-    def _fourier(self, cosmo, k, M, a, mass_def=None):
+    def _fourier(self, cosmo, k, M, a):
         "TODO: Write some useful docstring."""
 
     @templatemethod
-    def _projected(self, cosmo, r, M, a, mass_def=None):
+    def _projected(self, cosmo, r, M, a):
         """TODO: Write some useful docstring."""
 
     @templatemethod
-    def _cumul2d(self, cosmo, r, M, a, mass_def=None):
+    def _cumul2d(self, cosmo, r, M, a):
         """TODO: Write some useful docstring."""
 
     @warn_api
-    def real(self, cosmo, r, M, a, *, mass_def=None):
+    def real(self, cosmo, r, M, a):
         """ Returns the 3D real-space value of the profile as a
         function of cosmology, radius, halo mass and scale factor.
 
@@ -131,8 +136,6 @@ class HaloProfile(CCLAutoRepr):
             r (float or array_like): comoving radius in Mpc.
             M (float or array_like): halo mass in units of M_sun.
             a (float): scale factor.
-            mass_def (:class:`~pyccl.halos.massdef.MassDef`):
-                a mass definition object.
 
         Returns:
             float or array_like: halo profile. The shape of the
@@ -142,11 +145,11 @@ class HaloProfile(CCLAutoRepr):
             squeezed out on output.
         """
         if self._is_implemented("_real"):
-            return self._real(cosmo, r, M, a, mass_def)
-        return self._fftlog_wrap(cosmo, r, M, a, mass_def, fourier_out=False)
+            return self._real(cosmo, r, M, a)
+        return self._fftlog_wrap(cosmo, r, M, a, fourier_out=False)
 
     @warn_api
-    def fourier(self, cosmo, k, M, a, *, mass_def=None):
+    def fourier(self, cosmo, k, M, a):
         """ Returns the Fourier-space value of the profile as a
         function of cosmology, wavenumber, halo mass and
         scale factor.
@@ -160,8 +163,6 @@ class HaloProfile(CCLAutoRepr):
             k (float or array_like): comoving wavenumber in Mpc^-1.
             M (float or array_like): halo mass in units of M_sun.
             a (float): scale factor.
-            mass_def (:class:`~pyccl.halos.massdef.MassDef`):
-                a mass definition object.
 
         Returns:
             float or array_like: halo profile. The shape of the
@@ -171,11 +172,11 @@ class HaloProfile(CCLAutoRepr):
             squeezed out on output.
         """
         if self._is_implemented("_fourier"):
-            return self._fourier(cosmo, k, M, a, mass_def)
-        return self._fftlog_wrap(cosmo, k, M, a, mass_def, fourier_out=True)
+            return self._fourier(cosmo, k, M, a)
+        return self._fftlog_wrap(cosmo, k, M, a, fourier_out=True)
 
     @warn_api(pairs=[("r_t", "r")])
-    def projected(self, cosmo, r, M, a, *, mass_def=None):
+    def projected(self, cosmo, r, M, a):
         """ Returns the 2D projected profile as a function of
         cosmology, radius, halo mass and scale factor.
 
@@ -188,8 +189,6 @@ class HaloProfile(CCLAutoRepr):
             r (float or array_like): comoving radius in Mpc.
             M (float or array_like): halo mass in units of M_sun.
             a (float): scale factor.
-            mass_def (:class:`~pyccl.halos.massdef.MassDef`):
-                a mass definition object.
 
         Returns:
             float or array_like: halo profile. The shape of the
@@ -199,12 +198,11 @@ class HaloProfile(CCLAutoRepr):
             squeezed out on output.
         """
         if self._is_implemented("_projected"):
-            return self._projected(cosmo, r, M, a, mass_def)
-        return self._projected_fftlog_wrap(cosmo, r, M, a, mass_def,
-                                           is_cumul2d=False)
+            return self._projected(cosmo, r, M, a)
+        return self._projected_fftlog_wrap(cosmo, r, M, a, is_cumul2d=False)
 
     @warn_api(pairs=[("r_t", "r")])
-    def cumul2d(self, cosmo, r, M, a, *, mass_def=None):
+    def cumul2d(self, cosmo, r, M, a):
         """ Returns the 2D cumulative surface density as a
         function of cosmology, radius, halo mass and scale
         factor.
@@ -218,8 +216,6 @@ class HaloProfile(CCLAutoRepr):
             r (float or array_like): comoving radius in Mpc.
             M (float or array_like): halo mass in units of M_sun.
             a (float): scale factor.
-            mass_def (:class:`~pyccl.halos.massdef.MassDef`):
-                a mass definition object.
 
         Returns:
             float or array_like: halo profile. The shape of the
@@ -229,12 +225,11 @@ class HaloProfile(CCLAutoRepr):
             squeezed out on output.
         """
         if self._is_implemented("_cumul2d"):
-            return self._cumul2d(cosmo, r, M, a, mass_def)
-        return self._projected_fftlog_wrap(cosmo, r, M, a, mass_def,
-                                           is_cumul2d=True)
+            return self._cumul2d(cosmo, r, M, a)
+        return self._projected_fftlog_wrap(cosmo, r, M, a, is_cumul2d=True)
 
     @warn_api
-    def convergence(self, cosmo, r, M, *, a_lens, a_source, mass_def=None):
+    def convergence(self, cosmo, r, M, *, a_lens, a_source):
         """ Returns the convergence as a function of cosmology,
         radius, halo mass and the scale factors of the source
         and the lens.
@@ -251,20 +246,18 @@ class HaloProfile(CCLAutoRepr):
             a_lens (float): scale factor of lens.
             a_source (float or array_like): scale factor of source.
                 If array_like, it must have the same shape as `r`.
-            mass_def (:class:`~pyccl.halos.massdef.MassDef`):
-                a mass definition object.
 
         Returns:
             float or array_like: convergence \
                 :math:`\\kappa`
         """
-        Sigma = self.projected(cosmo, r, M, a_lens, mass_def=mass_def)
+        Sigma = self.projected(cosmo, r, M, a_lens)
         Sigma /= a_lens**2
         Sigma_crit = cosmo.sigma_critical(a_lens=a_lens, a_source=a_source)
         return Sigma / Sigma_crit
 
     @warn_api
-    def shear(self, cosmo, r, M, *, a_lens, a_source, mass_def=None):
+    def shear(self, cosmo, r, M, *, a_lens, a_source):
         """ Returns the shear (tangential) as a function of cosmology,
         radius, halo mass and the scale factors of the
         source and the lens.
@@ -284,20 +277,18 @@ class HaloProfile(CCLAutoRepr):
             a_lens (float): scale factor of lens.
             a_source (float or array_like): source's scale factor.
                 If array_like, it must have the same shape as `r`.
-            mass_def (:class:`~pyccl.halos.massdef.MassDef`):
-                a mass definition object.
 
         Returns:
             float or array_like: shear \
                 :math:`\\gamma`
         """
-        Sigma = self.projected(cosmo, r, M, a_lens, mass_def=mass_def)
-        Sigma_bar = self.cumul2d(cosmo, r, M, a_lens, mass_def=mass_def)
+        Sigma = self.projected(cosmo, r, M, a_lens)
+        Sigma_bar = self.cumul2d(cosmo, r, M, a_lens)
         Sigma_crit = cosmo.sigma_critical(a_lens=a_lens, a_source=a_source)
         return (Sigma_bar - Sigma) / (Sigma_crit * a_lens**2)
 
     @warn_api
-    def reduced_shear(self, cosmo, r, M, *, a_lens, a_source, mass_def=None):
+    def reduced_shear(self, cosmo, r, M, *, a_lens, a_source):
         """ Returns the reduced shear as a function of cosmology,
         radius, halo mass and the scale factors of the
         source and the lens.
@@ -315,21 +306,18 @@ class HaloProfile(CCLAutoRepr):
             a_lens (float): scale factor of lens.
             a_source (float or array_like): source's scale factor.
                 If array_like, it must have the same shape as `r`.
-            mass_def (:class:`~pyccl.halos.massdef.MassDef`):
-                a mass definition object.
 
         Returns:
             float or array_like: reduced shear \
                 :math:`g_t`
         """
-        convergence = self.convergence(cosmo, r, M, a_lens=a_lens,
-                                       a_source=a_source, mass_def=mass_def)
-        shear = self.shear(cosmo, r, M, a_lens=a_lens, a_source=a_source,
-                           mass_def=mass_def)
+        convergence = self.convergence(cosmo, r, M,
+                                       a_lens=a_lens, a_source=a_source)
+        shear = self.shear(cosmo, r, M, a_lens=a_lens, a_source=a_source)
         return shear / (1.0 - convergence)
 
     @warn_api
-    def magnification(self, cosmo, r, M, *, a_lens, a_source, mass_def=None):
+    def magnification(self, cosmo, r, M, *, a_lens, a_source):
         """ Returns the magnification for input parameters.
 
         .. math::
@@ -346,23 +334,18 @@ class HaloProfile(CCLAutoRepr):
             a_lens (float): scale factor of lens.
             a_source (float or array_like): source's scale factor.
                 If array_like, it must have the same shape as `r`.
-            mass_def (:class:`~pyccl.halos.massdef.MassDef`):
-                a mass definition object.
 
         Returns:
             float or array_like: magnification\
                 :math:`\\mu`
         """
-        convergence = self.convergence(cosmo, r, M, a_lens=a_lens,
-                                       a_source=a_source, mass_def=mass_def)
-        shear = self.shear(cosmo, r, M, a_lens=a_lens, a_source=a_source,
-                           mass_def=mass_def)
-
+        convergence = self.convergence(cosmo, r, M,
+                                       a_lens=a_lens, a_source=a_source)
+        shear = self.shear(cosmo, r, M, a_lens=a_lens, a_source=a_source)
         return 1.0 / ((1.0 - convergence)**2 - np.abs(shear)**2)
 
-    def _fftlog_wrap(self, cosmo, k, M, a, mass_def,
-                     fourier_out=False,
-                     large_padding=True):
+    def _fftlog_wrap(self, cosmo, k, M, a, *,
+                     fourier_out=False, large_padding=True):
         # This computes the 3D Hankel transform
         #  \rho(k) = 4\pi \int dr r^2 \rho(r) j_0(k r)
         # if fourier_out == False, and
@@ -392,7 +375,7 @@ class HaloProfile(CCLAutoRepr):
 
         p_k_out = np.zeros([nM, k_use.size])
         # Compute real profile values
-        p_real_M = p_func(cosmo, r_arr, M_use, a, mass_def)
+        p_real_M = p_func(cosmo, r_arr, M_use, a)
         # Power-law index to pass to FFTLog.
         plaw_index = self._get_plaw_fourier(cosmo, a)
 
@@ -417,8 +400,7 @@ class HaloProfile(CCLAutoRepr):
             p_k_out = np.squeeze(p_k_out, axis=0)
         return p_k_out
 
-    def _projected_fftlog_wrap(self, cosmo, r_t, M, a, mass_def,
-                               is_cumul2d=False):
+    def _projected_fftlog_wrap(self, cosmo, r_t, M, a, *, is_cumul2d=False):
         # This computes Sigma(R) from the Fourier-space profile as:
         # Sigma(R) = \frac{1}{2\pi} \int dk k J_0(k R) \rho(k)
         r_t_use = np.atleast_1d(r_t)
@@ -437,17 +419,12 @@ class HaloProfile(CCLAutoRepr):
         # Compute Fourier-space profile
         if self._is_implemented("_fourier"):
             # Compute from `_fourier` if available.
-            p_fourier = self._fourier(cosmo, k_arr, M_use,
-                                      a, mass_def)
+            p_fourier = self._fourier(cosmo, k_arr, M_use, a)
         else:
             # Compute with FFTLog otherwise.
             lpad = self.precision_fftlog['large_padding_2D']
-            p_fourier = self._fftlog_wrap(cosmo,
-                                          k_arr,
-                                          M_use, a,
-                                          mass_def,
-                                          fourier_out=True,
-                                          large_padding=lpad)
+            p_fourier = self._fftlog_wrap(cosmo, k_arr, M_use, a,
+                                          fourier_out=True, large_padding=lpad)
         if is_cumul2d:
             # The cumulative profile involves a factor 1/(k R) in
             # the integrand.
@@ -493,6 +470,13 @@ class HaloProfileNumberCounts(HaloProfile):
 class HaloProfileMatter(HaloProfile):
     """Base for matter halo profiles."""
     normprof = True
+
+    def _get_comoving_radius(self, cosmo, r, M, a):
+        """Helper to get the comoving radius and the scale radius."""
+        R_M = self.mass_concentration.get_radius(cosmo, M, a) / a
+        c_M = self.mass_concentration.get_concentration(cosmo, M, a)
+        R_s = R_M / c_M
+        return R_s, R_M, c_M
 
 
 class HaloProfilePressure(HaloProfile):


### PR DESCRIPTION
This PR contains fixes to some design flaws in halos which can ultimately cause memory leaks and model inconsistencies.
Note: at the moment it breaks API (to make review easier), but once review is complete I will clone it into a non API-breaking one.

(5' read)

Problem 1
-------------
When `MassDef` is instantiated with a concentration it inadvertently contains a reference to itself:
```python
mass_def is mass_def.concentration.mass_def is mass_def.[...].mass_def
```
This causes a memory leak because when the object is deleted, the garbage collector doesn't know the order of deletion so the instances hang in there for the rest of the runtime. This can easily be demonstrated:
```python
import pyccl as ccl


class Concentration:

    def __init__(self, mass_def):
        self.mass_def = mass_def
        self.id = hex(id(self))[-5:]
        print(f"Concentration {self.id} created.")

    def __del__(self):
        print(f"Concentration {self.id} destroyed.")


class MassDef:

    def __init__(self):
        self.concentration = Concentration(self)  # line that causes the problem
        self.id = hex(id(self))[-5:]
        print(f"MassDef {self.id} created.")

    def __del__(self):
        print(f"MassDef {self.id} destroyed.")


mass_def = MassDef()
del mass_def  # doesn't do anything

print("program ends")
```
which outputs
```bash
Concentration 36050 created.
MassDef 3af50 created.
program ends
MassDef 3af50 destroyed.
Concentration 36050 destroyed.
```

An easy way to fix that is to use a weakref proxy of `self` when passing it to the `Concentration` constructor:
`import weakref ... self.concentration = Concentration(weakref.proxy(self))`. This allows the reference count of `mass_def` to go to zero and the gbc to purge it. This tactic is not generally advised though.

However, there is a deeper design flaw with the interplay of `MassDef` and `Concentration`.

Problem 2
-------------
Matter profiles require a `Concentration` to initialize. However, this isn't really a parameter; it is akin to setting up the model. As is `mass_def` (which is why we agreed to deprecate it from calls to subclasses of `HMIngredients`). This is how these two are used in the code, in every matter profile:
```python
    def _real(self, cosmo, r, M, a, mass_def):
        # Comoving virial radius
        R_M = mass_def.get_radius(cosmo, M, a) / a
        c_M = self.concentration(cosmo, M, a)
        R_s = R_M / c_M
```
so they aren't used in anything other than finding the comoving virial radius, given `M`. These two work together; they should be together, but one is passed at initialization and the other one at calls. What's more, this creates an inconsistency: the `mass_def` of `concentration` may not be the same as the `mass_def` passed in `_real`. Luckily, most implemented concentrations are `mass_def`-agnostic, and also users have (hopefully) been passing the same one, but this can easily create problems.

Solution
-----------
- One way is to add a check every time e.g. `_real` is called to verify that the mass definitions are consistent. That's a bad solution, no explanation needed.
- Another way is to deprecate `concentration` in `__init__` and pass it as an extra argument in e.g. `_real`. That's a bad solution because not all profiles use a `Concentration`, so we'll end up unnecessarily complicating the code.
- Another way is to move `mass_def` to `__init__` and deprecate it from e.g. `_real`. That's okay, but the non-matter profiles still use `mass_def` to compute the radius, given the mass. That means, in order to be consistent, we'd have to introduce `mass_def` as an `__init__` argument in all profiles.
- I propose the following. Since `MassDef` and `Concentration` are so strongly coupled, it makes sense to combine them into one single object. Then, every profile will accept a `MassConcentration` object in `__init__` which contains all the info it will ever need: mass definition and an optional concentration. This will simplify things.

In practice, the new class would contain `self.mass_def` and `self.concentration` and would avoid self-references and other caveats. It would initialize both the mass definition and the concentration prescription at the same time.

This is what it could look like:
```python
class MassConcentration(MassDef, Concentration):
    def __init__(self, *, mass_def, concentration):
        # careful with initialization: we don't want cyclic references like in MassDef
        self.mass_def = mass_def
        self.concentration = concentration
```
and then, all halo profiles would have:
```python
class HaloProfileNFW(HaloProfile):
    def __init__(self, mass_concentration, ...):
        self.mass_concentration = mass_concentration
        ...

    def _real(self, cosmo, r, M, a):
        R_M = self.mass_concentration.get_radius(cosmo, M, a) / a
        c_M = self.mass_concentration.concentration(cosmo, M, a)
        R_s = R_M / cM
```
We could even go as far as implementing a `get_comoving_virial_radius` method, to do all of that in a single step and avoid having to repeat that in all matter profiles.

It would also make physical sense because the parameters passed in `__init__` would uniquely define a profile 'entity', which would then be called via its methods and `(r, M, a)` (and `cosmo` which is an outlier as we've already discussed).

For `v2.final` we can leave things as they are, but add warnings that these will be deprecated in the future, and point users towards using `MassConcentration` objects instead of separate `MassDef` and `Concentration`.

The solution would _simplify_ the code - for example, in `benchmarks/test_haloprofile.py` we do
```python
    mdef = ccl.halos.MassDef(mDelta, 'matter')
    c = ccl.halos.ConcentrationConstant(c=concentration, mdef=mdef)
    mdef = ccl.halos.MassDef(mDelta, 'matter', concentration=c)
    p = ccl.halos.HaloProfileEinasto(c, truncated=False)
```
so there are two instantiations of a mass definition to get the one we want to use. With the new implementation we won't need that - it would be a single step.

This proposal is a widely used design pattern in OOP called "dependency injection", and is a technique where an object is passed as a dependency to another object, rather than having the dependent object create the dependency itself. It helps to reduce coupling between different objects, and makes the code more modular and testable.