### PR TITLE
Container for MG params

### DIFF
--- a/benchmarks/test_correlation_MG.py
+++ b/benchmarks/test_correlation_MG.py
@@ -24,7 +24,7 @@ def set_up(request):
     cosmo = ccl.Cosmology(Omega_c=0.12/h0**2, Omega_b=0.0221/h0**2, Omega_k=0,
                           h=h0, A_s=np.exp(logA)/10**10, n_s=0.96, Neff=3.046,
                           m_nu=0.0, w0=-1, wa=0, T_CMB=2.7255,
-                          mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.1),
+                          mg_parametrization=MuSigmaMG(mu_0=0.1, sigma_0=0.1),
                           transfer_function='boltzmann_class',
                           matter_power_spectrum='linear')
 

--- a/benchmarks/test_correlation_MG.py
+++ b/benchmarks/test_correlation_MG.py
@@ -1,6 +1,8 @@
 import os
 import numpy as np
 import pyccl as ccl
+from pyccl.modified_gravity import MuSigmaMG
+
 from scipy.interpolate import interp1d
 import pytest
 
@@ -22,7 +24,7 @@ def set_up(request):
     cosmo = ccl.Cosmology(Omega_c=0.12/h0**2, Omega_b=0.0221/h0**2, Omega_k=0,
                           h=h0, A_s=np.exp(logA)/10**10, n_s=0.96, Neff=3.046,
                           m_nu=0.0, w0=-1, wa=0, T_CMB=2.7255,
-                          mu_0=0.1, sigma_0=0.1,
+                          mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.1),
                           transfer_function='boltzmann_class',
                           matter_power_spectrum='linear')
 

--- a/benchmarks/test_correlation_MG2.py
+++ b/benchmarks/test_correlation_MG2.py
@@ -24,7 +24,7 @@ def set_up(request):
     cosmo = ccl.Cosmology(Omega_c=0.12/h0**2, Omega_b=0.0221/h0**2, Omega_k=0,
                           h=h0, A_s=np.exp(logA)/10**10, n_s=0.96, Neff=3.046,
                           m_nu=0.0, w0=-1, wa=0, T_CMB=2.7255,
-                          mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.1),
+                          mg_parametrization=MuSigmaMG(mu_0=0.1, sigma_0=0.1),
                           transfer_function='boltzmann_isitgr',
                           matter_power_spectrum='linear')
 

--- a/benchmarks/test_correlation_MG2.py
+++ b/benchmarks/test_correlation_MG2.py
@@ -1,6 +1,8 @@
 import os
 import numpy as np
 import pyccl as ccl
+from pyccl.modified_gravity import MuSigmaMG
+
 from scipy.interpolate import interp1d
 import pytest
 
@@ -22,7 +24,7 @@ def set_up(request):
     cosmo = ccl.Cosmology(Omega_c=0.12/h0**2, Omega_b=0.0221/h0**2, Omega_k=0,
                           h=h0, A_s=np.exp(logA)/10**10, n_s=0.96, Neff=3.046,
                           m_nu=0.0, w0=-1, wa=0, T_CMB=2.7255,
-                          mu_0=0.1, sigma_0=0.1,
+                          mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.1),
                           transfer_function='boltzmann_isitgr',
                           matter_power_spectrum='linear')
 

--- a/benchmarks/test_correlation_MG3_SD.py
+++ b/benchmarks/test_correlation_MG3_SD.py
@@ -26,8 +26,8 @@ def set_up(request):
                           h=h0, A_s=np.exp(logA)/10**10, n_s=0.96, Neff=3.046,
                           m_nu=0.0, w0=-1, wa=0, T_CMB=2.7255,
                           mg_parametrisation=MuSigmaMG(
-                            mu_0=0.1, sigma_0=0.1,
-                            c1_mg=1.1, c2_mg=1.1, lambda_mg=1),
+                              mu_0=0.1, sigma_0=0.1,
+                              c1_mg=1.1, c2_mg=1.1, lambda_mg=1),
                           transfer_function='boltzmann_isitgr',
                           matter_power_spectrum='linear')
 

--- a/benchmarks/test_correlation_MG3_SD.py
+++ b/benchmarks/test_correlation_MG3_SD.py
@@ -25,7 +25,7 @@ def set_up(request):
     cosmo = ccl.Cosmology(Omega_c=0.12/h0**2, Omega_b=0.0221/h0**2, Omega_k=0,
                           h=h0, A_s=np.exp(logA)/10**10, n_s=0.96, Neff=3.046,
                           m_nu=0.0, w0=-1, wa=0, T_CMB=2.7255,
-                          mg_parametrisation=MuSigmaMG(
+                          mg_parametrization=MuSigmaMG(
                               mu_0=0.1, sigma_0=0.1,
                               c1_mg=1.1, c2_mg=1.1, lambda_mg=1),
                           transfer_function='boltzmann_isitgr',

--- a/benchmarks/test_correlation_MG3_SD.py
+++ b/benchmarks/test_correlation_MG3_SD.py
@@ -1,6 +1,8 @@
 import os
 import numpy as np
 import pyccl as ccl
+from pyccl.modified_gravity import MuSigmaMG
+
 from scipy.interpolate import interp1d
 import pytest
 
@@ -23,8 +25,9 @@ def set_up(request):
     cosmo = ccl.Cosmology(Omega_c=0.12/h0**2, Omega_b=0.0221/h0**2, Omega_k=0,
                           h=h0, A_s=np.exp(logA)/10**10, n_s=0.96, Neff=3.046,
                           m_nu=0.0, w0=-1, wa=0, T_CMB=2.7255,
-                          mu_0=0.1, sigma_0=0.1,
-                          c1_mg=1.1, c2_mg=1.1, lambda_mg=1,
+                          mg_parametrisation=MuSigmaMG(
+                            mu_0=0.1, sigma_0=0.1,
+                            c1_mg=1.1, c2_mg=1.1, lambda_mg=1),
                           transfer_function='boltzmann_isitgr',
                           matter_power_spectrum='linear')
 

--- a/benchmarks/test_distances.py
+++ b/benchmarks/test_distances.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pyccl as ccl
+from pyccl.modified_gravity import MuSigmaMG
+
 import pytest
 
 # Set tolerances
@@ -463,7 +465,8 @@ def compare_distances_muSig(z, chi_bench, dm_bench, Omega_v, w0, wa):
     cosmo = ccl.Cosmology(
         Omega_c=Omega_c, Omega_b=Omega_b, Neff=Neff,
         h=h, A_s=A_s, n_s=n_s, Omega_k=Omega_k,
-        w0=w0, wa=wa, mu_0=mu_0, sigma_0=sigma_0, Omega_g=0.)
+        w0=w0, wa=wa, Omega_g=0.,
+        mg_parametrisation=MuSigmaMG(mu_0=mu_0, sigma_0=sigma_0))
 
     # Calculate distance using pyccl
     a = 1. / (1. + z)
@@ -493,7 +496,8 @@ def compare_distances_hiz_muSig(z, chi_bench, Omega_v, w0, wa):
     cosmo = ccl.Cosmology(
         Omega_c=Omega_c, Omega_b=Omega_b, Neff=Neff,
         h=h, A_s=A_s, n_s=n_s, Omega_k=Omega_k,
-        w0=w0, wa=wa, mu_0=mu_0, sigma_0=sigma_0, Omega_g=0.)
+        w0=w0, wa=wa, Omega_g=0.,
+        mg_parametrisation=MuSigmaMG(mu_0=mu_0, sigma_0=sigma_0))
 
     # Calculate distance using pyccl
     a = 1. / (1. + z)

