### PR TITLE
Adding large scale extrapolation of HEFT power spectra with biased li…

### DIFF
--- a/benchmarks/test_ptpk_bacco_lbias.py
+++ b/benchmarks/test_ptpk_bacco_lbias.py
@@ -59,7 +59,7 @@ def test_pt_pk(comb):
     for iz, z in enumerate(zs):
         a = 1./(1+z)
         kin = data[iz][0]
-        ind = np.where((kin < 1.0) & (kin > 1E-3))
+        ind = np.where((kin < 1.0) & (kin > 1E-2))
         k = kin[ind]
         dpk = data[iz][i_d+1][ind]
         tpk = pk(k, a, COSMO)

--- a/pyccl/tests/test_bacco_lbias_power.py
+++ b/pyccl/tests/test_bacco_lbias_power.py
@@ -60,7 +60,7 @@ def test_bacco_lbias_k2pk_types(typ_nlin, typ_nloc):
                                   'b2:bs', 'b2:bk2', 'bs:bs', 'bs:bk2',
                                   'bk2:bk2', 'b1:b3nl'])
 def test_bacco_lbias_deconstruction(kind):
-    ptc = ccl.nl_pt.BaccoLbiasCalculator(cosmo=COSMO)
+    ptc = ccl.nl_pt.BaccoLbiasCalculator(cosmo=COSMO, extrap_lin=False)
     b_nc = ['b1', 'b2', 'bs', 'bk2', 'b3nl']
     pk1 = ptc.get_pk2d_template(kind)
 


### PR DESCRIPTION
This PR adds extrapolation of the BACCO HEFT power spectra at large scales with the appropriately biased linear power spectrum from baccoemu. This is to avoid extrapolation issues that happen when extrapolating outside the k range covered by the BACCO HEFT emulator.