### PR TITLE
fixed the build dependencies to include numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8", "cmake", "swig"]
+requires = ["setuptools>=64", "setuptools_scm>=8", "cmake", "swig", "numpy"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyccl"


### PR DESCRIPTION
By including numpy as a build dependency, this fixes build installation issues through the pip and uv.

This fixes isolated installs with pip.

@henryiii helped me figure out this fix!

This should fix #1180