--- a/benchmarks/test_distances.py
+++ b/benchmarks/test_distances.py
@@ -466,7 +466,7 @@ def compare_distances_muSig(z, chi_bench, dm_bench, Omega_v, w0, wa):
         Omega_c=Omega_c, Omega_b=Omega_b, Neff=Neff,
         h=h, A_s=A_s, n_s=n_s, Omega_k=Omega_k,
         w0=w0, wa=wa, Omega_g=0.,
-        mg_parametrisation=MuSigmaMG(mu_0=mu_0, sigma_0=sigma_0))
+        mg_parametrization=MuSigmaMG(mu_0=mu_0, sigma_0=sigma_0))
 
     # Calculate distance using pyccl
     a = 1. / (1. + z)
@@ -497,7 +497,7 @@ def compare_distances_hiz_muSig(z, chi_bench, Omega_v, w0, wa):
         Omega_c=Omega_c, Omega_b=Omega_b, Neff=Neff,
         h=h, A_s=A_s, n_s=n_s, Omega_k=Omega_k,
         w0=w0, wa=wa, Omega_g=0.,
-        mg_parametrisation=MuSigmaMG(mu_0=mu_0, sigma_0=sigma_0))
+        mg_parametrization=MuSigmaMG(mu_0=mu_0, sigma_0=sigma_0))
 
     # Calculate distance using pyccl
     a = 1. / (1. + z)

--- a/benchmarks/test_growth.py
+++ b/benchmarks/test_growth.py
@@ -2,6 +2,8 @@ import numpy as np
 import pytest
 
 import pyccl as ccl
+from pyccl.modified_gravity import MuSigmaMG
+
 
 GROWTH_HIZ_TOLERANCE = 6.0e-6
 GROWTH_TOLERANCE = 1e-4
@@ -87,7 +89,8 @@ def compare_growth(
     cosmo = ccl.Cosmology(
         Omega_c=Omega_c, Omega_b=Omega_b, Neff=Neff, m_nu=m_nu,
         h=h, A_s=A_s, n_s=n_s, Omega_k=Omega_k, Omega_g=0,
-        w0=w0, wa=wa, mu_0=mu_0, sigma_0=sigma_0)
+        w0=w0, wa=wa,
+        mg_parametrisation=MuSigmaMG(mu_0=mu_0, sigma_0=sigma_0))
 
     # Calculate distance using pyccl
     a = 1. / (1. + z)

--- a/benchmarks/test_growth.py
+++ b/benchmarks/test_growth.py
@@ -90,7 +90,7 @@ def compare_growth(
         Omega_c=Omega_c, Omega_b=Omega_b, Neff=Neff, m_nu=m_nu,
         h=h, A_s=A_s, n_s=n_s, Omega_k=Omega_k, Omega_g=0,
         w0=w0, wa=wa,
-        mg_parametrisation=MuSigmaMG(mu_0=mu_0, sigma_0=sigma_0))
+        mg_parametrization=MuSigmaMG(mu_0=mu_0, sigma_0=sigma_0))
 
     # Calculate distance using pyccl
     a = 1. / (1. + z)

--- a/benchmarks/test_halomod_numbercounts.py
+++ b/benchmarks/test_halomod_numbercounts.py
@@ -15,7 +15,6 @@ def test_hmcalculator_number_counts_numcosmo():
         w0=-1.0,
         wa=0.0,
         T_CMB=2.7245,
-        mu_0=0.0,
         transfer_function='eisenstein_hu',
         matter_power_spectrum='linear'
     )
@@ -74,7 +73,6 @@ def test_hmcalculator_number_counts_numcosmo_highacc():
         w0=-1.0,
         wa=0.0,
         T_CMB=2.7245,
-        mu_0=0.0,
         transfer_function='eisenstein_hu',
         matter_power_spectrum='linear'
     )

--- a/benchmarks/test_power_mg.py
+++ b/benchmarks/test_power_mg.py
@@ -20,7 +20,7 @@ def test_power_mg(model):
         n_s=0.96,
         Neff=3.046,
         Omega_k=0,
-        mg_parametrisation=MuSigmaMG(
+        mg_parametrization=MuSigmaMG(
             mu_0=mu_0[model],
             sigma_0=sigma_0[model]),
         matter_power_spectrum='linear',

--- a/benchmarks/test_power_mg.py
+++ b/benchmarks/test_power_mg.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 import pyccl as ccl
+from pyccl.modified_gravity import MuSigmaMG
+
 
 POWER_MG_TOL = 1e-2
 
@@ -17,9 +19,10 @@ def test_power_mg(model):
         A_s=2.1e-9,
         n_s=0.96,
         Neff=3.046,
-        mu_0=mu_0[model],
-        sigma_0=sigma_0[model],
         Omega_k=0,
+        mg_parametrisation=MuSigmaMG(
+            mu_0=mu_0[model],
+            sigma_0=sigma_0[model]),
         matter_power_spectrum='linear',
         transfer_function='boltzmann_class')
 

