### PR TITLE
Baryons objects as convenience input for Cosmology

### DIFF
--- a/pyccl/cosmology.py
+++ b/pyccl/cosmology.py
@@ -174,10 +174,9 @@ class Cosmology(CCLObject):
             The transfer function to use. Defaults to 'boltzmann_camb'.
         matter_power_spectrum (:obj:`str` or :class:`~pyccl.emulators.emu_base.EmulatorPk`):
             The matter power spectrum to use. Defaults to 'halofit'.
-        baryonic_effects (:class:`~pyccl.baryons.baryons_base.Baryons`, `'bcm'` or `None`):
-            The baryonic effects model to use. Options are `None` (no baryonic effects),
-            `'bcm'` (the Schneider 2015 model with default parameters -- see :class:`~pyccl.baryons.schneider15.BaryonsSchneider15`),
-            or a baryonic effects object. Defaults to `None`.
+        baryonic_effects (:class:`~pyccl.baryons.baryons_base.Baryons` or `None`):
+            The baryonic effects model to use. Options are `None` (no baryonic effects), or
+            a :class:`~pyccl.baryons.baryons_base.Baryons` object.
         extra_parameters (:obj:`dict`): Dictionary holding extra
             parameters. Currently supports extra parameters for CAMB.
             Details described below. Defaults to None.
@@ -240,8 +239,8 @@ class Cosmology(CCLObject):
 
         self.baryons = baryonic_effects
         if not isinstance(self.baryons, baryons.Baryons):
-            if self.baryons not in (None, 'bcm'):
-                raise ValueError("`baryonic_effects` must be `None`, `'bcm'`, "
+            if self.baryons is not None:
+                raise ValueError("`baryonic_effects` must be `None` "
                                  "or a `Baryons` instance.")
 
         # going to save these for later
@@ -574,9 +573,6 @@ class Cosmology(CCLObject):
 
         # Include baryonic effects
         if self.baryons is not None:
-            if self.baryons == 'bcm':  # Initialise convenience baryons model
-                self.baryons = baryons.BaryonsSchneider15(
-                    log10Mc=np.log10(1.2E14), eta_b=0.5, k_s=55.0)
             pk = self.baryons.include_baryonic_effects(self, pk)
         return pk
 

--- a/pyccl/tests/test_baryons.py
+++ b/pyccl/tests/test_baryons.py
@@ -1,9 +1,10 @@
 import pytest
 import numpy as np
 import pyccl as ccl
+import pytest
 
 
-COSMO = ccl.CosmologyVanillaLCDM()
+COSMO = ccl.CosmologyVanillaLCDM(transfer_function='bbks')
 bar = ccl.BaryonsSchneider15()
 
 
@@ -46,14 +47,17 @@ def test_baryons_from_name():
 def test_baryons_in_cosmology():
     # Test that applying baryons during cosmology creation works.
     # 1. Outside of cosmo
-    cosmo_nb = ccl.CosmologyVanillaLCDM(baryonic_effects=None)
+    cosmo_nb = ccl.CosmologyVanillaLCDM(
+        transfer_function='bbks', baryonic_effects=None)
     pk_nb = cosmo_nb.get_nonlin_power()
     pk_wb = bar.include_baryonic_effects(cosmo_nb, pk_nb)
     # 2. In cosmo - default BCM model
-    cosmo_wb1 = ccl.CosmologyVanillaLCDM(baryonic_effects='bcm')
+    cosmo_wb1 = ccl.CosmologyVanillaLCDM(
+        transfer_function='bbks', baryonic_effects='bcm')
     pk_wb1 = cosmo_wb1.get_nonlin_power()
     # 3. In cosmo - from object.
-    cosmo_wb2 = ccl.CosmologyVanillaLCDM(baryonic_effects=bar)
+    cosmo_wb2 = ccl.CosmologyVanillaLCDM(
+        transfer_function='bbks', baryonic_effects=bar)
     pk_wb2 = cosmo_wb2.get_nonlin_power()
 
     ks = np.geomspace(1E-2, 10, 128)
@@ -63,3 +67,8 @@ def test_baryons_in_cosmology():
 
     assert np.allclose(pk_wb, pk_wb1, atol=0, rtol=1E-6)
     assert np.allclose(pk_wb, pk_wb2, atol=0, rtol=1E-6)
+
+
+def test_baryons_in_cosmology_error():
+    with pytest.raises(ValueError):
+        ccl.CosmologyVanillaLCDM(baryonic_effects=3.1416)

--- a/pyccl/tests/test_baryons.py
+++ b/pyccl/tests/test_baryons.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 import pyccl as ccl
 import pytest

--- a/pyccl/tests/test_baryons.py
+++ b/pyccl/tests/test_baryons.py
@@ -50,21 +50,15 @@ def test_baryons_in_cosmology():
         transfer_function='bbks', baryonic_effects=None)
     pk_nb = cosmo_nb.get_nonlin_power()
     pk_wb = bar.include_baryonic_effects(cosmo_nb, pk_nb)
