### PR TITLE
Bug in EPT calculator when assigning linear and SPT templates

### DIFF
--- a/pyccl/nl_pt/ept.py
+++ b/pyccl/nl_pt/ept.py
@@ -269,7 +269,7 @@ class EulerianPTCalculator(CCLAutoRepr):
                                       for a in self.a_s])
         if 'pt' in [self.b1_pk_kind, self.bk2_pk_kind]:
             if 'linear' in pks:
-                pk = pks['linear']
+                pk = pks['linear'].copy()
             else:
                 pk = np.array([cosmo.linear_matter_power(self.k_s, a)
                                for a in self.a_s])

--- a/pyccl/tests/test_ept_power.py
+++ b/pyccl/tests/test_ept_power.py
@@ -65,6 +65,22 @@ def test_ept_get_pk2d_nl(nl):
     assert isinstance(pk, ccl.Pk2D)
 
 
+def test_ept_b1_bk2_eq():
+    # Tests that pk templates for b1 and b_k2 are
+    # assigned correctly.
+    ptc = ccl.nl_pt.EulerianPTCalculator(
+        with_NC=True, with_IA=False,
+        b1_pk_kind='linear', bk2_pk_kind='linear')
+    ptc.update_ingredients(COSMO)
+    assert ptc.pk_bk is ptc.pk_b1
+
+    ptc = ccl.nl_pt.EulerianPTCalculator(
+        with_NC=True, with_IA=False,
+        b1_pk_kind='linear', bk2_pk_kind='pt')
+    ptc.update_ingredients(cosmo=COSMO)
+    assert not (ptc.pk_bk is ptc.pk_b1)
+
+
 @pytest.mark.parametrize('typ_nlin,typ_nloc', [('linear', 'nonlinear'),
                                                ('nonlinear', 'linear'),
                                                ('nonlinear', 'pt'),


### PR DESCRIPTION
This is a bug reported originally by Alex Roskill (@AlexRoskill)

When the EPT calculator object is requested to use the linear power spectrum for the b1 term and the SPT power spectrum for the bk2 term, or vice-versa, an error in how arrays are handled leads to both power spectra being the SPT power spectrum. This PR fixes this.