--- a/benchmarks/test_power_mg2.py
+++ b/benchmarks/test_power_mg2.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 import pyccl as ccl
+from pyccl.modified_gravity import MuSigmaMG
+
 
 POWER_MG_TOL = 1e-4
 
@@ -17,11 +19,12 @@ def test_power_mg(model):
         A_s=2.1e-9,
         n_s=0.96,
         Neff=3.046,
-        mu_0=mu_0[model],
-        sigma_0=sigma_0[model],
         Omega_k=0,
         m_nu=0,
         T_CMB=2.7255,
+        mg_parametrisation=MuSigmaMG(
+            mu_0=mu_0[model],
+            sigma_0=sigma_0[model]),
         matter_power_spectrum='linear',
         transfer_function='boltzmann_isitgr')
 

--- a/benchmarks/test_power_mg2.py
+++ b/benchmarks/test_power_mg2.py
@@ -22,7 +22,7 @@ def test_power_mg(model):
         Omega_k=0,
         m_nu=0,
         T_CMB=2.7255,
-        mg_parametrisation=MuSigmaMG(
+        mg_parametrization=MuSigmaMG(
             mu_0=mu_0[model],
             sigma_0=sigma_0[model]),
         matter_power_spectrum='linear',

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -273,11 +273,11 @@ def get_isitgr_pk_lin(cosmo):
     cp.omk = cosmo['Omega_k']
     cp.GR = 1  # means GR modified!
     cp.ISiTGR_muSigma = True
-    cp.mu0 = cosmo['mu_0']
-    cp.Sigma0 = cosmo['sigma_0']
-    cp.c1 = cosmo['c1_mg']
-    cp.c2 = cosmo['c2_mg']
-    cp.Lambda = cosmo['lambda_mg']
+    cp.mu0 = cosmo.mg_parametrisation.mu_0
+    cp.Sigma0 = cosmo.mg_parametrisation.sigma_0
+    cp.c1 = cosmo.mg_parametrisation.c1_mg
+    cp.c2 = cosmo.mg_parametrisation.c2_mg
+    cp.Lambda = cosmo.mg_parametrisation.lambda_mg
 
     # "constants"
     cp.TCMB = cosmo['T_CMB']

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -273,11 +273,11 @@ def get_isitgr_pk_lin(cosmo):
     cp.omk = cosmo['Omega_k']
     cp.GR = 1  # means GR modified!
     cp.ISiTGR_muSigma = True
-    cp.mu0 = cosmo.mg_parametrisation.mu_0
-    cp.Sigma0 = cosmo.mg_parametrisation.sigma_0
-    cp.c1 = cosmo.mg_parametrisation.c1_mg
-    cp.c2 = cosmo.mg_parametrisation.c2_mg
-    cp.Lambda = cosmo.mg_parametrisation.lambda_mg
+    cp.mu0 = cosmo.mg_parametrization.mu_0
+    cp.Sigma0 = cosmo.mg_parametrization.sigma_0
+    cp.c1 = cosmo.mg_parametrization.c1_mg
+    cp.c2 = cosmo.mg_parametrization.c2_mg
+    cp.Lambda = cosmo.mg_parametrization.lambda_mg
 
     # "constants"
     cp.TCMB = cosmo['T_CMB']

--- a/pyccl/cosmology.py
+++ b/pyccl/cosmology.py
@@ -157,7 +157,7 @@ class Cosmology(CCLObject):
             a :class:`~pyccl.baryons.baryons_base.Baryons` object.
         mg_parametrization (:class:`~pyccl.modified_gravity.modified_gravity_base.ModifiedGravity`
             or `None`):
-            The modified gravity parametrisation to use. Options are `None` (no MG), or
+            The modified gravity parametrization to use. Options are `None` (no MG), or
             a :class:`~pyccl.modified_gravity.modified_gravity_base.ModifiedGravity` object. 
             Currently, only :class:`~pyccl.modified_gravity.MuSigmaMG` is supported.
         extra_parameters (:obj:`dict`): Dictionary holding extra
@@ -235,14 +235,14 @@ class Cosmology(CCLObject):
 
         if self.mg_parametrization is None:
             # Internally, CCL still relies exclusively on the mu-Sigma
-            # parametrisation, so we fill that in for now unless something
+            # parametrization, so we fill that in for now unless something
             # else is provided.
             self.mg_parametrization = modified_gravity.MuSigmaMG()
         if not isinstance(
                 self.mg_parametrization,
                 modified_gravity.MuSigmaMG):
             raise NotImplementedError("`mg_parametrization` only supports the "
-                                      "mu-Sigma parametrisation at this point")
+                                      "mu-Sigma parametrization at this point")
 
         # going to save these for later
         self._params_init_kwargs = dict(
@@ -412,7 +412,7 @@ class Cosmology(CCLObject):
             Omega_l += rho_g/rho_crit - Omega_g
 
         # Take the mu-Sigma parameters from the modified_gravity container
-        # object. This is the only supported MG parametrisation at this time.
+        # object. This is the only supported MG parametrization at this time.
         assert isinstance(self.mg_parametrization, modified_gravity.MuSigmaMG)
         mu_0 = self.mg_parametrization.mu_0
         sigma_0 = self.mg_parametrization.sigma_0
@@ -752,7 +752,7 @@ class CosmologyCalculator(Cosmology):
             temperature. The default is the same as in the base class
         mg_parametrization (:class:`~pyccl.modified_gravity.ModifiedGravity`
             or `None`):
-            The modified gravity parametrisation to use. Options are `None`
+            The modified gravity parametrization to use. Options are `None`
             (no MG), or a :class:`~pyccl.modified_gravity.ModifiedGravity`
             object. Currently, only :class:`~pyccl.modified_gravity.MuSigmaMG`
             is supported.

--- a/pyccl/cosmology.py
+++ b/pyccl/cosmology.py
@@ -159,6 +159,7 @@ class Cosmology(CCLObject):
             or `None`):
             The modified gravity parametrisation to use. Options are `None` (no MG), or
             a :class:`~pyccl.modified_gravity.modified_gravity_base.ModifiedGravity` object. 
