### PR TITLE
`self is other` shortcut for `__eq__`

### DIFF
--- a/pyccl/base/schema.py
+++ b/pyccl/base/schema.py
@@ -283,6 +283,9 @@ class CCLObject(ABC):
         return hash(repr(self))
 
     def __eq__(self, other):
+        # Exit early if it is the same object.
+        if self is other:
+            return True
         # Two same-type objects are equal if their representations are equal.
         if type(self) is not type(other):
             return False
@@ -292,8 +295,7 @@ class CCLObject(ABC):
                 if not is_equal(getattr(self, attr), getattr(other, attr)):
                     return False
             return True
-        # Fall back to default Python comparison.
-        return id(self) == id(other)
+        return False
 
 
 class CCLAutoRepr(CCLObject):

--- a/pyccl/parameters.py
+++ b/pyccl/parameters.py
@@ -201,6 +201,8 @@ class FFTLogParams:
         return repr(self.to_dict())
 
     def __eq__(self, other):
+        if self is other:
+            True
         if type(self) != type(other):
             return False
         return self.to_dict() == other.to_dict()

--- a/pyccl/pk2d.py
+++ b/pyccl/pk2d.py
@@ -184,6 +184,9 @@ class Pk2D(CCLObject):
                    extrap_order_hik=extrap_order_hik)
 
     def __eq__(self, other):
+        # Check object id.
+        if self is other:
+            return True
         # Check the object class.
         if type(self) is not type(other):
             return False

--- a/pyccl/tk3d.py
+++ b/pyccl/tk3d.py
@@ -137,6 +137,9 @@ class Tk3D(CCLObject):
         check(status)
 
     def __eq__(self, other):
+        # Check object id.
+        if self is other:
+            return True
         # Check the object class.
         if type(self) is not type(other):
             return False

--- a/pyccl/tracers.py
+++ b/pyccl/tracers.py
@@ -188,6 +188,10 @@ class Tracer(CCLObject):
         self._trc = []
 
     def __eq__(self, other):
+        # Check object id.
+        if self is other:
+            return True
+
         # Check the object class.
         if type(self) is not type(other):
             return False


### PR DESCRIPTION
We didn't include this check in the beginning which would make comparison much faster for same-id objects.