### PR TITLE
Preserve API in v2.final

### DIFF
--- a/pyccl/base/deprecations.py
+++ b/pyccl/base/deprecations.py
@@ -31,10 +31,11 @@ def mass_def_api(func):
     # TODO: CCLv3 - remove `mass_def=None` default from some HaloProfiles.
     @functools.wraps(func)
     @unlock_instance
-    def wrapper(self, *args, mass_def=None, **kwargs):
+    def wrapper(self, *args, mass_def=None, mdef_other=None, **kwargs):
         if type(args[-1]).__name__ == "MassDef":
             *args, mass_def = args
 
+        mass_def = mass_def or mdef_other
         if mass_def is not None:
             warnings.warn(
                 "mass_def is deprecated as an argument of {func.__name__} "

--- a/pyccl/halos/__init__.py
+++ b/pyccl/halos/__init__.py
@@ -3,9 +3,9 @@ from .concentration import *
 from .hbias import *
 from .hmfunc import *
 from .massdef import *
-from .halo_model import *
 from .profiles import *
 from .profiles_2pt import *
 from .pk_1pt import *
 from .pk_2pt import *
 from .pk_4pt import *
+from .halo_model import *

--- a/pyccl/halos/halo_model.py
+++ b/pyccl/halos/halo_model.py
@@ -1,8 +1,9 @@
 __all__ = ("HMCalculator",)
 
+import warnings
 import numpy as np
 
-from .. import CCLAutoRepr, unlock_instance
+from .. import CCLAutoRepr, CCLDeprecationWarning, unlock_instance
 from .. import warn_api, deprecate_attr, deprecated
 from .. import physical_constants as const
 from . import MassDef
@@ -421,3 +422,23 @@ class HMCalculator(CCLAutoRepr):
                 cosmo, k, self._mass, a, prof3, prof2=prof4).T
 
         return self._integrate_over_mf(uk12[None, :, :] * uk34[:, None, :])
+
+
+# TODO: Remove for CCLv3.
+def __getattr__(name):
+    warn = lambda n, m: warnings.warn(  # noqa
+        f"{n} is moved to pyccl.halos.{m}", CCLDeprecationWarning)
+    if name in ["halomod_mean_profile_1pt", "halomod_bias_1pt"]:
+        from .pk_1pt import __dict__ as mod_dict
+        warn(name, "pk_1pt")
+        return mod_dict[name]
+    elif name in ["halomod_power_spectrum", "halomod_Pk2D"]:
+        from .pk_2pt import __dict__ as mod_dict
+        warn(name, "pk_2pt")
+        return mod_dict[name]
+    elif name in ["halomod_trispectrum_1h", "halomod_Tk3D_1h",
+                  "halomod_Tk3D_SSC_linear_bias", "halomod_Tk3D_SSC"]:
+        from .pk_4pt import __dict__ as mod_dict
+        warn(name, "pk_4pt")
+        return mod_dict[name]
+    return eval(name) if name in locals() else None

--- a/pyccl/halos/halo_model_base.py
+++ b/pyccl/halos/halo_model_base.py
@@ -141,7 +141,6 @@ class MassFunc(HMIngredients):
             float or array_like: :math:`f(\\sigma_M)` function.
         """
 
-    @mass_def_api
     def __call__(self, cosmo, M, a):
         """ Returns the mass function for input parameters.
 
@@ -166,6 +165,7 @@ class MassFunc(HMIngredients):
         return mf
 
     @deprecated(new_function=__call__)
+    @mass_def_api
     def get_mass_function(self, cosmo, M, a):
         return self(cosmo, M, a)
 
@@ -203,7 +203,6 @@ class HaloBias(HMIngredients):
             float or array_like: f(sigma_M) function.
         """
 
-    @mass_def_api
     def __call__(self, cosmo, M, a):
         """ Returns the halo bias for input parameters.
 
@@ -223,6 +222,7 @@ class HaloBias(HMIngredients):
         return b
 
     @deprecated(new_function=__call__)