+            Currently, only :class:`~pyccl.modified_gravity.MuSigmaMG` is supported.
         extra_parameters (:obj:`dict`): Dictionary holding extra
             parameters. Currently supports extra parameters for CAMB.
             Details described below. Defaults to None.
@@ -749,10 +750,11 @@ class CosmologyCalculator(Cosmology):
             same as in the Cosmology base class.
         T_ncdm (:obj:`float`): Non-CDM temperature in units of photon
             temperature. The default is the same as in the base class
-        mu_0 (:obj:`float`): One of the parameters of the mu-Sigma
-            modified gravity model. Defaults to 0.0
-        sigma_0 (:obj:`float`): One of the parameters of the mu-Sigma
-            modified gravity model. Defaults to 0.0
+        mg_parametrisation (:class:`~pyccl.modified_gravity.modified_gravity_base.ModifiedGravity`
+            or `None`):
+            The modified gravity parametrisation to use. Options are `None` (no MG), or
+            a :class:`~pyccl.modified_gravity.modified_gravity_base.ModifiedGravity` object. 
+            Currently, only :class:`~pyccl.modified_gravity.MuSigmaMG` is supported.
         background (:obj:`dict`): a dictionary describing the background
             expansion. It must contain three mandatory entries: ``'a'``: an
             array of monotonically ascending scale-factor values. ``'chi'``:

--- a/pyccl/cosmology.py
+++ b/pyccl/cosmology.py
@@ -148,28 +148,6 @@ class Cosmology(CCLObject):
             of state. Defaults to 0.
         T_CMB (:obj:`float`): The CMB temperature today. The default of
             is 2.725.
-        mu_0 (:obj:`float`): One of the parameters of the mu-Sigma
-            modified gravity model. Defaults to 0.0
-        sigma_0 (:obj:`float`): One of the parameters of the mu-Sigma
-            modified gravity model. Defaults to 0.0
-        c1_mg (:obj:`float`): MG parameter that enters in the scale
-            dependence of mu affecting its large scale behavior. Default to 1.
-            See, e.g., Eqs. (46) in Ade et al. 2015, arXiv:1502.01590
-            where their f1 and f2 functions are set equal to the commonly used
-            ratio of dark energy density parameter at scale factor a over
-            the dark energy density parameter today
-        c2_mg (:obj:`float`): MG parameter that enters in the scale
-            dependence of Sigma affecting its large scale behavior. Default 1.
-            See, e.g., Eqs. (47) in Ade et al. 2015, arXiv:1502.01590
-            where their f1 and f2 functions are set equal to the commonly used
-            ratio of dark energy density parameter at scale factor a over
-            the dark energy density parameter today
-        lambda_mg (:obj:`float`): MG parameter that sets the start
-            of dependance on c1 and c2 MG parameters. Defaults to 0.0
-            See, e.g., Eqs. (46) & (47) in Ade et al. 2015, arXiv:1502.01590
-            where their f1 and f2 functions are set equal to the commonly used
-            ratio of dark energy density parameter at scale factor a over
-            the dark energy density parameter today
         transfer_function (:obj:`str` or :class:`~pyccl.emulators.emu_base.EmulatorPk`):
             The transfer function to use. Defaults to 'boltzmann_camb'.
         matter_power_spectrum (:obj:`str` or :class:`~pyccl.emulators.emu_base.EmulatorPk`):
@@ -177,6 +155,10 @@ class Cosmology(CCLObject):
         baryonic_effects (:class:`~pyccl.baryons.baryons_base.Baryons` or `None`):
             The baryonic effects model to use. Options are `None` (no baryonic effects), or
             a :class:`~pyccl.baryons.baryons_base.Baryons` object.
+        mg_parametrisation (:class:`~pyccl.modified_gravity.modified_gravity_base.ModifiedGravity`
+            or `None`):
+            The modified gravity parametrisation to use. Options are `None` (no MG), or
+            a :class:`~pyccl.modified_gravity.modified_gravity_base.ModifiedGravity` object. 
         extra_parameters (:obj:`dict`): Dictionary holding extra
             parameters. Currently supports extra parameters for CAMB.
             Details described below. Defaults to None.

--- a/pyccl/cosmology.py
+++ b/pyccl/cosmology.py
@@ -750,11 +750,12 @@ class CosmologyCalculator(Cosmology):
             same as in the Cosmology base class.
         T_ncdm (:obj:`float`): Non-CDM temperature in units of photon
             temperature. The default is the same as in the base class
