### PR TITLE
Additional improvements to halos

### DIFF
--- a/pyccl/base/schema.py
+++ b/pyccl/base/schema.py
@@ -374,6 +374,8 @@ def _subclasses(cls):
 def from_name(cls, name):
     """Obtain particular model."""
     mod = {p.name: p for p in cls._subclasses() if hasattr(p, "name")}
+    if name not in mod:
+        raise KeyError(f"Invalid model {name}.")
     return mod[name]
 
 

--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -55,11 +55,17 @@ class HMCalculator(CCLAutoRepr):
 
     @warn_api(pairs=[("massfunc", "mass_function"), ("hbias", "halo_bias"),
                      ("nlog10M", "nM")])
-    def __init__(self, *, mass_function, halo_bias, mass_def,
+    def __init__(self, *, mass_function, halo_bias, mass_def=None,
                  log10M_min=8., log10M_max=16., nM=128,
                  integration_method_M='simpson', k_min=1E-5):
         # Initialize halo model ingredients
-        self.mass_def = MassDef.create_instance(mass_def)
+        if mass_def is not None:
+            self.mass_def = MassDef.create_instance(mass_def)
+        else:
+            if isinstance(mass_function, str) or isinstance(halo_bias, str):
+                raise ValueError("Need to provide mass_def if mass_function "
+                                 "or halo_bias are str.")
+            self.mass_def = mass_function.mass_def
         kw = {"mass_def": self.mass_def}
         self.mass_function = MassFunc.create_instance(mass_function, **kw)
         self.halo_bias = HaloBias.create_instance(halo_bias, **kw)

--- a/pyccl/halos/massdef.py
+++ b/pyccl/halos/massdef.py
@@ -97,8 +97,11 @@ class MassDef(CCLAutoRepr, CCLNamedClass):
     @warn_api(pairs=[("c_m_relation", "concentration")])
     def __init__(self, Delta, rho_type=None, *, concentration=None):
         # Check it makes sense
-        if isinstance(Delta, str) and Delta not in ["fof", "vir"]:
-            raise ValueError(f"Unknown Delta type {Delta}.")
+        if isinstance(Delta, str):
+            if Delta.isdigit():
+                Delta = int(Delta)
+            elif Delta not in ["fof", "vir"]:
+                raise ValueError(f"Unknown Delta type {Delta}.")
         if isinstance(Delta, (int, float)) and Delta < 0:
             raise ValueError("Delta must be a positive number.")
         if rho_type not in ['matter', 'critical']:


### PR DESCRIPTION
I brought the extra stuff from 1064 to here, so that we keep the other PR as clean as possible.

The main change this PR introduces, is to make `mass_def` an optional argument in `HMCalculator` because if `mass_function` and `halo_bias` are passed as instances (rather than str) we can just use their own `mass_def`. We can do that because some lines below we enforce that all `mass_def`s are equal.
So an `HMCalculator` can be instantiated in one of the following ways:
```python
## From strings
# hmc way 1
hmc = ccl.halos.HMCalculator(mass_function="Tinker10", halo_bias="Tinker10", mass_def="200c")


## From instances
# Initialize instances
# instances way 1
mdef = ccl.halos.MassDef200c()
hmf = ccl.halos.MassFunctionTinker10(mass_def=mdef)  # mass_def can also be a string
hbf = ccl.halos.HaloBiasTinker10(mass_def=mdef)      # mass_def can also be a string

# instances way 2
hmf = ccl.halos.MassFunc.from_name("Tinker10")(mass_def="200c")  # mass_def can also be an instance
hbf = ccl.halos.HaloBias.from_name("Tinker10")(mass_def="200c")  # mass_def can also be an instance

# instances way 3
hmf = ccl.halos.MassFunc.create_instance("Tinker10", mass_def="200c")  # mass_def can also be an instance
hbf = ccl.halos.HaloBias.create_instance("Tinker10", mass_def="200c")  # mass_def can also be an instance

# hmc way 2
hmc = ccl.halos.HMCalculator(mass_function=hmf, halo_bias=hbf, mass_def=mdef)

# hmc way 3
hmc = ccl.halos.HMCalculator(mass_function=hmf, halo_bias=hbf)
```