+    @mass_def_api
     def get_halo_bias(self, cosmo, M, a):
         return self(cosmo, M, a)
 
@@ -244,7 +244,6 @@ class Concentration(HMIngredients):
     def _concentration(self, cosmo, M, a):
         """Implementation of the c(M) relation."""
 
-    @mass_def_api
     def __call__(self, cosmo, M, a):
         """ Returns the concentration for input parameters.
 
@@ -263,6 +262,7 @@ class Concentration(HMIngredients):
         return c
 
     @deprecated(new_function=__call__)
+    @mass_def_api
     def get_concentration(self, cosmo, M, a):
         return self(cosmo, M, a)
 

--- a/pyccl/halos/halo_model_base.py
+++ b/pyccl/halos/halo_model_base.py
@@ -6,7 +6,7 @@ from abc import abstractmethod
 import numpy as np
 
 from .. import CCLAutoRepr, CCLNamedClass, lib, check
-from .. import warn_api, deprecated, deprecate_attr
+from .. import deprecate_attr, deprecated, warn_api, mass_def_api
 from .. import physical_constants as const
 
 
@@ -141,6 +141,7 @@ class MassFunc(HMIngredients):
             float or array_like: :math:`f(\\sigma_M)` function.
         """
 
+    @mass_def_api
     def __call__(self, cosmo, M, a):
         """ Returns the mass function for input parameters.
 
@@ -202,6 +203,7 @@ class HaloBias(HMIngredients):
             float or array_like: f(sigma_M) function.
         """
 
+    @mass_def_api
     def __call__(self, cosmo, M, a):
         """ Returns the halo bias for input parameters.
 
@@ -242,6 +244,7 @@ class Concentration(HMIngredients):
     def _concentration(self, cosmo, M, a):
         """Implementation of the c(M) relation."""
 
+    @mass_def_api
     def __call__(self, cosmo, M, a):
         """ Returns the concentration for input parameters.
 

--- a/pyccl/halos/massdef.py
+++ b/pyccl/halos/massdef.py
@@ -254,7 +254,11 @@ class MassDef(CCLAutoRepr, CCLNamedClass):
             # Bogus input - can't parse it.
             raise ValueError("Could not parse mass definition string.")
         Delta, rho_type = name[:-1], parser[name[-1]]
