### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,13 @@ jobs:
     steps:
 
       - name: Checkout CCL repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           channels: conda-forge
+          conda-remove-defaults: true
           show-channel-urls: true
           miniforge-version: latest
           miniforge-variant: Miniforge3
@@ -85,7 +86,7 @@ jobs:
         run: echo "TODAY=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
 
       - name: Get cached environment
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache
         with:
           path: ${{ matrix.prefix }}
@@ -108,7 +109,7 @@ jobs:
         run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
       - name: Cache pip packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: pip-py${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('**/environment.yml') }}-${{ hashFiles('setup.py') }}
@@ -146,7 +147,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout CCL repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Lint
         uses: py-actions/flake8@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.cibw_archs }}
           path: ./wheelhouse/*.whl
@@ -41,12 +41,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
@@ -57,7 +57,7 @@ jobs:
         run: python -m build --sdist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: cibw-*
           path: dist
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: cibw-*
           path: dist


### PR DESCRIPTION
Solve CI warnings:
- Fixed: "Node.js 20 actions are deprecated"
- Ensure `default` conda channel is not used.