### PR TITLE
No normprof

### DIFF
--- a/pyccl/base/deprecations.py
+++ b/pyccl/base/deprecations.py
@@ -146,9 +146,8 @@ def warn_api(func=None, *, pairs=[], reorder=[]):
         if any([par.startswith("normprof") and kwargs.get(par) is not None
                 for par in kwargs]):
             warnings.warn(
-                "Argument `normprof` has been deprecated. Change the default "
-                "value only by subclassing. More comprehensive profile "
-                "normalization options will be provided with CCLv3.0.0.",
+                "Argument `normprof` will be deprecated in CCL v3. All "
+                "profiles will carry their own normalisation.",
                 CCLDeprecationWarning)
 
         # API compatibility for deprecated HMCalculator argument k_min.

--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -156,16 +156,6 @@ class HMCalculator(CCLAutoRepr):
                            self._mass, a, mass_def=self.mass_def).T
         return 1. / self._integrate_over_mf(uk0)
 
-    def get_profile_norm(self, cosmo, a, prof):
-        """Compute the normalization of a profile."""
-        if not prof.normprof:  # TODO: Remove for CCLv3.
-            return 1
-        uk0 = prof._normalization(self)(cosmo=cosmo, a=a)
-        if isinstance(uk0, (int, float)):
-            return 1 / uk0
-        self._get_ingredients(cosmo, a, get_bf=False)
-        return 1 / self._integrate_over_mf(uk0)
-
     @warn_api(pairs=[("sel", "selection"),
                      ("amin", "a_min"),
                      ("amax", "a_max")],

--- a/pyccl/halos/pk_1pt.py
+++ b/pyccl/halos/pk_1pt.py
@@ -1,4 +1,4 @@
-from ..base import UnlockInstance, warn_api
+from ..base import warn_api
 import numpy as np
 
 
@@ -28,11 +28,6 @@ def _Ix1(func, cosmo, hmc, k, a, prof, normprof):
         `k` and `a` respectively. If `k` or `a` are scalars, the
         corresponding dimension will be squeezed out on output.
     """
-    # TODO: Remove for CCLv3.
-    if normprof is not None:
-        with UnlockInstance(prof):
-            prof.normprof = normprof
-
     func = getattr(hmc, func)
 
     a_use = np.atleast_1d(a).astype(float)
@@ -43,8 +38,9 @@ def _Ix1(func, cosmo, hmc, k, a, prof, normprof):
     out = np.zeros([na, nk])
     for ia, aa in enumerate(a_use):
         i11 = func(cosmo, k_use, aa, prof)
-        norm = hmc.get_profile_norm(cosmo, aa, prof)
-        out[ia] = i11 * norm
+        norm = prof.normalization(hmc, cosmo, aa) if normprof else 1
+        # TODO: CCLv3 remove if
+        out[ia] = i11 / norm
 
     if np.ndim(a) == 0:
         out = np.squeeze(out, axis=0)

--- a/pyccl/halos/pk_2pt.py
+++ b/pyccl/halos/pk_2pt.py
@@ -1,4 +1,4 @@
-from ..base import UnlockInstance, warn_api
+from ..base import warn_api
 from ..pk2d import Pk2D, parse_pk
 from .profiles_2pt import Profile2pt
 import numpy as np
@@ -105,14 +105,6 @@ def halomod_power_spectrum(cosmo, hmc, k, a, prof, *,
     if prof_2pt is None:
         prof_2pt = Profile2pt()
 
-    # TODO: Remove for CCLv3.
-    if normprof1 is not None:
-        with UnlockInstance(prof):
-            prof.normprof = normprof1
-    if normprof2 is not None:
-        with UnlockInstance(prof2):
-            prof2.normprof = normprof2
-
     pk2d = parse_pk(cosmo, p_of_k_a)
     extrap = cosmo if extrap_pk else None  # extrapolation rule for pk2d
 
@@ -121,12 +113,14 @@ def halomod_power_spectrum(cosmo, hmc, k, a, prof, *,
     out = np.zeros([na, nk])
     for ia, aa in enumerate(a_use):
         # normalizations
-        norm1 = hmc.get_profile_norm(cosmo, aa, prof)
+        norm1 = prof.normalization(hmc, cosmo, aa) if normprof1 else 1
+        # TODO: CCLv3, remove if
 
         if prof2 == prof:
             norm2 = norm1
         else:
-            norm2 = hmc.get_profile_norm(cosmo, aa, prof2)
+            norm2 = prof2.normalization(hmc, cosmo, aa) if normprof2 else 1
+            # TODO: CCLv3, remove if
 
         if get_2h:
             # bias factors
@@ -154,10 +148,10 @@ def halomod_power_spectrum(cosmo, hmc, k, a, prof, *,
 
         # smooth 1h/2h transition region
         if smooth_transition is None:
-            out[ia] = (pk_1h + pk_2h) * norm1 * norm2
+            out[ia] = (pk_1h + pk_2h) / (norm1 * norm2)
         else:
             alpha = smooth_transition(aa)
-            out[ia] = (pk_1h**alpha + pk_2h**alpha)**(1/alpha) * norm1 * norm2
+            out[ia] = (pk_1h**alpha + pk_2h**alpha)**(1/alpha) / (norm1*norm2)
 
     if np.ndim(a) == 0:
         out = np.squeeze(out, axis=0)

--- a/pyccl/halos/pk_4pt.py
+++ b/pyccl/halos/pk_4pt.py
@@ -1,4 +1,4 @@
-from ..base import UnlockInstance, warn_api
+from ..base import warn_api
 from ..pk2d import parse_pk
 from ..tk3d import Tk3D
 from ..errors import CCLWarning
@@ -82,30 +82,33 @@ def halomod_trispectrum_1h(cosmo, hmc, k, a, prof, *,
 
     # define all the profiles
     prof, prof2, prof3, prof4, prof12_2pt, prof34_2pt = \
-        _allocate_profiles(prof, prof2, prof3, prof4, prof12_2pt, prof34_2pt,
-                           normprof1, normprof2, normprof3, normprof4)
+        _allocate_profiles(prof, prof2, prof3, prof4, prof12_2pt, prof34_2pt)
 
     na = len(a_use)
     nk = len(k_use)
     out = np.zeros([na, nk, nk])
     for ia, aa in enumerate(a_use):
         # normalizations
-        norm1 = hmc.get_profile_norm(cosmo, aa, prof)
+        norm1 = prof.normalization(hmc, cosmo, aa) if normprof1 else 1
+        # TODO: CCLv3 remove if
 
         if prof2 == prof:
             norm2 = norm1
         else:
-            norm2 = hmc.get_profile_norm(cosmo, aa, prof2)
+            norm2 = prof2.normalization(hmc, cosmo, aa) if normprof2 else 1
+            # TODO: CCLv3 remove if
 
         if prof3 == prof:
             norm3 = norm1
         else:
-            norm3 = hmc.get_profile_norm(cosmo, aa, prof3)
+            norm3 = prof3.normalization(hmc, cosmo, aa) if normprof3 else 1
+            # TODO: CCLv3 remove if
 
         if prof4 == prof2:
             norm4 = norm2
         else:
-            norm4 = hmc.get_profile_norm(cosmo, aa, prof4)
+            norm4 = prof4.normalization(hmc, cosmo, aa) if normprof4 else 1
+            # TODO: CCLv3 remove if
 
         # trispectrum
         tk_1h = hmc.I_0_22(cosmo, k_use, aa,
@@ -114,7 +117,7 @@ def halomod_trispectrum_1h(cosmo, hmc, k, a, prof, *,
                            prof12_2pt=prof12_2pt,
                            prof34_2pt=prof34_2pt)
 
-        out[ia] = tk_1h * norm1 * norm2 * norm3 * norm4  # assign
+        out[ia] = tk_1h / (norm1 * norm2 * norm3 * norm4)  # assign
 
     if np.ndim(a) == 0:
         out = np.squeeze(out, axis=0)
@@ -306,14 +309,15 @@ def halomod_Tk3D_SSC_linear_bias(cosmo, hmc, *, prof,
     nk = len(k_use)
     dpk12, dpk34 = [np.zeros([na, nk]) for _ in range(2)]
     for ia, aa in enumerate(a_arr):
-        norm = hmc.get_profile_norm(cosmo, aa, prof)**2
+        norm = prof.normalization(hmc, cosmo, aa)**2
+        # TODO: CCLv3 remove if
         i12 = hmc.I_1_2(cosmo, k_use, aa, prof, prof2=prof, prof_2pt=prof_2pt)
 
         pk = pk2d(k_use, aa, cosmo=extrap)
         dpk = pk2d(k_use, aa, derivative=True, cosmo=extrap)
 
         # ~ (47/21 - 1/3 dlogPk/dlogk) * Pk + I12
-        dpk12[ia] = (47/21 - dpk/3)*pk + i12 * norm
+        dpk12[ia] = (47/21 - dpk/3)*pk + i12 / norm
         dpk34[ia] = dpk12[ia].copy()
 
         # Counter terms for clustering (i.e. - (bA + bB) * PAB)
@@ -323,7 +327,7 @@ def halomod_Tk3D_SSC_linear_bias(cosmo, hmc, *, prof,
             i02 = hmc.I_0_2(cosmo, k_use, aa, prof,
                             prof2=prof, prof_2pt=prof_2pt)
 
-            P_12 = P_34 = pk + i02 * norm
+            P_12 = P_34 = pk + i02 / norm
 
             if is_number_counts1:
                 b1 = bias1[ia]
@@ -439,8 +443,7 @@ def halomod_Tk3D_SSC(
 
     # define all the profiles
     prof, prof2, prof3, prof4, prof12_2pt, prof34_2pt = \
-        _allocate_profiles(prof, prof2, prof3, prof4, prof12_2pt, prof34_2pt,
-                           normprof1, normprof2, normprof3, normprof4)
+        _allocate_profiles(prof, prof2, prof3, prof4, prof12_2pt, prof34_2pt)
 
     k_use = np.exp(lk_arr)
     pk2d = parse_pk(cosmo, p_of_k_a)
@@ -449,28 +452,32 @@ def halomod_Tk3D_SSC(
     dpk12, dpk34 = [np.zeros((len(a_arr), len(k_use))) for _ in range(2)]
     for ia, aa in enumerate(a_arr):
         # normalizations & I11 integral
-        norm1 = hmc.get_profile_norm(cosmo, aa, prof)
+        norm1 = prof.normalization(hmc, cosmo, aa) if normprof1 else 1
+        # TODO: CCLv3 remove if
         i11_1 = hmc.I_1_1(cosmo, k_use, aa, prof)
 
         if prof2 == prof:
             norm2 = norm1
             i11_2 = i11_1
         else:
-            norm2 = hmc.get_profile_norm(cosmo, aa, prof2)
+            norm2 = prof2.normalization(hmc, cosmo, aa) if normprof2 else 1
+            # TODO: CCLv3 remove if
             i11_2 = hmc.I_1_1(cosmo, k_use, aa, prof2)
 
         if prof3 == prof:
             norm3 = norm1
             i11_3 = i11_1
         else:
-            norm3 = hmc.get_profile_norm(cosmo, aa, prof3)
+            norm3 = prof3.normalization(hmc, cosmo, aa) if normprof3 else 1
+            # TODO: CCLv3 remove if
             i11_3 = hmc.I_1_1(cosmo, k_use, aa, prof3)
 
         if prof4 == prof2:
             norm4 = norm2
             i11_4 = i11_2
         else:
-            norm4 = hmc.get_profile_norm(cosmo, aa, prof4)
+            norm4 = prof4.normalization(hmc, cosmo, aa) if normprof4 else 1
+            # TODO: CCLv3 remove if
             i11_4 = hmc.I_1_1(cosmo, k_use, aa, prof4)
 
         # I12 integral
@@ -487,17 +494,17 @@ def halomod_Tk3D_SSC(
         dpk = pk2d(k_use, aa, derivative=True, cosmo=extrap)
 
         # (47/21 - 1/3 dlogPk/dlogk) * I11 * I11 * Pk + I12
-        dpk12[ia] = norm1 * norm2 * ((47/21 - dpk/3)*i11_1*i11_2*pk + i12_12)
-        dpk34[ia] = norm3 * norm4 * ((47/21 - dpk/3)*i11_3*i11_4*pk + i12_34)
+        dpk12[ia] = ((47/21 - dpk/3)*i11_1*i11_2*pk + i12_12) / (norm1 * norm2)
+        dpk34[ia] = ((47/21 - dpk/3)*i11_3*i11_4*pk + i12_34) / (norm3 * norm4)
 
         # Counter terms for clustering (i.e. - (bA + bB) * PAB)
         def _get_counterterm(pA, pB, p2pt, nA, nB, i11_A, i11_B):
             """Helper to compute counter-terms."""
             # p : profiles | p2pt : 2-point | n : norms | i11 : I_1_1 integral
-            bA = i11_A * nA if isinstance(pA, ProfNC) else np.zeros_like(k_use)
-            bB = i11_B * nB if isinstance(pB, ProfNC) else np.zeros_like(k_use)
+            bA = i11_A / nA if isinstance(pA, ProfNC) else np.zeros_like(k_use)
+            bB = i11_B / nB if isinstance(pB, ProfNC) else np.zeros_like(k_use)
             i02 = hmc.I_0_2(cosmo, k_use, aa, pA, prof2=pB, prof_2pt=p2pt)
-            P = nA * nB * (pk * i11_A * i11_B + i02)
+            P = (pk * i11_A * i11_B + i02) / (nA * nB)
             return (bA + bB) * P
 
         if isinstance(prof, ProfNC) or isinstance(prof2, ProfNC):
@@ -519,8 +526,7 @@ def halomod_Tk3D_SSC(
                 extrap_order_hik=extrap_order_hik, is_logt=use_log)
 
 
-def _allocate_profiles(prof, prof2, prof3, prof4, prof12_2pt, prof34_2pt,
-                       normprof1, normprof2, normprof3, normprof4):
+def _allocate_profiles(prof, prof2, prof3, prof4, prof12_2pt, prof34_2pt):
     """Helper that controls how the undefined profiles are allocated."""
     if prof2 is None:
         prof2 = prof
@@ -532,20 +538,6 @@ def _allocate_profiles(prof, prof2, prof3, prof4, prof12_2pt, prof34_2pt,
         prof12_2pt = Profile2pt()
     if prof34_2pt is None:
         prof34_2pt = prof12_2pt
-
-    # TODO: Remove for CCLv3.
-    if normprof1 is not None:
-        with UnlockInstance(prof):
-            prof.normprof = normprof1
-    if normprof2 is not None:
-        with UnlockInstance(prof2):
-            prof2.normprof = normprof2
-    if normprof3 is not None:
-        with UnlockInstance(prof3):
-            prof3.normprof = normprof3
-    if normprof4 is not None:
-        with UnlockInstance(prof4):
-            prof4.normprof = normprof4
 
     return prof, prof2, prof3, prof4, prof12_2pt, prof34_2pt
 

--- a/pyccl/halos/profiles/cib_shang12.py
+++ b/pyccl/halos/profiles/cib_shang12.py
@@ -82,7 +82,7 @@ class HaloProfileCIBShang12(HaloProfileCIB):
     """
     __repr_attrs__ = __eq_attrs__ = (
         "nu", "alpha", "T0", "beta", "gamma", "s_z", "log10Meff", "siglog10M",
-        "Mmin", "L0", "concentration", "precision_fftlog", "normprof")
+        "Mmin", "L0", "concentration", "precision_fftlog",)
     __getattr__ = deprecate_attr(pairs=[('l10meff', 'log10Meff'),
                                         ('sigLM', 'siglog10M')]
                                  )(super.__getattribute__)