-        return lambda: cls(Delta, rho_type)  # noqa
+        # return cls(Delta, rho_type)  # TODO: Uncomment for CCLv3.
+        return lambda: cls(Delta, rho_type)  # noqa  # TODO: Remove for CCLv3.
+
+    # TODO: Uncomment for CCLv3 and remove CCLNamedClass inheritance.
+    # create_instance = from_name
 
     @classmethod
     def from_specs(cls, mass_def=None, *,
@@ -327,12 +331,18 @@ class MassDef(CCLAutoRepr, CCLNamedClass):
 
 # TODO: Remove these definitions and uncomment the new ones for CCLv3.
 # These will all throw warnings now.
+factory_warn = lambda: warnings.warn(  # noqa
+    "In CCLv3.0.0 MassDef factories will become variables.",
+    CCLDeprecationWarning)
+
+
 def MassDef200m(c_m='Duffy08'):
     r""":math:`\Delta = 200m` mass definition.
 
     Args:
         c_m (string): concentration-mass relation.
     """
+    factory_warn()
     return MassDef(200, 'matter', c_m_relation=c_m)
 
 
@@ -342,6 +352,7 @@ def MassDef200c(c_m='Duffy08'):
     Args:
         c_m (string): concentration-mass relation.
     """
+    factory_warn()
     return MassDef(200, 'critical', c_m_relation=c_m)
 
 
@@ -351,6 +362,7 @@ def MassDef500c(c_m='Ishiyama21'):
     Args:
         c_m (string): concentration-mass relation.
     """
+    factory_warn()
     return MassDef(500, 'critical', c_m_relation=c_m)
 
 
@@ -360,32 +372,19 @@ def MassDefVir(c_m='Klypin11'):
     Args:
         c_m (string): concentration-mass relation.
     """
+    factory_warn()
     return MassDef('vir', 'critical', c_m_relation=c_m)
 
 
-# def MassDef200m():
-#     r""":math:`\Delta = 200m` mass definition."""
-#     return MassDef(200, 'matter')
-
-
-# def MassDef200c():
-#     r""":math:`\Delta = 200c` mass definition."""
-#     return MassDef(200, 'critical')
-
-
-# def MassDef500c():
-#     r""":math:`\Delta = 500m` mass definition."""
-#     return MassDef(500, 'critical')
-
-
-# def MassDefVir():
-#     r""":math:`\Delta = \rm vir` mass definition."""
-#     return MassDef('vir', 'critical')
-
-
 def MassDefFof():
-    r""":math:`\Delta = \rm FoF` mass definition."""
-    return MassDef('fof', 'matter')
+    return MassDef("fof", "matter")
+
+
+# MassDef200m = MassDef(200, "matter")
+# MassDef200c = MassDef(200, "critical")
+# MassDef500c = MassDef(500, "critical")
+# MassDefVir = MassDef("vir", "critical")
+# MassDefFof = MassDef("fof", "matter")
 
 
 def mass_translator(*,

--- a/pyccl/halos/massdef.py
+++ b/pyccl/halos/massdef.py
@@ -2,12 +2,14 @@ __all__ = ("mass2radius_lagrangian", "convert_concentration", "MassDef",
            "MassDef200m", "MassDef200c", "MassDef500c", "MassDefVir",
            "MassDefFof", "mass_translator",)
 
+import warnings
+import weakref
 from functools import cached_property
 from typing import Union, Callable
 
 import numpy as np
 
-from .. import CCLAutoRepr, CCLNamedClass, lib, check
+from .. import CCLAutoRepr, CCLDeprecationWarning, CCLNamedClass, lib, check
 from .. import warn_api, deprecate_attr
 from . import Concentration, HaloBias, MassFunc
 
@@ -96,7 +98,7 @@ class MassDef(CCLAutoRepr, CCLNamedClass):
     __getattr__ = deprecate_attr(pairs=[('c_m_relation', 'concentration')]
                                  )(super.__getattribute__)
 
-    def __init__(self, Delta, rho_type=None):
+    def __init__(self, Delta, rho_type, c_m_relation=None):
         # Check it makes sense
         if isinstance(Delta, str):
             if Delta.isdigit():
@@ -110,6 +112,14 @@ class MassDef(CCLAutoRepr, CCLNamedClass):
 
         self.Delta = Delta
         self.rho_type = rho_type
+
+        # TODO: Remove c_m_relation for CCLv3.
+        if c_m_relation is not None:
+            warnings.warn("c_m_relation is deprecated from MassDef and will "
+                          "be removed in CCLv3.0.0.", CCLDeprecationWarning)
+            c_m_relation = Concentration.create_instance(
+                c_m_relation, mass_def=weakref.proxy(self))
+        self.concentration = c_m_relation
 
     @cached_property
     def name(self):
@@ -193,6 +203,36 @@ class MassDef(CCLAutoRepr, CCLNamedClass):
         if np.ndim(M) == 0:
             return R[0]
         return R
+
+    def translate_mass(self, cosmo, M, a, m_def_other):
+        """ Translate halo mass in this definition into another definition
+
+        Args:
+            cosmo (:class:`~pyccl.core.Cosmology`): A Cosmology object.
+            M (float or array_like): halo mass in units of M_sun.
+            a (float): scale factor.
+            m_def_other (:obj:`MassDef`): another mass definition.
+
+        Returns:
+            float or array_like: halo masses in new definition.
+        """
+        # TODO: Remove for CCLv3.
+        warnings.warn("translate_mass is a deprecated method of MassDef and "
+                      "will be removed in CCLv3.0.0. Use `pyccl.halos.mass_"
+                      "translator`.", CCLDeprecationWarning)
+        if self == m_def_other:
+            return M
+        if self.concentration is None:
+            raise ValueError("No associated c(M) relation.")
+        om_this = cosmo.omega_x(a, self.rho_type)
+        D_this = self.get_Delta(cosmo, a) * om_this
+        c_this = self._get_concentration(cosmo, M, a)
+        R_this = self.get_radius(cosmo, M, a)
+        om_new = cosmo.omega_x(a, m_def_other.rho_type)
+        D_new = m_def_other.get_Delta(cosmo, a) * om_new
+        c_new = convert_concentration(cosmo, c_this, D_this, D_new)
+        R_new = c_new * R_this / c_this
+        return m_def_other.get_mass(cosmo, R_new, a)
 
     @classmethod
     def from_name(cls, name):
@@ -285,24 +325,62 @@ class MassDef(CCLAutoRepr, CCLNamedClass):
         return mass_def, *out
 
 
-def MassDef200m():
-    r""":math:`\Delta = 200m` mass definition."""
-    return MassDef(200, 'matter')
+# TODO: Remove these definitions and uncomment the new ones for CCLv3.
+# These will all throw warnings now.
+def MassDef200m(c_m='Duffy08'):
+    r""":math:`\Delta = 200m` mass definition.
+
+    Args:
+        c_m (string): concentration-mass relation.
+    """
+    return MassDef(200, 'matter', c_m_relation=c_m)
 
 
-def MassDef200c():
-    r""":math:`\Delta = 200c` mass definition."""
-    return MassDef(200, 'critical')
+def MassDef200c(c_m='Duffy08'):
+    r""":math:`\Delta = 200c` mass definition.
+
+    Args:
+        c_m (string): concentration-mass relation.
+    """
+    return MassDef(200, 'critical', c_m_relation=c_m)
 
 
-def MassDef500c():
-    r""":math:`\Delta = 500m` mass definition."""
-    return MassDef(500, 'critical')
+def MassDef500c(c_m='Ishiyama21'):
+    r""":math:`\Delta = 500m` mass definition.
+
+    Args:
+        c_m (string): concentration-mass relation.
+    """
+    return MassDef(500, 'critical', c_m_relation=c_m)
 
 
-def MassDefVir():
-    r""":math:`\Delta = \rm vir` mass definition."""
-    return MassDef('vir', 'critical')
+def MassDefVir(c_m='Klypin11'):
+    r""":math:`\Delta = \rm vir` mass definition.
+
+    Args:
+        c_m (string): concentration-mass relation.
+    """
+    return MassDef('vir', 'critical', c_m_relation=c_m)
+
+
+# def MassDef200m():
+#     r""":math:`\Delta = 200m` mass definition."""
+#     return MassDef(200, 'matter')
+
+
+# def MassDef200c():
+#     r""":math:`\Delta = 200c` mass definition."""
+#     return MassDef(200, 'critical')
+
+
+# def MassDef500c():
+#     r""":math:`\Delta = 500m` mass definition."""
+#     return MassDef(500, 'critical')
+
+
+# def MassDefVir():
+#     r""":math:`\Delta = \rm vir` mass definition."""
+#     return MassDef('vir', 'critical')
 
 
 def MassDefFof():

--- a/pyccl/halos/pk_4pt.py
+++ b/pyccl/halos/pk_4pt.py
@@ -440,7 +440,7 @@ def halomod_Tk3D_SSC(
     if lk_arr is None:
         lk_arr = cosmo.get_pk_spline_lk()
     if a_arr is None:
-        a_arr = cosmo.get_pk_splne_a()
+        a_arr = cosmo.get_pk_spline_a()
 
     # define all the profiles
     prof, prof2, prof3, prof4, prof12_2pt, prof34_2pt = \

--- a/pyccl/halos/profiles/gaussian.py
+++ b/pyccl/halos/profiles/gaussian.py
@@ -26,7 +26,7 @@ class HaloProfileGaussian(HaloProfile):
 
     @deprecated()
     @warn_api
-    def __init__(self, *, r_scale, rho0, mass_def):
+    def __init__(self, *, r_scale, rho0, mass_def=None):
         self.rho_0 = rho0
         self.r_scale = r_scale
         super().__init__(mass_def=mass_def)

--- a/pyccl/halos/profiles/powerlaw.py
+++ b/pyccl/halos/profiles/powerlaw.py
@@ -27,7 +27,7 @@ class HaloProfilePowerLaw(HaloProfile):
 
     @deprecated()
     @warn_api
-    def __init__(self, *, r_scale, tilt, mass_def):
+    def __init__(self, *, r_scale, tilt, mass_def=None):
         self.r_scale = r_scale
         self.tilt = tilt
         super().__init__(mass_def=mass_def)

--- a/pyccl/halos/profiles/pressure_gnfw.py
+++ b/pyccl/halos/profiles/pressure_gnfw.py
@@ -73,7 +73,7 @@ class HaloProfilePressureGNFW(HaloProfilePressure):
     def __init__(self, *, mass_bias=0.8, P0=6.41,
                  c500=1.81, alpha=1.33, alpha_P=0.12,
                  beta=4.13, gamma=0.31, P0_hexp=-1.,
-                 qrange=(1e-3, 1e3), nq=128, x_out=np.inf, mass_def):
+                 qrange=(1e-3, 1e3), nq=128, x_out=np.inf, mass_def=None):
         self.qrange = qrange
         self.nq = nq
         self.mass_bias = mass_bias

--- a/pyccl/halos/profiles/profile_base.py
+++ b/pyccl/halos/profiles/profile_base.py
@@ -69,6 +69,20 @@ class HaloProfile(CCLAutoRepr):
         if out:
             self.concentration = out[0]
 
+        # TODO: Remove for CCLv3.
+        self._is_number_counts = isinstance(self, HaloProfileNumberCounts)
+
+    @property
+    def is_number_counts(self):
+        # TODO: Remove for CCLv3.
+        return self._is_number_counts
+
+    @is_number_counts.setter
+    @unlock_instance
+    def is_number_counts(self, value):
+        # TODO: Remove for CCLv3.
+        self._is_number_counts = value
+
     def get_normalization(self, cosmo, a, *, hmc=None):
         """Profiles may be normalized by an overall function of redshift
         (or scale factor). This function may be cosmology dependent and

--- a/pyccl/halos/profiles/profile_base.py
+++ b/pyccl/halos/profiles/profile_base.py
@@ -53,6 +53,9 @@ class HaloProfile(CCLAutoRepr):
         # Initialize FFTLog.
         self.precision_fftlog = FFTLogParams()
 
+        # TODO: Remove for CCLv3.
+        self._is_number_counts = isinstance(self, HaloProfileNumberCounts)
+
         if (mass_def, concentration) == (None, None):
             warnings.warn(
                 "mass_def (or concentration where applicable) will become a "
@@ -68,9 +71,6 @@ class HaloProfile(CCLAutoRepr):
             mass_def, concentration=concentration)
         if out:
             self.concentration = out[0]
-
-        # TODO: Remove for CCLv3.
-        self._is_number_counts = isinstance(self, HaloProfileNumberCounts)
 
     @property
     def is_number_counts(self):

--- a/pyccl/halos/profiles_2pt.py
+++ b/pyccl/halos/profiles_2pt.py
@@ -1,6 +1,6 @@
 __all__ = ("Profile2pt", "Profile2ptHOD", "Profile2ptCIB",)
 
-from .. import CCLAutoRepr, warn_api
+from .. import CCLAutoRepr, mass_def_api, warn_api
 from . import HaloProfileHOD, HaloProfileCIBShang12
 
 
@@ -39,6 +39,7 @@ class Profile2pt(CCLAutoRepr):
         if r_corr is not None:
             self.r_corr = r_corr
 
+    @mass_def_api
     @warn_api
     def fourier_2pt(self, cosmo, k, M, a, prof, *, prof2=None):
         """ Return the Fourier-space two-point moment between
@@ -97,6 +98,7 @@ class Profile2ptHOD(Profile2pt):
     :class:`~pyccl.halos.profiles.HaloProfileHOD`.
     """
 
+    @mass_def_api
     @warn_api
     def fourier_2pt(self, cosmo, k, M, a, prof, *, prof2=None):
         """ Returns the Fourier-space two-point moment for the HOD
@@ -143,6 +145,7 @@ class Profile2ptCIB(Profile2pt):
     and Eq. 15 of McCarthy & Madhavacheril (2021PhRvD.103j3515M)).
     """
 
+    @mass_def_api
     @warn_api
     def fourier_2pt(self, cosmo, k, M, a, prof, *, prof2=None):
         """ Returns the Fourier-space two-point moment for the CIB

--- a/pyccl/neutrinos.py
+++ b/pyccl/neutrinos.py
@@ -23,7 +23,7 @@ class NeutrinoMassSplits(Enum):
 
 
 @deprecated(new_function=omega_x)
-def Omeganuh2(a, *, m_nu,
+def Omeganuh2(a, m_nu,
               T_CMB=DefaultParams.T_CMB,
               T_ncdm=DefaultParams.T_ncdm):
     """Calculate :math:`\\Omega_\\nu\\,h^2` at a given scale factor given

--- a/pyccl/tests/test_massdef.py
+++ b/pyccl/tests/test_massdef.py
@@ -85,13 +85,6 @@ def test_translate_mass():
         assert np.shape(m) == np.shape(M)
 
 
-def test_translate_mass_raises():
-    hmd = ccl.halos.MassDef(200, 'matter')
-    hmdb = ccl.halos.MassDef(200, 'critical')
-    with pytest.raises(AttributeError):
-        hmd.translate_mass(COSMO, 1E12, 1., mass_def_other=hmdb)
-
-
 @pytest.mark.parametrize('scls', [ccl.halos.MassDef200m,
                                   ccl.halos.MassDef200c,
                                   ccl.halos.MassDef500c,

--- a/pyccl/tests/test_v3_api.py
+++ b/pyccl/tests/test_v3_api.py
@@ -1,7 +1,6 @@
 import pyccl as ccl
 import pytest
 
-
 # TODO: Remove for CCLv3.
 
 
@@ -11,3 +10,19 @@ def test_unexpected_argument_raises():
     with pytest.raises(TypeError):
         # here, `c_m` was renamed to `concentration`
         ccl.halos.MassDef200c(hello="Duffy08")
+
+
+def test_mass_def_api():
+    # Check API preserved in functions where `mass_def` is deprecated.
+    cosmo = ccl.CosmologyVanillaLCDM(transfer_function="bbks")
+    mdef = ccl.halos.MassDef200c()
+    prof0 = ccl.halos.HaloProfilePressureGNFW(mass_def=mdef)
+    res0 = prof0.real(cosmo, 1, 1e14, 1)
+
+    with pytest.warns(ccl.CCLDeprecationWarning):
+        prof1 = ccl.halos.HaloProfilePressureGNFW()
+    with pytest.warns(ccl.CCLDeprecationWarning):
+        res1 = prof1.real(cosmo, 1, 1e14, 1, mdef)
+    with pytest.warns(ccl.CCLDeprecationWarning):
+        res2 = prof1.real(cosmo, 1, 1e14, 1, mass_def=mdef)
+    assert res0 == res1 == res2


### PR DESCRIPTION
Currently `v3_wip` breaks the API. WIth this PR we preserve it for CCLv2.final. I ran the old tests with the new code and came up with a list of things that failed (because API was broken). This list should be complete now.

- [x] Reinstate `mass_def` (and `mdef_other`) in `HaloProfile`,`Profile2pt`, `MassFunc`, `HaloBias`, `Concentration`.
- [x] Reinstate `c_m_relation` in `MassDef`.
- [x] Reinstate relative module paths in `halos`.
- [x] Reinstate `is_number_counts` property in `HaloProfile`.
- [x] Remove `*` from deprecated function `Omeganuh2`.
- [x] Fix typo in `halomod_Tk3D_SSC`.

Bonus:
- [x] Make `MassDef200c` etc. variables instead of factories in CCLv3.