### PR TITLE
Fix for issue #1191

### DIFF
--- a/pyccl/cosmology.py
+++ b/pyccl/cosmology.py
@@ -294,6 +294,16 @@ class Cosmology(CCLObject):
                 modified_gravity.MuSigmaMG):
             raise NotImplementedError("`mg_parametrization` only supports the "
                                       "mu-Sigma parametrization at this point")
+        """
+        if isinstance(
+                self.mg_parametrization,
+                modified_gravity.MuSigmaMG) and self.transfer_function_type is not 'boltzmann_isitgr':
+            raise ValueError("mu-Sigma parametrization is inconsistent with your transfer function choice (required to use isitgr)"
+                             )
+        """    
+
+        
+
 
         # going to save these for later
         self._params_init_kwargs = dict(
@@ -470,6 +480,11 @@ class Cosmology(CCLObject):
         c1_mg = self.mg_parametrization.c1_mg
         c2_mg = self.mg_parametrization.c2_mg
         lambda_mg = self.mg_parametrization.lambda_mg
+
+        if(c1_mg != 0. or c2_mg !=0. or lambda_mg != 0.):
+            
+            if isinstance(self.mg_parametrization, modified_gravity.MuSigmaMG) and self.transfer_function_type is not 'boltzmann_isitgr':
+                raise ValueError("mu-Sigma parametrization is inconsistent with your transfer function choice (required to use isitgr)")
 
         self._fill_params(
             m_nu=nu_mass, sum_nu_masses=sum(nu_mass), N_nu_mass=N_nu_mass,


### PR DESCRIPTION
Modified cosmology.py so that it complains when mu-sigma scale-dependent parameters are non-zero but transfer function isn't the isitgr one