### PR TITLE
Additional halos features

### DIFF
--- a/pyccl/base/schema.py
+++ b/pyccl/base/schema.py
@@ -355,6 +355,8 @@ class CCLNamedClass(CCLObject):
     def from_name(cls, name):
         """Obtain particular model."""
         mod = {p.name: p for p in cls._subclasses() if hasattr(p, "name")}
+        if name not in mod:
+            raise KeyError(f"Invalid model {name}.")
         return mod[name]
 
     @classmethod

--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -55,11 +55,17 @@ class HMCalculator(CCLAutoRepr):
 
     @warn_api(pairs=[("massfunc", "mass_function"), ("hbias", "halo_bias"),
                      ("nlog10M", "nM")])
-    def __init__(self, *, mass_function, halo_bias, mass_def,
+    def __init__(self, *, mass_function, halo_bias, mass_def=None,
                  log10M_min=8., log10M_max=16., nM=128,
                  integration_method_M='simpson', k_min=1E-5):
         # Initialize halo model ingredients
-        self.mass_def = MassDef.create_instance(mass_def)
+        if mass_def is not None:
+            self.mass_def = MassDef.create_instance(mass_def)
+        else:
+            if isinstance(mass_function, str) or isinstance(halo_bias, str):
+                raise ValueError("Need to provide mass_def if mass_function "
+                                 "or halo_bias are str.")
+            self.mass_def = mass_function.mass_def
         kw = {"mass_def": self.mass_def}
         self.mass_function = MassFunc.create_instance(mass_function, **kw)
         self.halo_bias = HaloBias.create_instance(halo_bias, **kw)

--- a/pyccl/halos/massdef.py
+++ b/pyccl/halos/massdef.py
@@ -98,8 +98,11 @@ class MassDef(CCLAutoRepr, CCLNamedClass):
     @warn_api(pairs=[("c_m_relation", "concentration")])
     def __init__(self, Delta, rho_type=None, *, concentration=None):
         # Check it makes sense
-        if isinstance(Delta, str) and Delta not in ["fof", "vir"]:
-            raise ValueError(f"Unknown Delta type {Delta}.")
+        if isinstance(Delta, str):
+            if Delta.isdigit():
+                Delta = int(Delta)
+            elif Delta not in ["fof", "vir"]:
+                raise ValueError(f"Unknown Delta type {Delta}.")
         if isinstance(Delta, (int, float)) and Delta < 0:
             raise ValueError("Delta must be a positive number.")
         if rho_type not in ['matter', 'critical']:

--- a/pyccl/tests/test_cclobject.py
+++ b/pyccl/tests/test_cclobject.py
@@ -9,15 +9,34 @@ def all_subclasses(cls):
         [s for c in cls.__subclasses__() for s in all_subclasses(c)])
 
 
-def test_fancy_repr():
-    # Test fancy-repr controls.
+def test_method_control_raises():
+    # All method control subclasses must contain a default implementation.
+    with pytest.raises(ValueError):
+        class MyMethodControl(ccl.base.schema._CustomMethod, method="name"):
+            pass
+
+
+def test_repr_control():
+    # Test custom repr controls.
     cosmo = ccl.CosmologyVanillaLCDM()
 
-    ccl.FancyRepr.disable()
+    ccl.CustomRepr.disable()
     assert repr(cosmo) == object.__repr__(cosmo)
 
-    ccl.FancyRepr.enable()
+    ccl.CustomRepr.enable()
     assert repr(cosmo) != object.__repr__(cosmo)
+
+
+def test_eq_control():
+    # Test custom eq controls.
+    cosmo = [ccl.CosmologyVanillaLCDM() for _ in range(2)]
+    assert id(cosmo[0]) != id(cosmo[1])
+
+    ccl.CustomEq.disable()
+    assert cosmo[0] != cosmo[1]
+
+    ccl.CustomRepr.enable()
+    assert cosmo[0] == cosmo[1]
 
 
 def check_eq_repr_hash(self, other, *, equal=True):

