### PR TITLE
fixing normalisation issue of trispectrum in halomodel

### DIFF
--- a/pyccl/halos/pk_4pt.py
+++ b/pyccl/halos/pk_4pt.py
@@ -546,7 +546,7 @@ def _get_norms(prof, prof2, prof3, prof4, cosmo, aa, hmc):
         norm3 = prof3.get_normalization(cosmo, aa, hmc=hmc)
 
     if prof4 == prof:
-        norm4 = norm3
+        norm4 = norm1
     elif prof4 == prof2:
         norm4 = norm2
     elif prof4 == prof3:


### PR DESCRIPTION
There existed an issue of the amplitude of the trispectrum for the case of `matter, matter, HOD, matter` (found by Davide Sciotti), giving way too large values for the trispectrum in that case.  

Reason: `_get_norms` assigned a wrong norm in this case. In particular, the code asks if profile_1 and profile_4 are the same but assigns norm_4 to norm_3 instead of norm_1. Due to the structure of the `matter, matter, HOD, matter`, this would assign the HOD norm twice in this case.

After the fix, the amplitudes of the trispectra are consistent.