--- a/pyccl/halos/profiles/einasto.py
+++ b/pyccl/halos/profiles/einasto.py
@@ -41,7 +41,7 @@ class HaloProfileEinasto(HaloProfileMatter):
             'cosmo' to calculate the value from cosmology. Default: 'cosmo'
     """
     __repr_attrs__ = __eq_attrs__ = (
-        "truncated", "alpha", "precision_fftlog", "concentration", "normprof",)
+        "truncated", "alpha", "precision_fftlog", "concentration",)
 
     @warn_api(pairs=[("c_M_relation", "concentration")])
     def __init__(self, *, concentration, truncated=True, alpha='cosmo'):

--- a/pyccl/halos/profiles/gaussian.py
+++ b/pyccl/halos/profiles/gaussian.py
@@ -22,9 +22,7 @@ class HaloProfileGaussian(HaloProfile):
         rho0 (:obj:`function`): the amplitude of the profile.
             It should have the same signature as `r_scale`.
     """
-    __repr_attrs__ = __eq_attrs__ = ("r_scale", "rho_0", "precision_fftlog",
-                                     "normprof",)
-    normprof = False
+    __repr_attrs__ = __eq_attrs__ = ("r_scale", "rho_0", "precision_fftlog",)
 
     @deprecated()
     @warn_api

