### PR TITLE
Adding prescription of Costanzi et al. 2013 for evaluating the halo mas function in nuCDM cosmologies 

### DIFF
--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -35,6 +35,15 @@ def get_camb_pk_lin(cosmo, *, nonlin=False):
     except (KeyError, TypeError):
         pass
 
+    # Get extra parameters to evaluate
+    # the halo mass function in cosmology with massive neutrinos
+    # using prescription by Costanzi et al. 2013(JCAP12(2013)012)
+    use_costanzi13 = False
+    try:
+        use_costanzi13 = cosmo["extra_parameters"]["use_costanzi13"]
+    except (KeyError, TypeError):
+        pass
+
     # z sampling from CCL parameters
     na = lib.get_pk_spline_na(cosmo.cosmo)
     status = 0
@@ -151,8 +160,13 @@ def get_camb_pk_lin(cosmo, *, nonlin=False):
     camb_res = camb.get_transfer_functions(cp)
 
     def construct_Pk2D(camb_res, nonlin=False):
-        k, z, pk = camb_res.get_linear_matter_power_spectrum(
-            hubble_units=True, nonlinear=nonlin)
+        if not use_costanzi13:
+            k, z, pk = camb_res.get_linear_matter_power_spectrum(
+                hubble_units=True, nonlinear=nonlin)
+        else:
+            k, z, pk = camb_res.get_linear_matter_power_spectrum(
+                var1='delta_nonu', var2='delta_nonu',
+                hubble_units=True, nonlinear=nonlin)
 
         # convert to non-h inverse units
         k *= cosmo['h']

--- a/pyccl/halos/halo_model_base.py
+++ b/pyccl/halos/halo_model_base.py
@@ -193,7 +193,23 @@ class MassFunc(HMIngredients):
         logM, sigM, dlns_dlogM = self._get_logM_sigM(
             cosmo, M_use, a, return_dlns=True)
 
-        rho = (const.RHO_CRITICAL * cosmo['Omega_m'] * cosmo['h']**2)
+        # prescription by Costanzi et al. 2013(JCAP12(2013)012)
+        # to evaluate the halo mass function in nuCDM cosmology
+
+        use_costanzi13 = False
+
+        try:
+            use_costanzi13 = cosmo["extra_parameters"]["use_costanzi13"]
+        except (KeyError, TypeError):
+            pass
+
+        if not use_costanzi13:
+            rho = (const.RHO_CRITICAL * cosmo['Omega_m'] * cosmo['h']**2)
+        else:
+            rho = (const.RHO_CRITICAL
+                   * (cosmo['Omega_c'] + cosmo['Omega_b'])
+                   * cosmo['h']**2)
+
         f = self._get_fsigma(cosmo, sigM, a, 2.302585092994046 * logM)
         mf = f * rho * dlns_dlogM / M_use
         if np.ndim(M) == 0:


### PR DESCRIPTION
Neutrinos don’t cluster on halo scales and thus contribute negligibly to the collapse of massive dark matter halos. So, the halo mass function (HMF) should depend only on cold dark matter and baryons in nuCDM cosmologies. For cosmologies with massive neutrinos, it was found by [Costanzi et al. 2013](https://ui.adsabs.harvard.edu/abs/2013JCAP...12..012C/abstract) that using Plin_(CDM + Baryon) instead of Plin_matter when computing the HMF is important for the universality of the [Tinker et al. 2008](https://arxiv.org/abs/0803.2706) mass function in nuCDM cosmologies. This prescription is used in cluster cosmology analyses (e.g. the DES Y1 analysis in [To et al. 2021](https://ui.adsabs.harvard.edu/abs/2021PhRvL.126n1301T/abstract)).

For this PR, I just implemented the suggestion by  Vittorio Ghirardini in #1179 to add the option of using this prescription in CCL