--- a/pyccl/tests/test_cclobject.py
+++ b/pyccl/tests/test_cclobject.py
@@ -35,7 +35,7 @@ def test_eq_control():
     ccl.CustomEq.disable()
     assert cosmo[0] != cosmo[1]
 
-    ccl.CustomRepr.enable()
+    ccl.CustomEq.enable()
     assert cosmo[0] == cosmo[1]
 
 

--- a/pyccl/tests/test_massdef.py
+++ b/pyccl/tests/test_massdef.py
@@ -110,7 +110,7 @@ def test_subclasses_smoke(scls):
     assert np.isfinite(hmd.get_Delta(COSMO, 1.))
 
 
-@pytest.mark.parametrize('name', ['200m', '200c', '500c', 'vir'])
+@pytest.mark.parametrize('name', ['200m', '200c', '500c', 'vir', '350m'])
 def test_massdef_from_string_smoke(name):
     hmd_class = ccl.halos.MassDef.from_name(name)
     hmd = hmd_class()

--- a/pyccl/tests/test_pkhm.py
+++ b/pyccl/tests/test_pkhm.py
@@ -341,3 +341,13 @@ def test_hmcalculator_from_string_smoke():
         COSMO, massfunc="Tinker10", hbias="Tinker10", mass_def="200m")
     for attr in ["_massfunc", "_hbias", "_mdef"]:
         assert getattr(hmc1, attr).name == getattr(hmc2, attr).name
+
+
+def test_hmcalculator_from_string_raises():
+    # Check that if the necessary arguments aren't provided, it raises.
+    kw = {"mass_function": "Tinker10", "halo_bias": "Tinker10"}
+    with pytest.raises(ValueError):
+        # needs a mass_def to pass to the halo model ingredients
+        ccl.halos.HMCalculator(**kw)
+    # but this one is fine
+    ccl.halos.HMCalculator(**kw, mass_def="200c")


### PR DESCRIPTION
This is a rebased copy of 1065.

I brought the extra stuff from 1064 to here, so that we keep the other PR as clean as possible, and this PR also defines a library-level control to turn on/off the custom `__eq__` methods, just as we had with the `__repr__` methods.


Old Description
--------------------
The main change this PR introduces, is to make `mass_def` an optional argument in `HMCalculator` because if `mass_function` and `halo_bias` are passed as instances (rather than str) we can just use their own `mass_def`. We can do that because some lines below we enforce that all `mass_def`s are equal.
So an `HMCalculator` can be instantiated in one of the following ways:
```python
## From strings
# hmc way 1
hmc = ccl.halos.HMCalculator(mass_function="Tinker10", halo_bias="Tinker10", mass_def="200c")


## From instances
# Initialize instances
# instances way 1
mdef = ccl.halos.MassDef200c()
hmf = ccl.halos.MassFunctionTinker10(mass_def=mdef)  # mass_def can also be a string
hbf = ccl.halos.HaloBiasTinker10(mass_def=mdef)      # mass_def can also be a string

# instances way 2
hmf = ccl.halos.MassFunc.from_name("Tinker10")(mass_def="200c")  # mass_def can also be an instance
hbf = ccl.halos.HaloBias.from_name("Tinker10")(mass_def="200c")  # mass_def can also be an instance

# instances way 3
hmf = ccl.halos.MassFunc.create_instance("Tinker10", mass_def="200c")  # mass_def can also be an instance
hbf = ccl.halos.HaloBias.create_instance("Tinker10", mass_def="200c")  # mass_def can also be an instance

# hmc way 2
hmc = ccl.halos.HMCalculator(mass_function=hmf, halo_bias=hbf, mass_def=mdef)

# hmc way 3
hmc = ccl.halos.HMCalculator(mass_function=hmf, halo_bias=hbf)
```