--- a/pyccl/halos/profiles/hernquist.py
+++ b/pyccl/halos/profiles/hernquist.py
@@ -45,7 +45,7 @@ class HaloProfileHernquist(HaloProfileMatter):
     """
     __repr_attrs__ = __eq_attrs__ = (
         "fourier_analytic", "projected_analytic", "cumul2d_analytic",
-        "truncated", "concentration", "precision_fftlog", "normprof",)
+        "truncated", "concentration", "precision_fftlog",)
 
     @warn_api(pairs=[("c_M_relation", "concentration")])
     def __init__(self, *, concentration,

--- a/pyccl/halos/profiles/hod.py
+++ b/pyccl/halos/profiles/hod.py
@@ -113,7 +113,7 @@ class HaloProfileHOD(HaloProfileNumberCounts):
         "log10Mmin_0", "log10Mmin_p", "siglnM_0", "siglnM_p", "log10M0_0",
         "log10M0_p", "log10M1_0", "log10M1_p", "alpha_0", "alpha_p", "fc_0",
         "fc_p", "bg_0", "bg_p", "bmax_0", "bmax_p", "a_pivot",
-        "ns_independent", "concentration", "precision_fftlog", "normprof",)
+        "ns_independent", "concentration", "precision_fftlog",)
     __getattr__ = deprecate_attr(pairs=[
         ("lMmin_0", "log10Mmin_0"), ("lMmin_p", "log10Mmin_p"),
         ("siglM_0", "siglnM_0"), ("siglM_p", "siglnM_p"),
@@ -321,6 +321,20 @@ class HaloProfileHOD(HaloProfileNumberCounts):
         if np.ndim(M) == 0:
             prof = np.squeeze(prof, axis=0)
         return prof
+
+    def normalization(self, hmc, cosmo, a):
+        """Returns the normalization of this profile, which is the
+        mean galaxy number density.
+        """
+        Nc = self._Nc(hmc._mass, a)
+        Ns = self._Ns(hmc._mass, a)
+        fc = self._fc(a)
+        if self.ns_independent:
+            Ngal = Nc*fc + Ns
+        else:
+            Ngal = Nc*(fc + Ns)
+        hmc._get_ingredients(cosmo, a, get_bf=False)
+        return hmc._integrate_over_mf(Ngal)
 
     def _fourier(self, cosmo, k, M, a, mass_def):
         M_use = np.atleast_1d(M)

--- a/pyccl/halos/profiles/nfw.py
+++ b/pyccl/halos/profiles/nfw.py
@@ -47,7 +47,7 @@ class HaloProfileNFW(HaloProfileMatter):
     """
     __repr_attrs__ = __eq_attrs__ = (
         "fourier_analytic", "projected_analytic", "cumul2d_analytic",
-        "truncated", "concentration", "precision_fftlog", "normprof",)
+        "truncated", "concentration", "precision_fftlog",)
 
     @warn_api(pairs=[("c_M_relation", "concentration")])
     def __init__(self, *, concentration,

--- a/pyccl/halos/profiles/powerlaw.py
+++ b/pyccl/halos/profiles/powerlaw.py
@@ -22,9 +22,7 @@ class HaloProfilePowerLaw(HaloProfile):
             profile. The signature of this function should
             be `f(cosmo, a)`.
     """
-    __repr_attrs__ = __eq_attrs__ = ("r_scale", "tilt", "precision_fftlog",
-                                     "normprof",)
-    normprof = False
+    __repr_attrs__ = __eq_attrs__ = ("r_scale", "tilt", "precision_fftlog",)
 
     @deprecated()
     @warn_api

--- a/pyccl/halos/profiles/pressure_gnfw.py
+++ b/pyccl/halos/profiles/pressure_gnfw.py
@@ -67,7 +67,7 @@ class HaloProfilePressureGNFW(HaloProfilePressure):
     """
     __repr_attrs__ = __eq_attrs__ = (
         "mass_bias", "P0", "c500", "alpha", "alpha_P", "beta", "gamma",
-        "P0_hexp", "qrange", "nq", "x_out", "precision_fftlog", "normprof",)
+        "P0_hexp", "qrange", "nq", "x_out", "precision_fftlog",)
 
     @warn_api
     def __init__(self, *, mass_bias=0.8, P0=6.41,

--- a/pyccl/halos/profiles/profile_base.py
+++ b/pyccl/halos/profiles/profile_base.py
@@ -1,8 +1,8 @@
 from ...pyutils import resample_array, _fftlog_transform
 from ...base import CCLAutoRepr, unlock_instance, warn_api, deprecate_attr
 from ...parameters import FFTLogParams
+from ...parameters import physical_constants as const
 import numpy as np
-from abc import abstractmethod
 import functools
 from typing import Callable
 
@@ -47,35 +47,25 @@ class HaloProfile(CCLAutoRepr):
                             "_real or _fourier implementation.")
         self.precision_fftlog = FFTLogParams()
 
