### PR TITLE
fix halomod_trispectrum_3h symmetry issue

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - pyyaml
   - numpy < 2.4  # fast-pt uses np.trapz, which is deleted in numpy 2.4
   - scipy < 1.14 # velocileptors uses functions removed in recent scipy versions
-  - camb
+  - camb < 2
   - fast-pt
   - pytest
   - pytest-cov

--- a/pyccl/halos/pk_4pt.py
+++ b/pyccl/halos/pk_4pt.py
@@ -1099,8 +1099,8 @@ def halomod_trispectrum_3h(cosmo, hmc, k, a, prof, *, prof2=None,
         else:
             Bpt = get_Bpt(aa)
 
-        tk_3h = Bpt * (i1 * i3 * i24 + i1 * i4 * i32 +
-                       i3 * i2 * i14 + i4 * i2 * i31)
+        tk_3h = Bpt * (i1 * i3 * i24 + i1 * i4 * i32.T +
+                       i3 * i2 * i14 + i4 * i2 * i31.T)
 
         # Normalize
         out[ia, :, :] = tk_3h / norm

--- a/pyccl/halos/pk_4pt.py
+++ b/pyccl/halos/pk_4pt.py
@@ -1057,50 +1057,50 @@ def halomod_trispectrum_3h(cosmo, hmc, k, a, prof, *, prof2=None,
                                                 cosmo, aa, hmc)
         norm = norm1 * norm2 * norm3 * norm4
 
-        # Permutation 0 is 0 due to Bpt_1_2_34=0
+        # Permutation 0
         i1, i2, i3, i4 = _get_ints_I_1_1(hmc, cosmo, k_use, aa, prof, prof2,
                                          prof3, prof4)
 
-        # Permutation 1: 2 <-> 3
+        # Permutation 1
         i24 = hmc.I_1_2(cosmo, k_use, aa, prof2, prof2=prof4,
                         prof_2pt=prof24_2pt, diag=False)
-        # Permutation 2: 2 <-> 4
+        # Permutation 2
         if (prof3 == prof4) and (prof32_2pt == prof24_2pt):
-            i32 = i24.T
+            i23 = i24
         else:
-            i32 = hmc.I_1_2(cosmo, k_use, aa, prof3, prof2=prof2,
+            i23 = hmc.I_1_2(cosmo, k_use, aa, prof2, prof2=prof3,
                             prof_2pt=prof32_2pt, diag=False)
-        # Permutation 3: 1 <-> 3
+        # Permutation 3
         if (prof == prof2) and (prof14_2pt == prof24_2pt):
             i14 = i24
         elif ([prof, prof4] == [prof3, prof2]) and (prof14_2pt == prof32_2pt):
-            i14 = i32
+            i14 = i23.T
         elif ([prof, prof4] == [prof2, prof3]) and (prof14_2pt == prof32_2pt):
-            i14 = i32.T
+            i14 = i23
         else:
             i14 = hmc.I_1_2(cosmo, k_use, aa, prof, prof2=prof4,
                             prof_2pt=prof14_2pt, diag=False)
-        # Permutation 4: 1 <-> 4
+        # Permutation 4
         if (prof == prof2) and (prof13_2pt == prof32_2pt):
-            i31 = i32
+            i13 = i23
         elif prof3 == prof4 and (prof13_2pt == prof32_2pt):
-            i31 = i14.T
+            i13 = i14
         elif ([prof3, prof] == [prof2, prof4]) and (prof13_2pt == prof24_2pt):
-            i31 = i24
+            i13 = i24.T
         elif ([prof3, prof] == [prof4, prof2]) and (prof13_2pt == prof24_2pt):
-            i31 = i24.T
+            i13 = i24
         else:
-            i31 = hmc.I_1_2(cosmo, k_use, aa, prof3, prof2=prof,
+            i13 = hmc.I_1_2(cosmo, k_use, aa, prof, prof2=prof3,
                             prof_2pt=prof13_2pt, diag=False)
 
-        # Permutation 5: 12 <-> 34 is 0 due to Bpt_3_4_12=0
+        # Permutation 5
         if separable_growth:
             Bpt = Bpt_separable * (cosmo.growth_factor(aa)) ** 4
         else:
             Bpt = get_Bpt(aa)
 
-        tk_3h = Bpt * (i1 * i3 * i24 + i1 * i4 * i32.T +
-                       i3 * i2 * i14 + i4 * i2 * i31.T)
+        tk_3h = Bpt * (i1 * i3 * i24 + i1 * i4 * i23 +
+                       i3 * i2 * i14 + i4 * i2 * i13)
 
         # Normalize
         out[ia, :, :] = tk_3h / norm

--- a/pyccl/halos/pk_4pt.py
+++ b/pyccl/halos/pk_4pt.py
@@ -1073,10 +1073,10 @@ def halomod_trispectrum_3h(cosmo, hmc, k, a, prof, *, prof2=None,
         # Permutation 3
         if (prof == prof2) and (prof14_2pt == prof24_2pt):
             i14 = i24
-        elif ([prof, prof4] == [prof3, prof2]) and (prof14_2pt == prof32_2pt):
-            i14 = i23.T
         elif ([prof, prof4] == [prof2, prof3]) and (prof14_2pt == prof32_2pt):
             i14 = i23
+        elif ([prof, prof4] == [prof3, prof2]) and (prof14_2pt == prof32_2pt):
+            i14 = i23.T
         else:
             i14 = hmc.I_1_2(cosmo, k_use, aa, prof, prof2=prof4,
                             prof_2pt=prof14_2pt, diag=False)
@@ -1085,10 +1085,10 @@ def halomod_trispectrum_3h(cosmo, hmc, k, a, prof, *, prof2=None,
             i13 = i23
         elif prof3 == prof4 and (prof13_2pt == prof32_2pt):
             i13 = i14
-        elif ([prof3, prof] == [prof2, prof4]) and (prof13_2pt == prof24_2pt):
-            i13 = i24.T
-        elif ([prof3, prof] == [prof4, prof2]) and (prof13_2pt == prof24_2pt):
+        elif ([prof, prof3] == [prof2, prof4]) and (prof13_2pt == prof24_2pt):
             i13 = i24
+        elif ([prof, prof3] == [prof4, prof2]) and (prof13_2pt == prof24_2pt):
+            i13 = i24.T
         else:
             i13 = hmc.I_1_2(cosmo, k_use, aa, prof, prof2=prof3,
                             prof_2pt=prof13_2pt, diag=False)


### PR DESCRIPTION
The `galaxy-lensing-galaxy-lensing` block of the cNG covariance fails the symmetry check `cov = cov.T`. 
Digging a bit in the code, I found this to be unrelated to the projection, but instead connected to the cNG trispectrum itself, called through the `halomod_Tk3D_cNG` function. 
More in detail, the term which doesn't satisfy the symmetry relation `tkk = tkk.transpose(0, 2, 1)` is the 3-halo term, computed through `halomod_trispectrum_3h`: the very same check passes for all other terms 

```
tkk = halomod_trispectrum_3h(cosmo, hmc, np.exp(lk_arr), a_arr,
                              prof=prof,
                              prof2=prof2,
                              prof3=prof3,
                              prof4=prof4,
                              prof13_2pt=prof13_2pt,
                              prof14_2pt=prof14_2pt,
                              prof24_2pt=prof24_2pt,
                              prof32_2pt=prof32_2pt,
                              p_of_k_a=p_of_k_a,
                              separable_growth=separable_growth)
np.testing.assert_allclose(tkk, tkk.transpose(0, 2, 1), atol=0, rtol=1e-5)

AssertionError: 
Not equal to tolerance rtol=1e-05, atol=0

Mismatched elements: 2901184 / 3812500 (76.1%)
First 5 mismatches are at indices:
 [0, 0, 126]: 1100141314.5753217 (ACTUAL), 1100129201.7862258 (DESIRED)
 [0, 0, 127]: 952025678.7788904 (ACTUAL), 952013637.2011328 (DESIRED)
 [0, 0, 128]: 806908468.4248796 (ACTUAL), 806896743.8320149 (DESIRED)
 [0, 0, 129]: 693877697.1942735 (ACTUAL), 693866114.8928196 (DESIRED)
 [0, 0, 130]: 634861836.8934748 (ACTUAL), 634849663.0077951 (DESIRED)
Max absolute difference among violations: 2.24641765e+09
Max relative difference among violations: 3.20700322
 ACTUAL: array([[[5.550077e+06, 5.952075e+06, 6.401535e+06, ..., 4.239131e-01,
         3.230964e-01, 2.453429e-01],
        [5.952075e+06, 6.345617e+06, 6.805238e+06, ..., 4.532776e-01,...
 DESIRED: array([[[5.550077e+06, 5.952075e+06, 6.401535e+06, ..., 2.492856e-01,
         1.846306e-01, 1.357628e-01],
        [5.952075e+06, 6.345617e+06, 6.805238e+06, ..., 2.665536e-01,...
```

Note that this is irrespective of the value of `separable_growth`. 
From this point on, I have to give credit to Claude for suggesting the solution in the associated PR, which does indeed pass all the above symmetry checks, bot at the trispectrum and at the covariance level.