-    # 2. In cosmo - default BCM model
-    cosmo_wb1 = ccl.CosmologyVanillaLCDM(
-        transfer_function='bbks', baryonic_effects='bcm')
-    pk_wb1 = cosmo_wb1.get_nonlin_power()
-    # 3. In cosmo - from object.
+    # 2. In cosmo - from object.
     cosmo_wb2 = ccl.CosmologyVanillaLCDM(
         transfer_function='bbks', baryonic_effects=bar)
     pk_wb2 = cosmo_wb2.get_nonlin_power()
 
     ks = np.geomspace(1E-2, 10, 128)
     pk_wb = pk_wb(ks, 1.0)
-    pk_wb1 = pk_wb1(ks, 1.0)
     pk_wb2 = pk_wb2(ks, 1.0)
 
-    assert np.allclose(pk_wb, pk_wb1, atol=0, rtol=1E-6)
     assert np.allclose(pk_wb, pk_wb2, atol=0, rtol=1E-6)
 
 

--- a/pyccl/tests/test_baryons.py
+++ b/pyccl/tests/test_baryons.py
@@ -41,3 +41,25 @@ def test_baryons_from_name():
     bar2 = ccl.Baryons.from_name('Schneider15')
     assert bar.name == bar2.name
     assert bar2.name == 'Schneider15'
+
+
+def test_baryons_in_cosmology():
+    # Test that applying baryons during cosmology creation works.
+    # 1. Outside of cosmo
+    cosmo_nb = ccl.CosmologyVanillaLCDM(baryonic_effects=None)
+    pk_nb = cosmo_nb.get_nonlin_power()
+    pk_wb = bar.include_baryonic_effects(cosmo_nb, pk_nb)
+    # 2. In cosmo - default BCM model
+    cosmo_wb1 = ccl.CosmologyVanillaLCDM(baryonic_effects='bcm')
+    pk_wb1 = cosmo_wb1.get_nonlin_power()
+    # 3. In cosmo - from object.
+    cosmo_wb2 = ccl.CosmologyVanillaLCDM(baryonic_effects=bar)
+    pk_wb2 = cosmo_wb2.get_nonlin_power()
+
+    ks = np.geomspace(1E-2, 10, 128)
+    pk_wb = pk_wb(ks, 1.0)
+    pk_wb1 = pk_wb1(ks, 1.0)
+    pk_wb2 = pk_wb2(ks, 1.0)
+
+    assert np.allclose(pk_wb, pk_wb1, atol=0, rtol=1E-6)
+    assert np.allclose(pk_wb, pk_wb2, atol=0, rtol=1E-6)

--- a/readthedocs/api/pyccl.emulators.cosmicemu_MTIV_pk.rst
+++ b/readthedocs/api/pyccl.emulators.cosmicemu_MTIV_pk.rst
@@ -1,7 +1,0 @@
-pyccl.emulators.cosmicemu\_MTIV\_pk module
-==========================================
-
-.. automodule:: pyccl.emulators.cosmicemu_MTIV_pk
-   :members:
-   :undoc-members:
-   :show-inheritance:


### PR DESCRIPTION
This implements, as discussed in the last CCL telecon, the possibility to pass baryonic effects objects as part of the cosmology initialisation. This is a convenience feature, so users can just keep using Cosmology objects as containers for the non-linear matter power spectrum, which now can include baryonic effects.