-    @property
-    @abstractmethod
-    def normprof(self) -> bool:
-        """Normalize the profile in auto- and cross-correlations by
-        :math:`I^0_1(k\\rightarrow 0, a|u)`
-        (see :meth:`~pyccl.halos.halo_model.HMCalculator.I_0_1`).
+    def normalization(self, hmc, cosmo, a):
+        """Returns the overall normalisation factor of this profile.
+
+        Args:
+            hmc (:class:`~pyccl.halos.HMCalculator`): a halo model calculator
+                object.
+            cosmo (:class:`~pyccl.core.Cosmology`): a Cosmology object.
+            a (float): scale factor.
+
+        Reurns:
+            float: normalisation of this profile.
         """
-
-    # TODO: CCLv3 - Rename & allocate _normprof_bool to the subclasses.
-
-    def _normprof_false(self, hmc, **settings):
-        """Option for ``normprof = False``."""
-        return lambda *args, cosmo, a, **kwargs: 1.
-
-    def _normprof_true(self, hmc, k_min=1e-5):
-        """Option for ``normprof = True``."""
-        # TODO: remove the first two lines in CCLv3.
-        k_hmc = hmc.precision["k_min"]
-        k_min = k_hmc if k_hmc != k_min else k_min
-        M, mass_def = hmc._mass, hmc.mass_def
-        return functools.partial(self.fourier, k=k_min, M=M, mass_def=mass_def)
-
-    def _normalization(self, hmc, **settings):
-        """This is the API adapter and it decides which norm to use.
-        It returns a function of ``cosmo`` and ``a``. Optional args & kwargs.
-        """
-        if self.normprof:
-            return self._normprof_true(hmc, **settings)
-        return self._normprof_false(hmc, **settings)
+        uk0 = self.fourier(cosmo=cosmo, k=hmc.precision['k_min'],
+                           M=hmc._mass, a=a, mass_def=hmc.mass_def)
+        hmc._get_ingredients(cosmo, a, get_bf=False)
+        return hmc._integrate_over_mf(uk0)
+        # TODO: CCLv3 replace by the below in v3 (profiles will all have a
+        # default normalisation of 1. Normalisation will always be applied).
+        # return lambda *args, cosmo, a, **kwargs: 1.
 
     @unlock_instance(mutate=True)
     @functools.wraps(FFTLogParams.update_parameters)
@@ -482,19 +472,21 @@ class HaloProfile(CCLAutoRepr):
 
 class HaloProfileNumberCounts(HaloProfile):
     """Base for number counts halo profiles."""
-    normprof = True
 
 
 class HaloProfileMatter(HaloProfile):
     """Base for matter halo profiles."""
-    normprof = True
+
+    def normalization(self, hmc, cosmo, a):
+        """Returns the normalization of all matter overdensity
+        profiles, which is simply the comoving matter density.
+        """
+        return const.RHO_CRITICAL * cosmo["Omega_m"] * cosmo["h"]**2
 
 
 class HaloProfilePressure(HaloProfile):
     """Base for pressure halo profiles."""
-    normprof = False
 
 
 class HaloProfileCIB(HaloProfile):
     """Base for CIB halo profiles."""
-    normprof = False

--- a/pyccl/tests/test_halomodel.py
+++ b/pyccl/tests/test_halomodel.py
@@ -69,7 +69,8 @@ def get_pk_new(mf, c, cosmo, a, k, get_1h, get_2h):
                                  mass_def=mdef)
     return ccl.halos.halomod_power_spectrum(cosmo, hmc, k, a, prf,
                                             get_1h=get_1h,
-                                            get_2h=get_2h)
+                                            get_2h=get_2h,
+                                            normprof1=True)
 
 
 @pytest.mark.parametrize('mf_c', [['shethtormen', 'bhattacharya2011'],

--- a/pyccl/tests/test_tkkssc.py
+++ b/pyccl/tests/test_tkkssc.py
@@ -85,7 +85,8 @@ def test_tkkssc_linear_bias(isNC1, isNC2, isNC3, isNC4):
 
     # Test with the full T(k1,k2,a) for an NFW profile with bias ~1.
     tkk = ccl.halos.halomod_Tk3D_SSC(
-        COSMO, HMC, prof=NFW, lk_arr=np.log(KK), a_arr=AA)
+        COSMO, HMC, prof=NFW, lk_arr=np.log(KK), a_arr=AA,
+        normprof1=True)
     *_, (tkk_12, tkk_34) = tkk.get_spline_arrays()
     assert np.allclose(tkkl_12, tkk_12, atol=0, rtol=5e-3)
     assert np.allclose(tkkl_34, tkk_34, atol=0, rtol=5e-3)


### PR DESCRIPTION
This PR removes normprof altogether from v3. The idea is that all profiles should define their own normalisation function (unless the normalisation is just 1, which is the default).