### PR TITLE
Fixes Issue1303: allows camb v2

### DIFF
--- a/.github/environment.yml
+++ b/.github/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - pyyaml
   - numpy < 2.4  # fast-pt uses np.trapz, which is deleted in numpy 2.4
   - scipy < 1.14 # velocileptors uses functions removed in recent scipy versions
-  - camb < 2
+  - camb
   - fast-pt
   - pytest
   - pytest-cov
@@ -25,7 +25,6 @@ dependencies:
   - wheel # for classy
   - cython < 3  # for classy
   - pip:
-      - scipy<1.14
       - classy  # Note the benchmarks were generated with 2.9.4
       - isitgr  # Note the benchmarks were generated with 1.0.2
       - velocileptors @ git+https://github.com/sfschen/velocileptors
@@ -33,4 +32,3 @@ dependencies:
       - MiraTitanHMFemulator
       - dark_emulator @ git+https://github.com/DarkQuestCosmology/dark_emulator_public.git@main # Note the benchmarks were generated with 1.1.2
       - colossus
-      

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -35,6 +35,10 @@ def get_camb_pk_lin(cosmo, *, nonlin=False):
     except (KeyError, TypeError):
         pass
 
+    # CAMB 2.x defaults to AccuracyTarget=1. Use legacy default for behavior
+    # closer to CAMB 1.x unless explicitly overridden.
+    camb.config.AccuracyTarget = extra_camb_params.get("AccuracyTarget", 0)
+
     # z sampling from CCL parameters
     na = lib.get_pk_spline_na(cosmo.cosmo)
     status = 0
@@ -139,6 +143,7 @@ def get_camb_pk_lin(cosmo, *, nonlin=False):
         wa=cosmo['wa']
     )
 
+    # Setting lens_potential_accuracy to 0 to match CAMB v1 behavior
     cp.set_for_lmax(
         extra_camb_params.get("lmax", 5000),
         lens_potential_accuracy=0)

--- a/pyccl/boltzmann.py
+++ b/pyccl/boltzmann.py
@@ -139,7 +139,9 @@ def get_camb_pk_lin(cosmo, *, nonlin=False):
         wa=cosmo['wa']
     )
 
-    cp.set_for_lmax(extra_camb_params.get("lmax", 5000))
+    cp.set_for_lmax(
+        extra_camb_params.get("lmax", 5000),
+        lens_potential_accuracy=0)
     cp.InitPower.set_params(
         As=A_s_fid,
         ns=cosmo['n_s'])

--- a/pyccl/cosmology.py
+++ b/pyccl/cosmology.py
@@ -215,6 +215,7 @@ class Cosmology(CCLObject):
         * `HMCode_logT_AGN`
         * `kmax`
         * `lmax`
+        * `AccuracyTarget` (currently set to 0 to match CAMB v1 behavior)
         * `dark_energy_model`
 
     Consult the CAMB documentation for their usage. These parameters are passed


### PR DESCRIPTION
This PR fixes the bug introduced by the changes introduced by CAMB v2 in `set_for_lmax`. In order to keep the Pk linear, we need to not request lensing, which is now computed by default, by setting `lens_potential_accuracy=0`, as in CAMB v1. See [docs](https://camb.readthedocs.io/en/latest/model.html#camb.model.CAMBparams.set_for_lmax) and [GH diff](https://github.com/cmbant/CAMB/compare/1.6.6...2.0.0#diff-3bb9b02c0437dfe01d523940691a92ca0623718f7bbf43c80849c94a30d87d82R1032)