-        mg_parametrisation (:class:`~pyccl.modified_gravity.modified_gravity_base.ModifiedGravity`
+        mg_parametrisation (:class:`~pyccl.modified_gravity.ModifiedGravity`
             or `None`):
-            The modified gravity parametrisation to use. Options are `None` (no MG), or
-            a :class:`~pyccl.modified_gravity.modified_gravity_base.ModifiedGravity` object. 
-            Currently, only :class:`~pyccl.modified_gravity.MuSigmaMG` is supported.
+            The modified gravity parametrisation to use. Options are `None`
+            (no MG), or a :class:`~pyccl.modified_gravity.ModifiedGravity`
+            object. Currently, only :class:`~pyccl.modified_gravity.MuSigmaMG`
+            is supported.
         background (:obj:`dict`): a dictionary describing the background
             expansion. It must contain three mandatory entries: ``'a'``: an
             array of monotonically ascending scale-factor values. ``'chi'``:

--- a/pyccl/cosmology.py
+++ b/pyccl/cosmology.py
@@ -155,7 +155,7 @@ class Cosmology(CCLObject):
         baryonic_effects (:class:`~pyccl.baryons.baryons_base.Baryons` or `None`):
             The baryonic effects model to use. Options are `None` (no baryonic effects), or
             a :class:`~pyccl.baryons.baryons_base.Baryons` object.
-        mg_parametrisation (:class:`~pyccl.modified_gravity.modified_gravity_base.ModifiedGravity`
+        mg_parametrization (:class:`~pyccl.modified_gravity.modified_gravity_base.ModifiedGravity`
             or `None`):
             The modified gravity parametrisation to use. Options are `None` (no MG), or
             a :class:`~pyccl.modified_gravity.modified_gravity_base.ModifiedGravity` object. 
@@ -189,7 +189,7 @@ class Cosmology(CCLObject):
     from ._core.repr_ import build_string_Cosmology as __repr__
     __eq_attrs__ = ("_params_init_kwargs", "_config_init_kwargs",
                     "_accuracy_params", "lin_pk_emu", 'nl_pk_emu',
-                    "baryons", "mg_parametrisation")
+                    "baryons", "mg_parametrization")
 
     def __init__(
             self, *, Omega_c=None, Omega_b=None, h=None, n_s=None,
@@ -199,7 +199,7 @@ class Cosmology(CCLObject):
             transfer_function='boltzmann_camb',
             matter_power_spectrum='halofit',
             baryonic_effects=None,
-            mg_parametrisation=None,
+            mg_parametrization=None,
             extra_parameters=None,
             T_ncdm=DefaultParams.T_ncdm):
 
@@ -226,22 +226,22 @@ class Cosmology(CCLObject):
                 raise ValueError("`baryonic_effects` must be `None` "
                                  "or a `Baryons` instance.")
 
-        self.mg_parametrisation = mg_parametrisation
-        if self.mg_parametrisation is not None and not isinstance(
-                self.mg_parametrisation,
+        self.mg_parametrization = mg_parametrization
+        if self.mg_parametrization is not None and not isinstance(
+                self.mg_parametrization,
                 modified_gravity.ModifiedGravity):
-            raise ValueError("`mg_parametrisation` must be `None` "
+            raise ValueError("`mg_parametrization` must be `None` "
                              "or a `ModifiedGravity` instance.")
 
-        if self.mg_parametrisation is None:
+        if self.mg_parametrization is None:
             # Internally, CCL still relies exclusively on the mu-Sigma
             # parametrisation, so we fill that in for now unless something
             # else is provided.
-            self.mg_parametrisation = modified_gravity.MuSigmaMG()
+            self.mg_parametrization = modified_gravity.MuSigmaMG()
         if not isinstance(
-                self.mg_parametrisation,
+                self.mg_parametrization,
                 modified_gravity.MuSigmaMG):
-            raise NotImplementedError("`mg_parametrisation` only supports the "
+            raise NotImplementedError("`mg_parametrization` only supports the "
                                       "mu-Sigma parametrisation at this point")
 
         # going to save these for later
@@ -413,12 +413,12 @@ class Cosmology(CCLObject):
 
         # Take the mu-Sigma parameters from the modified_gravity container
         # object. This is the only supported MG parametrisation at this time.
-        assert isinstance(self.mg_parametrisation, modified_gravity.MuSigmaMG)
-        mu_0 = self.mg_parametrisation.mu_0
-        sigma_0 = self.mg_parametrisation.sigma_0
-        c1_mg = self.mg_parametrisation.c1_mg
-        c2_mg = self.mg_parametrisation.c2_mg
-        lambda_mg = self.mg_parametrisation.lambda_mg
+        assert isinstance(self.mg_parametrization, modified_gravity.MuSigmaMG)
+        mu_0 = self.mg_parametrization.mu_0
+        sigma_0 = self.mg_parametrization.sigma_0
+        c1_mg = self.mg_parametrization.c1_mg
+        c2_mg = self.mg_parametrization.c2_mg
+        lambda_mg = self.mg_parametrization.lambda_mg
 
         self._fill_params(
             m_nu=nu_mass, sum_nu_masses=sum(nu_mass), N_nu_mass=N_nu_mass,
@@ -512,7 +512,7 @@ class Cosmology(CCLObject):
             # For MG, the input sigma8 includes the effects of MG, while the
             # sigma8 that CAMB uses is the GR definition. So we need to rescale
             # sigma8 afterwards.
-            if self.mg_parametrisation.mu_0 != 0:
+            if self.mg_parametrization.mu_0 != 0:
                 rescale_s8 = True
         elif trf == 'boltzmann_class':
             pk = self.get_class_pk_lin()
@@ -535,7 +535,7 @@ class Cosmology(CCLObject):
         pkl = None
         if self._config_init_kwargs["matter_power_spectrum"] == "camb":
             rescale_mg = False
-            if self.mg_parametrisation.mu_0 != 0:
+            if self.mg_parametrization.mu_0 != 0:
                 raise ValueError("Can't rescale non-linear power spectrum "
                                  "from CAMB for mu-Sigma MG.")
             name = "delta_matter:delta_matter"
@@ -750,7 +750,7 @@ class CosmologyCalculator(Cosmology):
             same as in the Cosmology base class.
         T_ncdm (:obj:`float`): Non-CDM temperature in units of photon
             temperature. The default is the same as in the base class
-        mg_parametrisation (:class:`~pyccl.modified_gravity.ModifiedGravity`
+        mg_parametrization (:class:`~pyccl.modified_gravity.ModifiedGravity`
             or `None`):
             The modified gravity parametrisation to use. Options are `None`
             (no MG), or a :class:`~pyccl.modified_gravity.ModifiedGravity`
@@ -817,14 +817,14 @@ class CosmologyCalculator(Cosmology):
             sigma8=None, A_s=None, Omega_k=0., Omega_g=None,
             Neff=None, m_nu=0., mass_split="normal", w0=-1., wa=0.,
             T_CMB=DefaultParams.T_CMB, T_ncdm=DefaultParams.T_ncdm,
-            mg_parametrisation=None, background=None, growth=None,
+            mg_parametrization=None, background=None, growth=None,
             pk_linear=None, pk_nonlin=None, nonlinear_model=None):
 
         super().__init__(
             Omega_c=Omega_c, Omega_b=Omega_b, h=h, n_s=n_s, sigma8=sigma8,
             A_s=A_s, Omega_k=Omega_k, Omega_g=Omega_g, Neff=Neff, m_nu=m_nu,
             mass_split=mass_split, w0=w0, wa=wa, T_CMB=T_CMB, T_ncdm=T_ncdm,
-            mg_parametrisation=mg_parametrisation,
+            mg_parametrization=mg_parametrization,
             transfer_function="calculator", matter_power_spectrum="calculator")
 
         self._input_arrays = {"background": background, "growth": growth,

--- a/pyccl/modified_gravity/__init__.py
+++ b/pyccl/modified_gravity/__init__.py
@@ -1,0 +1,2 @@
+from .modified_gravity_base import *
+from .mu_Sigma import *

--- a/pyccl/modified_gravity/modified_gravity_base.py
+++ b/pyccl/modified_gravity/modified_gravity_base.py
@@ -1,0 +1,5 @@
+__all__ = ("ModifiedGravity",)
+
+
+class ModifiedGravity:
+    parametrisation: str = None

--- a/pyccl/modified_gravity/modified_gravity_base.py
+++ b/pyccl/modified_gravity/modified_gravity_base.py
@@ -2,4 +2,4 @@ __all__ = ("ModifiedGravity",)
 
 
 class ModifiedGravity:
-    parametrisation: str = None
+    parametrization: str = None

--- a/pyccl/modified_gravity/mu_Sigma.py
+++ b/pyccl/modified_gravity/mu_Sigma.py
@@ -1,0 +1,15 @@
+__all__ = ("MuSigmaMG",)
+
+from dataclasses import dataclass
+
+from . import ModifiedGravity
+
+
+@dataclass
+class MuSigmaMG(ModifiedGravity):
+    parametrisation: str = "mu_Sigma"
+    mu_0: float = 0
+    sigma_0: float = 0
+    c1_mg: float = 1
+    c2_mg: float = 1
+    lambda_mg: float = 0

--- a/pyccl/modified_gravity/mu_Sigma.py
+++ b/pyccl/modified_gravity/mu_Sigma.py
@@ -7,7 +7,7 @@ from . import ModifiedGravity
 
 @dataclass
 class MuSigmaMG(ModifiedGravity):
-    """The mu-Sigma parametrisation of modified gravity.
+    """The mu-Sigma parametrization of modified gravity.
 
     Args:
         mu_0 (:obj:`float`): One of the parameters of the mu-Sigma
@@ -34,7 +34,7 @@ class MuSigmaMG(ModifiedGravity):
             the dark energy density parameter today
     """
 
-    parametrisation: str = "mu_Sigma"
+    parametrization: str = "mu_Sigma"
     mu_0: float = 0
     sigma_0: float = 0
     c1_mg: float = 1

--- a/pyccl/modified_gravity/mu_Sigma.py
+++ b/pyccl/modified_gravity/mu_Sigma.py
@@ -7,6 +7,33 @@ from . import ModifiedGravity
 
 @dataclass
 class MuSigmaMG(ModifiedGravity):
+    """The mu-Sigma parametrisation of modified gravity.
+
+    Args:
+        mu_0 (:obj:`float`): One of the parameters of the mu-Sigma
+            modified gravity model. Defaults to 0.0
+        sigma_0 (:obj:`float`): One of the parameters of the mu-Sigma
+            modified gravity model. Defaults to 0.0
+        c1_mg (:obj:`float`): MG parameter that enters in the scale
+            dependence of mu affecting its large scale behavior. Default to 1.
+            See, e.g., Eqs. (46) in Ade et al. 2015, arXiv:1502.01590
+            where their f1 and f2 functions are set equal to the commonly used
+            ratio of dark energy density parameter at scale factor a over
+            the dark energy density parameter today
+        c2_mg (:obj:`float`): MG parameter that enters in the scale
+            dependence of Sigma affecting its large scale behavior. Default 1.
+            See, e.g., Eqs. (47) in Ade et al. 2015, arXiv:1502.01590
+            where their f1 and f2 functions are set equal to the commonly used
+            ratio of dark energy density parameter at scale factor a over
+            the dark energy density parameter today
+        lambda_mg (:obj:`float`): MG parameter that sets the start
+            of dependance on c1 and c2 MG parameters. Defaults to 0.0
+            See, e.g., Eqs. (46) & (47) in Ade et al. 2015, arXiv:1502.01590
+            where their f1 and f2 functions are set equal to the commonly used
+            ratio of dark energy density parameter at scale factor a over
+            the dark energy density parameter today
+    """
+
     parametrisation: str = "mu_Sigma"
     mu_0: float = 0
     sigma_0: float = 0

--- a/pyccl/tests/test_baryons_vd19.py
+++ b/pyccl/tests/test_baryons_vd19.py
@@ -8,7 +8,7 @@ BOOST_TOLERANCE = 1e-5
 # Set up the cosmological parameters to be used
 cosmo = ccl.Cosmology(Omega_c=0.27, Omega_b=0.045, h=0.67,
                       A_s=2.1e-9, n_s=0.96,
-                      transfer_function='boltzmann_camb')
+                      transfer_function='eisenstein_hu')
 k = 0.5*cosmo['h']
 a = 1.
 

--- a/pyccl/tests/test_baryons_vd19.py
+++ b/pyccl/tests/test_baryons_vd19.py
@@ -8,7 +8,7 @@ BOOST_TOLERANCE = 1e-5
 # Set up the cosmological parameters to be used
 cosmo = ccl.Cosmology(Omega_c=0.27, Omega_b=0.045, h=0.67,
                       A_s=2.1e-9, n_s=0.96,
-                      transfer_function='boltzmann_class')
+                      transfer_function='boltzmann_camb')
 k = 0.5*cosmo['h']
 a = 1.
 

--- a/pyccl/tests/test_baryons_vd19.py
+++ b/pyccl/tests/test_baryons_vd19.py
@@ -7,7 +7,7 @@ BOOST_TOLERANCE = 1e-5
 
 # Set up the cosmological parameters to be used
 cosmo = ccl.Cosmology(Omega_c=0.27, Omega_b=0.045, h=0.67,
-                      A_s=2.1e-9, n_s=0.96,
+                      sigma8=0.8, n_s=0.96,
                       transfer_function='eisenstein_hu')
 k = 0.5*cosmo['h']
 a = 1.

--- a/pyccl/tests/test_cells.py
+++ b/pyccl/tests/test_cells.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 import pyccl as ccl
+from pyccl.modified_gravity import MuSigmaMG
+
 
 ccl.gsl_params.LENSING_KERNEL_SPLINE_INTEGRATION = False
 COSMO = ccl.Cosmology(
@@ -92,7 +94,8 @@ def test_cells_mg():
     # same results.
 
     # set up a MG cosmology
-    cosmo_MG = ccl.CosmologyVanillaLCDM(mu_0=0.5, sigma_0=0.5,
+    cosmo_MG = ccl.CosmologyVanillaLCDM(mg_parametrisation=MuSigmaMG(
+                                        mu_0=0.5, sigma_0=0.5),
                                         transfer_function="bbks",
                                         matter_power_spectrum="linear")
     cosmo_MG.compute_nonlin_power()
@@ -103,7 +106,8 @@ def test_cells_mg():
     pk_nonlin = {"a": a, "k": np.exp(lk), "delta_matter:delta_matter": pk}
     cosmo_calc = ccl.CosmologyCalculator(
         Omega_c=0.25, Omega_b=0.05, h=0.67, n_s=0.96, sigma8=0.81,
-        mu_0=0.5, sigma_0=0.5, pk_nonlin=pk_nonlin)
+        mg_parametrisation=MuSigmaMG(mu_0=0.5, sigma_0=0.5),
+        pk_nonlin=pk_nonlin)
 
     # get the Cells
     ell = np.geomspace(2, 2000, 128)

--- a/pyccl/tests/test_cells.py
+++ b/pyccl/tests/test_cells.py
@@ -94,7 +94,7 @@ def test_cells_mg():
     # same results.
 
     # set up a MG cosmology
-    cosmo_MG = ccl.CosmologyVanillaLCDM(mg_parametrisation=MuSigmaMG(
+    cosmo_MG = ccl.CosmologyVanillaLCDM(mg_parametrization=MuSigmaMG(
                                         mu_0=0.5, sigma_0=0.5),
                                         transfer_function="bbks",
                                         matter_power_spectrum="linear")
@@ -106,7 +106,7 @@ def test_cells_mg():
     pk_nonlin = {"a": a, "k": np.exp(lk), "delta_matter:delta_matter": pk}
     cosmo_calc = ccl.CosmologyCalculator(
         Omega_c=0.25, Omega_b=0.05, h=0.67, n_s=0.96, sigma8=0.81,
-        mg_parametrisation=MuSigmaMG(mu_0=0.5, sigma_0=0.5),
+        mg_parametrization=MuSigmaMG(mu_0=0.5, sigma_0=0.5),
         pk_nonlin=pk_nonlin)
 
     # get the Cells

--- a/pyccl/tests/test_hmcalculator_number_counts.py
+++ b/pyccl/tests/test_hmcalculator_number_counts.py
@@ -111,7 +111,6 @@ def test_hmcalculator_number_counts_scipy_dblquad():
         w0=-1.0,
         wa=0.0,
         T_CMB=2.7245,
-        mu_0=0.0,
         transfer_function='eisenstein_hu',
         matter_power_spectrum='linear'
     )

--- a/pyccl/tests/test_mg.py
+++ b/pyccl/tests/test_mg.py
@@ -13,7 +13,7 @@ def test_mu_sigma_transfer_err(tf):
             h=0.7,
             A_s=2.1e-9,
             n_s=0.96,
-            mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.2),
+            mg_parametrization=MuSigmaMG(mu_0=0.1, sigma_0=0.2),
             transfer_function=tf,
             matter_power_spectrum='linear'
         )
@@ -34,7 +34,7 @@ def test_mg_error():
             h=0.7,
             sigma8=0.8,
             n_s=0.96,
-            mg_parametrisation=NotMG(),
+            mg_parametrization=NotMG(),
             transfer_function="bbks",
         )
 
@@ -45,6 +45,6 @@ def test_mg_error():
             h=0.7,
             sigma8=0.8,
             n_s=0.96,
-            mg_parametrisation=NotMuSigma(),
+            mg_parametrization=NotMuSigma(),
             transfer_function="bbks",
         )

--- a/pyccl/tests/test_mg.py
+++ b/pyccl/tests/test_mg.py
@@ -18,3 +18,19 @@ def test_mu_sigma_transfer_err(tf):
             matter_power_spectrum='linear'
         )
         ccl.linear_matter_power(cosmo, 1, 1)
+
+
+def test_mg_error():
+    class NotMG:
+        pass
+
+    with pytest.raises(ValueError):
+        ccl.Cosmology(
+            Omega_c=0.25,
+            Omega_b=0.05,
+            h=0.7,
+            sigma8=0.8,
+            n_s=0.96,
+            mg_parametrisation=NotMG(),
+            transfer_function="bbks",
+        )

--- a/pyccl/tests/test_mg.py
+++ b/pyccl/tests/test_mg.py
@@ -1,4 +1,6 @@
 import pyccl as ccl
+from pyccl.modified_gravity import MuSigmaMG
+
 import pytest
 
 
@@ -11,8 +13,7 @@ def test_mu_sigma_transfer_err(tf):
             h=0.7,
             A_s=2.1e-9,
             n_s=0.96,
-            mu_0=0.1,
-            sigma_0=0.2,
+            mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.2),
             transfer_function=tf,
             matter_power_spectrum='linear'
         )

--- a/pyccl/tests/test_mg.py
+++ b/pyccl/tests/test_mg.py
@@ -1,5 +1,5 @@
 import pyccl as ccl
-from pyccl.modified_gravity import MuSigmaMG
+from pyccl.modified_gravity import MuSigmaMG, ModifiedGravity
 
 import pytest
 
@@ -24,6 +24,9 @@ def test_mg_error():
     class NotMG:
         pass
 
+    class NotMuSigma(ModifiedGravity):
+        pass
+
     with pytest.raises(ValueError):
         ccl.Cosmology(
             Omega_c=0.25,
@@ -32,5 +35,16 @@ def test_mg_error():
             sigma8=0.8,
             n_s=0.96,
             mg_parametrisation=NotMG(),
+            transfer_function="bbks",
+        )
+
+    with pytest.raises(NotImplementedError):
+        ccl.Cosmology(
+            Omega_c=0.25,
+            Omega_b=0.05,
+            h=0.7,
+            sigma8=0.8,
+            n_s=0.96,
+            mg_parametrisation=NotMuSigma(),
             transfer_function="bbks",
         )

--- a/pyccl/tests/test_power_mu_sigma_sigma8norm.py
+++ b/pyccl/tests/test_power_mu_sigma_sigma8norm.py
@@ -23,7 +23,7 @@ def test_power_mu_sigma_sigma8norm(tf):
     cosmo_musig = ccl.Cosmology(
         Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
         transfer_function=tf,
-        mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.2))
+        mg_parametrization=MuSigmaMG(mu_0=0.1, sigma_0=0.2))
 
     # make sure sigma8 is correct
     assert np.allclose(ccl.sigma8(cosmo_musig), 0.8)
@@ -53,14 +53,14 @@ def test_power_mu_sigma_sigma8norm_norms_consistent(tf):
     cosmo = ccl.Cosmology(
         Omega_c=0.27, Omega_b=0.045, h=0.67, A_s=2e-9, n_s=0.96,
         transfer_function=tf,
-        mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.2))
+        mg_parametrization=MuSigmaMG(mu_0=0.1, sigma_0=0.2))
     sigma8 = ccl.sigma8(cosmo)
 
     # remake same but now give sigma8
     cosmo_s8 = ccl.Cosmology(
         Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=sigma8, n_s=0.96,
         transfer_function=tf,
-        mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.2))
+        mg_parametrization=MuSigmaMG(mu_0=0.1, sigma_0=0.2))
 
     # make sure they come out the same-ish
     assert np.allclose(ccl.sigma8(cosmo), ccl.sigma8(cosmo_s8))
@@ -86,7 +86,7 @@ def test_nonlin_camb_MG_error():
                               A_s=2.1e-9, n_s=n_s,
                               transfer_function="boltzmann_camb",
                               matter_power_spectrum="camb",
-                              mg_parametrisation=MuSigmaMG(
+                              mg_parametrization=MuSigmaMG(
                                   mu_0=0.1, sigma_0=0.2))
 
     k = np.logspace(-3, 1, 10)

--- a/pyccl/tests/test_power_mu_sigma_sigma8norm.py
+++ b/pyccl/tests/test_power_mu_sigma_sigma8norm.py
@@ -4,6 +4,8 @@ from unittest import mock
 import pyccl as ccl
 import sys
 from pyccl.boltzmann import get_isitgr_pk_lin
+from pyccl.modified_gravity import MuSigmaMG
+
 try:
     from importlib import reload
 except ImportError:
@@ -20,7 +22,8 @@ def test_power_mu_sigma_sigma8norm(tf):
 
     cosmo_musig = ccl.Cosmology(
         Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=0.8, n_s=0.96,
-        transfer_function=tf, mu_0=0.1, sigma_0=0.2)
+        transfer_function=tf,
+        mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.2))
 
     # make sure sigma8 is correct
     assert np.allclose(ccl.sigma8(cosmo_musig), 0.8)
@@ -49,13 +52,15 @@ def test_power_mu_sigma_sigma8norm_norms_consistent(tf):
     # make a cosmo with A_s
     cosmo = ccl.Cosmology(
         Omega_c=0.27, Omega_b=0.045, h=0.67, A_s=2e-9, n_s=0.96,
-        transfer_function=tf, mu_0=0.1, sigma_0=0.2)
+        transfer_function=tf,
+        mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.2))
     sigma8 = ccl.sigma8(cosmo)
 
     # remake same but now give sigma8
     cosmo_s8 = ccl.Cosmology(
         Omega_c=0.27, Omega_b=0.045, h=0.67, sigma8=sigma8, n_s=0.96,
-        transfer_function=tf, mu_0=0.1, sigma_0=0.2)
+        transfer_function=tf,
+        mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.2))
 
     # make sure they come out the same-ish
     assert np.allclose(ccl.sigma8(cosmo), ccl.sigma8(cosmo_s8))
@@ -81,7 +86,8 @@ def test_nonlin_camb_MG_error():
                               A_s=2.1e-9, n_s=n_s,
                               transfer_function="boltzmann_camb",
                               matter_power_spectrum="camb",
-                              mu_0=0.1, sigma_0=0.2)
+                              mg_parametrisation=MuSigmaMG(
+                                  mu_0=0.1, sigma_0=0.2))
 
     k = np.logspace(-3, 1, 10)
 


### PR DESCRIPTION
This PR introduces a `ModifiedGravity` interface to the `Cosmology` class which encapsulates MG parametrisations (just mu-Sigma for now). Under the hood (i.e. C-layer) nothing has changed.
The motivation is to reduce clutter in the `Cosmology` interface and allow different MG parametrisations in the future without breaking the API.

Instead of 
```
cosmo = ccl.Cosmology(
    Omega_c=0.25,
    Omega_b=0.05,
    h=0.7,
    A_s=2.1e-9,
    n_s=0.96,
    mu_0=0.1, sigma_0=0.2,
)
```
the new API is now
```
from pyccl.modified_gravity import MuSigmaMG
cosmo = ccl.Cosmology(
    Omega_c=0.25,
    Omega_b=0.05,
    h=0.7,
    A_s=2.1e-9,
    n_s=0.96,
    mg_parametrisation=MuSigmaMG(mu_0=0.1, sigma_0=0.2),
)
```

This doesn't use `CCLNamedClass` at the moment due to a conflict with `dataclass` (see #1118). 