### PR TITLE
Non-Limber memory fix

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -30,6 +30,6 @@ dependencies:
       - velocileptors @ git+https://github.com/sfschen/velocileptors
       - baccoemu @ git+https://bitbucket.org/rangulo/baccoemu.git@master
       - MiraTitanHMFemulator
-      - dark_emulator  # Note the benchmarks were generated with 1.1.2
+      - dark_emulator @ git+https://github.com/DarkQuestCosmology/dark_emulator_public.git@master # Note the benchmarks were generated with 1.1.2
       - colossus
       

--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -30,6 +30,6 @@ dependencies:
       - velocileptors @ git+https://github.com/sfschen/velocileptors
       - baccoemu @ git+https://bitbucket.org/rangulo/baccoemu.git@master
       - MiraTitanHMFemulator
-      - dark_emulator @ git+https://github.com/DarkQuestCosmology/dark_emulator_public.git@master # Note the benchmarks were generated with 1.1.2
+      - dark_emulator @ git+https://github.com/DarkQuestCosmology/dark_emulator_public.git@main # Note the benchmarks were generated with 1.1.2
       - colossus
       

--- a/pyccl/nonlimber/_nonlimber_FKEM.py
+++ b/pyccl/nonlimber/_nonlimber_FKEM.py
@@ -125,7 +125,7 @@ def _chi_integrands(cosmo, clt,
             clt._trc[i], cosmo, Nchi, chi_min, chi_max, ell, k, fk,
         )
         fks[i] = fk
-        transfers[i] = np.array(clt.get_transfer(np.log(k), avg_as[i]))
+        transfers[i] = np.array(clt.get_transfer(np.log(k), avg_as[i]))[i]
 
     return k, fks, transfers
 

--- a/pyccl/nonlimber/_nonlimber_FKEM.py
+++ b/pyccl/nonlimber/_nonlimber_FKEM.py
@@ -269,6 +269,10 @@ def _auto_limber_transition_ell(clt1, clt2, cosmo, psp_lin, psp_nonlin,
                 + cls_nonlimber_lin_temp
             )
             thresh = cl_temp / cl_limber_nonlin_temp[-1] - 1.0
+
+            lib.cl_tracer_collection_t_free(t1_temp)
+            lib.cl_tracer_collection_t_free(t2_temp)
+
             if np.abs(thresh) >= limber_max_error:
                 return status, False
     return status, True
@@ -514,4 +518,6 @@ def _nonlimber_FKEM(
         l_limber = ls[-1]
     if False in np.isfinite(cells):
         status = 1
+    lib.cl_tracer_collection_t_free(t1)
+    lib.cl_tracer_collection_t_free(t2)
     return l_limber, np.array(cells), status

--- a/pyccl/tests/test_cells.py
+++ b/pyccl/tests/test_cells.py
@@ -239,6 +239,46 @@ def test_fkem_warn_mismatched_pk_types_fallback_to_limber():
         assert meta["l_limber"] == -1
 
 
+def test_fkem_multicomponent_tracer():
+    # Smoke test to make sure multi-component tracers do not fail when
+    # FKEM non-Limber is calculated.
+    z = np.linspace(0.0, 2.0, 60)
+    nz = np.exp(-0.5 * ((z - 0.5) / 0.3) ** 2)
+    bz = np.ones_like(z)
+    mbz = 0.5 * np.ones_like(z)
+    ells = np.array([2.0, 5.0, 10.0, 20.0])
+    cosmo = ccl.CosmologyVanillaLCDM()
+
+    nc = ccl.NumberCountsTracer(
+        cosmo,
+        has_rsd=True,
+        dndz=(z, nz),
+        bias=(z, bz),
+        mag_bias=(z, mbz),
+    )
+
+    # gg auto test
+    cl_gg = ccl.angular_cl(
+        cosmo, nc, nc, ells,
+        non_limber_integration_method="FKEM",
+        l_limber=1000,
+        fkem_Nchi=100,
+        fkem_chi_min=1.0,
+    )
+    assert np.all(np.isfinite(cl_gg))
+
+    # cross test with weak lensing
+    lens = ccl.WeakLensingTracer(cosmo, dndz=(z, nz))
+    cl_gk = ccl.angular_cl(
+        cosmo, nc, lens, ells,
+        non_limber_integration_method="FKEM",
+        l_limber=1000,
+        fkem_Nchi=100,
+        fkem_chi_min=1.0,
+    )
+    assert np.all(np.isfinite(cl_gk))
+
+
 def test_cells_mg():
     # Check that if we feed the non-linear matter power spectrum from a MG
     # cosmology into a Calculator and get Cells using MG tracers, we get the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "numpy",
     "packaging",
-    "scipy<1.14",
+    "scipy",
     "pyyaml",
 ]
 


### PR DESCRIPTION
Tracer collections allocated wihtin the FKEM non-Limber code are not freed, leading to out-of-memory errors when running chains. This patch adds the necessary calls to free these structures. 