### PR TITLE
Fix GSL integration abort

### DIFF
--- a/pyccl/_core/parameters/cosmology_params.py
+++ b/pyccl/_core/parameters/cosmology_params.py
@@ -16,5 +16,6 @@ class CosmologyParams(CCLParameters, factory=lib.parameters):
 
     def __setattr__(self, key, value):
         if key == "m_nu":
+            self._instance.N_nu_mass = len(value)
             return lib.parameters_m_nu_set_custom(self._instance, value)
         super().__setattr__(key, value)

--- a/pyccl/ccl_core.i
+++ b/pyccl/ccl_core.i
@@ -15,6 +15,9 @@
 
 %inline %{
 void parameters_m_nu_set_custom(ccl_parameters *params, double *mass, int num) {
+  if(params->m_nu != NULL) {
+    free(params->m_nu);
+  }
   params->m_nu = (double*) malloc(num*sizeof(double));
   memcpy(params->m_nu, mass, num*sizeof(double));
 }

--- a/src/ccl_core.c
+++ b/src/ccl_core.c
@@ -235,6 +235,10 @@ computed_power, computed_sigma: store status of the computations
 */
 ccl_cosmology * ccl_cosmology_create(ccl_parameters params, ccl_configuration config)
 {
+  #ifndef USE_GSL_ERROR
+    gsl_set_error_handler_off();
+  #endif
+
   ccl_cosmology * cosmo = malloc(sizeof(ccl_cosmology));
   cosmo->params = params;
   cosmo->config = config;
@@ -382,10 +386,6 @@ ccl_parameters ccl_parameters_create(double Omega_c, double Omega_b, double Omeg
 				     int nz_mgrowth, double *zarr_mgrowth,
 				     double *dfarr_mgrowth, int *status)
 {
-  #ifndef USE_GSL_ERROR
-    gsl_set_error_handler_off();
-  #endif
-
   ccl_parameters params;
   // Initialize params
   params.m_nu = NULL;


### PR DESCRIPTION
This is a quick fix for the aborts reported in #1129 by moving the call to disable the GSL error handling from `ccl_parameters_create` to `ccl_cosmology_create`. 

This uncovered a bunch of other issues though. From the python side, `ccl_parameters_create` isn't being used any more.
It is still used from within the C code though, mainly in halofit and the mu-Sigma MG stuff. So now there are two places in the code that deal with the non-trivial aspects of the `ccl_parameters` struct, namely the allocation of the massive neutrino arrays and MG arrays.

Speaking of these arrays, right now you can do some pretty nasty stuff by accessing arbitrary memory because `N_nu_mass` can be changed from python. I added a fix for one memory leak but there might be others.

```python
import pyccl as ccl
import numpy as np

cosmo = ccl.CosmologyVanillaLCDM()

print(f"{cosmo._params.N_nu_mass=}")
print(f"{cosmo._params.m_nu=}")

print("Set cosmo._params.m_nu")
cosmo._params.m_nu = np.array([0.1, 0.2, 0.3])

print(f"{cosmo._params.N_nu_mass=}")
print(f"{cosmo._params.m_nu=}")

print("Set cosmo._params.N_nu_mass")
cosmo._params.N_nu_mass = 10
print(f"{cosmo._params.N_nu_mass=}")
print(f"{cosmo._params.m_nu=}")
```
gives
```
cosmo._params.N_nu_mass=0
cosmo._params.m_nu=[]
Set cosmo._params.m_nu
cosmo._params.N_nu_mass=3
cosmo._params.m_nu=[0.1, 0.2, 0.3]
Set cosmo._params.N_nu_mass
cosmo._params.N_nu_mass=10
cosmo._params.m_nu=[0.1, 0.2, 0.3, 0.0, 5e-324, 1.6e-322, 2.1470999305e-314, 1.5e-323, 9e-323, 1.5543504411933145e-303]
```
 
I'm aware that `_params` is supposed to be private but it shouldn't be that easy to mess with C memory.
 